### PR TITLE
feat: close architecture gaps from vendor assessment

### DIFF
--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -2,6 +2,7 @@ import { sql } from "drizzle-orm"
 import { integer, real, sqliteTable, text, unique } from "drizzle-orm/sqlite-core"
 
 import type { DownloadClientSettings } from "#/effect/domain/downloadClient"
+import type { IndexerCapabilities } from "#/effect/domain/indexer"
 import type { MediaServerSettings } from "#/effect/domain/mediaServer"
 import type { DecisionReason, MediaType, ReleaseDecision } from "#/effect/domain/release"
 import type {
@@ -190,6 +191,16 @@ export const settings = sqliteTable("settings", {
     .default(sql`(unixepoch())`),
 })
 
+export const rootFolders = sqliteTable("root_folders", {
+  id: integer().primaryKey({ autoIncrement: true }),
+  path: text().notNull().unique(),
+  freeSpaceBytes: integer("free_space_bytes"),
+  totalSpaceBytes: integer("total_space_bytes"),
+  createdAt: integer("created_at", { mode: "timestamp" })
+    .notNull()
+    .default(sql`(unixepoch())`),
+})
+
 export const indexers = sqliteTable("indexers", {
   id: integer().primaryKey({ autoIncrement: true }),
   name: text().notNull(),
@@ -202,6 +213,9 @@ export const indexers = sqliteTable("indexers", {
     .$type<ReadonlyArray<number>>()
     .notNull()
     .default(sql`'[]'`),
+  capabilities: text({ mode: "json" })
+    .$type<IndexerCapabilities | null>()
+    .default(sql`'null'`),
   createdAt: integer("created_at", { mode: "timestamp" })
     .notNull()
     .default(sql`(unixepoch())`),

--- a/src/effect/domain/categories.ts
+++ b/src/effect/domain/categories.ts
@@ -1,0 +1,144 @@
+/**
+ * Standard Torznab/Newznab category definitions.
+ * Parent categories are multiples of 1000.
+ * Sub-categories are parent + offset.
+ */
+
+export interface CategoryDef {
+  readonly id: number
+  readonly name: string
+  readonly parentId: number | null
+}
+
+/** Standard category tree — matches Prowlarr's Categories.cs */
+export const CATEGORIES: ReadonlyArray<CategoryDef> = [
+  // Console/Gaming
+  { id: 1000, name: "Console", parentId: null },
+  { id: 1010, name: "Console/NDS", parentId: 1000 },
+  { id: 1020, name: "Console/PSP", parentId: 1000 },
+  { id: 1030, name: "Console/Wii", parentId: 1000 },
+  { id: 1040, name: "Console/Xbox", parentId: 1000 },
+  { id: 1050, name: "Console/Xbox 360", parentId: 1000 },
+  { id: 1060, name: "Console/Wiiware", parentId: 1000 },
+  { id: 1070, name: "Console/Xbox 360 DLC", parentId: 1000 },
+  { id: 1080, name: "Console/PS3", parentId: 1000 },
+  { id: 1090, name: "Console/Other", parentId: 1000 },
+  { id: 1110, name: "Console/3DS", parentId: 1000 },
+  { id: 1120, name: "Console/PS Vita", parentId: 1000 },
+  { id: 1130, name: "Console/WiiU", parentId: 1000 },
+  { id: 1140, name: "Console/Xbox One", parentId: 1000 },
+  { id: 1180, name: "Console/PS4", parentId: 1000 },
+
+  // Movies
+  { id: 2000, name: "Movies", parentId: null },
+  { id: 2010, name: "Movies/Foreign", parentId: 2000 },
+  { id: 2020, name: "Movies/Other", parentId: 2000 },
+  { id: 2030, name: "Movies/SD", parentId: 2000 },
+  { id: 2040, name: "Movies/HD", parentId: 2000 },
+  { id: 2045, name: "Movies/UHD", parentId: 2000 },
+  { id: 2050, name: "Movies/BluRay", parentId: 2000 },
+  { id: 2060, name: "Movies/3D", parentId: 2000 },
+  { id: 2070, name: "Movies/DVD", parentId: 2000 },
+  { id: 2080, name: "Movies/WEB-DL", parentId: 2000 },
+
+  // Audio
+  { id: 3000, name: "Audio", parentId: null },
+  { id: 3010, name: "Audio/MP3", parentId: 3000 },
+  { id: 3020, name: "Audio/Video", parentId: 3000 },
+  { id: 3030, name: "Audio/Audiobook", parentId: 3000 },
+  { id: 3040, name: "Audio/Lossless", parentId: 3000 },
+  { id: 3050, name: "Audio/Other", parentId: 3000 },
+  { id: 3060, name: "Audio/Foreign", parentId: 3000 },
+
+  // PC
+  { id: 4000, name: "PC", parentId: null },
+  { id: 4010, name: "PC/0day", parentId: 4000 },
+  { id: 4020, name: "PC/ISO", parentId: 4000 },
+  { id: 4030, name: "PC/Mac", parentId: 4000 },
+  { id: 4040, name: "PC/Phone-Other", parentId: 4000 },
+  { id: 4050, name: "PC/Games", parentId: 4000 },
+  { id: 4060, name: "PC/Phone-IOS", parentId: 4000 },
+  { id: 4070, name: "PC/Phone-Android", parentId: 4000 },
+
+  // TV
+  { id: 5000, name: "TV", parentId: null },
+  { id: 5020, name: "TV/Foreign", parentId: 5000 },
+  { id: 5030, name: "TV/SD", parentId: 5000 },
+  { id: 5040, name: "TV/HD", parentId: 5000 },
+  { id: 5045, name: "TV/UHD", parentId: 5000 },
+  { id: 5050, name: "TV/Other", parentId: 5000 },
+  { id: 5060, name: "TV/Sport", parentId: 5000 },
+  { id: 5070, name: "TV/Anime", parentId: 5000 },
+  { id: 5080, name: "TV/Documentary", parentId: 5000 },
+
+  // XXX (included for completeness/filtering)
+  { id: 6000, name: "XXX", parentId: null },
+  { id: 6010, name: "XXX/DVD", parentId: 6000 },
+  { id: 6020, name: "XXX/WMV", parentId: 6000 },
+  { id: 6030, name: "XXX/XviD", parentId: 6000 },
+  { id: 6040, name: "XXX/x264", parentId: 6000 },
+  { id: 6050, name: "XXX/Pack", parentId: 6000 },
+  { id: 6060, name: "XXX/ImageSet", parentId: 6000 },
+  { id: 6070, name: "XXX/Other", parentId: 6000 },
+  { id: 6080, name: "XXX/SD", parentId: 6000 },
+  { id: 6090, name: "XXX/WEB-DL", parentId: 6000 },
+
+  // Books
+  { id: 7000, name: "Books", parentId: null },
+  { id: 7010, name: "Books/Mags", parentId: 7000 },
+  { id: 7020, name: "Books/EBook", parentId: 7000 },
+  { id: 7030, name: "Books/Comics", parentId: 7000 },
+  { id: 7040, name: "Books/Technical", parentId: 7000 },
+  { id: 7050, name: "Books/Other", parentId: 7000 },
+  { id: 7060, name: "Books/Foreign", parentId: 7000 },
+
+  // Other
+  { id: 8000, name: "Other", parentId: null },
+  { id: 8010, name: "Other/Misc", parentId: 8000 },
+  { id: 8020, name: "Other/Hashed", parentId: 8000 },
+]
+
+// ── Lookup maps ──
+
+const BY_ID = new Map(CATEGORIES.map((c) => [c.id, c]))
+
+/** Look up a category by its standard ID. */
+export function getCategoryById(id: number): CategoryDef | undefined {
+  return BY_ID.get(id)
+}
+
+/** Get the parent category for a sub-category, or itself if already a parent. */
+export function getParentCategory(id: number): CategoryDef | undefined {
+  const cat = BY_ID.get(id)
+  if (!cat) return undefined
+  if (cat.parentId === null) return cat
+  return BY_ID.get(cat.parentId)
+}
+
+/** Check if a category ID belongs to (or is) a given parent category. */
+export function isInCategory(categoryId: number, parentId: number): boolean {
+  if (categoryId === parentId) return true
+  const cat = BY_ID.get(categoryId)
+  return cat?.parentId === parentId
+}
+
+/** All standard movie category IDs (2000-2080). */
+export const MOVIE_CATEGORIES: ReadonlyArray<number> = CATEGORIES.filter(
+  (c) => c.id === 2000 || c.parentId === 2000,
+).map((c) => c.id)
+
+/** All standard TV category IDs (5000-5080). */
+export const TV_CATEGORIES: ReadonlyArray<number> = CATEGORIES.filter(
+  (c) => c.id === 5000 || c.parentId === 5000,
+).map((c) => c.id)
+
+/**
+ * Normalize a category string from a release to a standard category ID.
+ * Returns the numeric ID if it's a valid standard category, null otherwise.
+ */
+export function normalizeCategory(category: string): number | null {
+  const id = Number(category)
+  if (Number.isNaN(id)) return null
+  if (BY_ID.has(id)) return id
+  return null
+}

--- a/src/effect/domain/indexer.ts
+++ b/src/effect/domain/indexer.ts
@@ -76,6 +76,7 @@ export interface IndexerWithHealth {
   readonly enabled: boolean
   readonly priority: number
   readonly categories: ReadonlyArray<number>
+  readonly capabilities: IndexerCapabilities | null
   readonly createdAt: Date
   readonly updatedAt: Date
   readonly health: {

--- a/src/effect/domain/quality.ts
+++ b/src/effect/domain/quality.ts
@@ -131,6 +131,14 @@ export const DEFAULT_QUALITY_ORDER: ReadonlyArray<QualityName> = [
   "RAWHD",
 ]
 
+/** Set of valid quality names for O(1) lookup. */
+const QUALITY_NAMES: ReadonlySet<string> = new Set(Object.keys(Quality))
+
+/** Parse a string into a QualityName, returning null if invalid. */
+export function parseQualityName(s: string): QualityName | null {
+  return QUALITY_NAMES.has(s) ? (s as QualityName) : null
+}
+
 /** Fields available for custom format spec matching. */
 export type SpecField =
   | "releaseTitle"

--- a/src/effect/domain/tmdb.ts
+++ b/src/effect/domain/tmdb.ts
@@ -1,0 +1,49 @@
+/** TMDB API response types — parsed at boundary, used throughout. */
+
+export interface TmdbMovie {
+  readonly id: number
+  readonly title: string
+  readonly originalTitle: string
+  readonly overview: string
+  readonly releaseDate: string | null
+  readonly year: number | null
+  readonly posterPath: string | null
+  readonly backdropPath: string | null
+  readonly popularity: number
+  readonly voteAverage: number
+  readonly voteCount: number
+  readonly genreIds: ReadonlyArray<number>
+  readonly originalLanguage: string
+}
+
+export interface TmdbMovieDetails extends TmdbMovie {
+  readonly imdbId: string | null
+  readonly runtime: number | null
+  readonly status: string
+  readonly tagline: string | null
+  readonly genres: ReadonlyArray<{ readonly id: number; readonly name: string }>
+  readonly productionCompanies: ReadonlyArray<{
+    readonly id: number
+    readonly name: string
+    readonly logoPath: string | null
+    readonly originCountry: string
+  }>
+  readonly budget: number
+  readonly revenue: number
+}
+
+export interface TmdbSearchResult {
+  readonly page: number
+  readonly totalPages: number
+  readonly totalResults: number
+  readonly results: ReadonlyArray<TmdbMovie>
+}
+
+/** TMDB image base URL — poster/backdrop paths get appended to this. */
+export const TMDB_IMAGE_BASE = "https://image.tmdb.org/t/p" as const
+
+export type TmdbImageSize = "w92" | "w154" | "w185" | "w342" | "w500" | "w780" | "original"
+
+export function tmdbImageUrl(path: string, size: TmdbImageSize = "w500"): string {
+  return `${TMDB_IMAGE_BASE}/${size}${path}`
+}

--- a/src/effect/errors.ts
+++ b/src/effect/errors.ts
@@ -107,3 +107,16 @@ export class AcquisitionError extends Data.TaggedError("AcquisitionError")<{
   readonly stage: AcquisitionStage
   readonly message: string
 }> {}
+
+export type MetadataErrorReason =
+  | "api_key_missing"
+  | "not_found"
+  | "rate_limited"
+  | "request_failed"
+
+export class MetadataError extends Data.TaggedError("MetadataError")<{
+  readonly provider: string
+  readonly reason: MetadataErrorReason
+  readonly message: string
+  readonly retryable: boolean
+}> {}

--- a/src/effect/layers.ts
+++ b/src/effect/layers.ts
@@ -14,9 +14,11 @@ import { MovieServiceLive } from "./services/MovieService"
 import { ProfileDefaultsEngineLive } from "./services/ProfileDefaultsEngine"
 import { ProfileServiceLive } from "./services/ProfileService"
 import { ReleasePolicyEngineLive } from "./services/ReleasePolicyEngine"
+import { RootFolderServiceLive } from "./services/RootFolderService"
 import { SchedulerServiceLive } from "./services/SchedulerService"
 import { SeriesServiceLive } from "./services/SeriesService"
 import { TitleParserServiceLive } from "./services/TitleParserService"
+import { TmdbClientLive } from "./services/TmdbClient"
 
 /** All application services, fully wired. Db + CryptoService also exposed for direct use. */
 export const AppLive = Layer.mergeAll(
@@ -38,8 +40,10 @@ export const AppLive = Layer.mergeAll(
   Layer.provideMerge(TitleParserServiceLive),
   Layer.provideMerge(ProfileDefaultsEngineLive),
   Layer.provideMerge(ConfigServiceLive),
+  Layer.provideMerge(RootFolderServiceLive),
   Layer.provideMerge(ProfileServiceLive),
   Layer.provideMerge(AdapterRegistryLive),
   Layer.provideMerge(CryptoServiceLive),
+  Layer.provideMerge(TmdbClientLive),
   Layer.provideMerge(DbLive),
 )

--- a/src/effect/services/AcquisitionPipeline.ts
+++ b/src/effect/services/AcquisitionPipeline.ts
@@ -4,7 +4,8 @@ import { Context, Effect, Layer } from "effect"
 
 import { downloadQueue } from "#/db/schema"
 import type { IndexerProtocol } from "#/effect/domain/indexer"
-import type { RankedDecision } from "#/effect/domain/release"
+import { parseQualityName } from "#/effect/domain/quality"
+import type { ExistingFile, RankedDecision } from "#/effect/domain/release"
 import {
   AcquisitionError,
   type DownloadClientError,
@@ -129,6 +130,28 @@ export const AcquisitionPipelineLive = Layer.effect(
     const linkQueueToMovie = (hash: string, movieId: number) =>
       db.update(downloadQueue).set({ movieId }).where(eq(downloadQueue.externalId, hash))
 
+    /** Parse existing file info from movie row, validating quality name at boundary. */
+    const existingFileFromMovie = (movie: {
+      hasFile: boolean
+      existingQualityName: string | null
+      existingQualityRank: number | null
+      existingFormatScore: number | null
+    }): ExistingFile | undefined => {
+      if (
+        !movie.hasFile ||
+        movie.existingQualityName === null ||
+        movie.existingQualityRank === null
+      )
+        return undefined
+      const qualityName = parseQualityName(movie.existingQualityName)
+      if (!qualityName) return undefined
+      return {
+        qualityName,
+        qualityRank: movie.existingQualityRank,
+        formatScore: movie.existingFormatScore ?? 0,
+      }
+    }
+
     return {
       searchAndGrab: (movieId) =>
         Effect.gen(function* () {
@@ -143,24 +166,11 @@ export const AcquisitionPipelineLive = Layer.effect(
 
           if (releases.length === 0) return null
 
-          // Build evaluation context
-          const existingFile =
-            movie.hasFile &&
-            movie.existingQualityName !== null &&
-            movie.existingQualityRank !== null
-              ? {
-                  qualityName:
-                    movie.existingQualityName as import("#/effect/domain/quality").QualityName,
-                  qualityRank: movie.existingQualityRank,
-                  formatScore: movie.existingFormatScore ?? 0,
-                }
-              : undefined
-
           // Evaluate
           const decisions = yield* policyEngine.evaluate(releases, movie.qualityProfileId, {
             mediaId: movie.id,
             mediaType: "movie",
-            existingFile,
+            existingFile: existingFileFromMovie(movie),
           })
 
           // Record decisions
@@ -198,22 +208,10 @@ export const AcquisitionPipelineLive = Layer.effect(
             tmdbId: movie.tmdbId,
           })
 
-          const existingFile =
-            movie.hasFile &&
-            movie.existingQualityName !== null &&
-            movie.existingQualityRank !== null
-              ? {
-                  qualityName:
-                    movie.existingQualityName as import("#/effect/domain/quality").QualityName,
-                  qualityRank: movie.existingQualityRank,
-                  formatScore: movie.existingFormatScore ?? 0,
-                }
-              : undefined
-
           const decisions = yield* policyEngine.evaluate(releases, movie.qualityProfileId, {
             mediaId: movie.id,
             mediaType: "movie",
-            existingFile,
+            existingFile: existingFileFromMovie(movie),
           })
 
           yield* policyEngine.recordDecisions(decisions, {

--- a/src/effect/services/AdapterRegistry.test.ts
+++ b/src/effect/services/AdapterRegistry.test.ts
@@ -23,7 +23,7 @@ describe("AdapterRegistry", () => {
 
       expect(downloadTypes).toEqual(["qbittorrent", "sabnzbd"])
       expect(indexerTypes).toEqual(["newznab", "torznab"])
-      expect(mediaServerTypes).toEqual(["plex"])
+      expect(mediaServerTypes).toEqual(["jellyfin", "plex"])
     }).pipe(Effect.provide(AdapterRegistryLive)),
   )
 

--- a/src/effect/services/AdapterRegistry.ts
+++ b/src/effect/services/AdapterRegistry.ts
@@ -14,6 +14,7 @@ import type {
 import { ValidationError } from "../errors"
 import type { DownloadClientAdapter } from "./DownloadClientAdapter"
 import type { IndexerAdapter } from "./IndexerAdapter"
+import { createJellyfinAdapter, jellyfinMetadata } from "./JellyfinAdapter"
 import type { MediaServerAdapter } from "./MediaServerAdapter"
 import { createPlexAdapter, plexMetadata } from "./PlexAdapter"
 import { createQBittorrentAdapter, qbittorrentMetadata } from "./QBittorrentAdapter"
@@ -155,6 +156,7 @@ export const AdapterRegistryLive = Layer.sync(AdapterRegistry, () => {
   registry.registerIndexer("torznab", torznabMetadata, createTorznabAdapter)
   registry.registerIndexer("newznab", newznabMetadata, createTorznabAdapter)
   registry.registerMediaServer("plex", plexMetadata, createPlexAdapter)
+  registry.registerMediaServer("jellyfin", jellyfinMetadata, createJellyfinAdapter)
 
   return registry
 })

--- a/src/effect/services/IndexerService.ts
+++ b/src/effect/services/IndexerService.ts
@@ -89,6 +89,7 @@ function toWithHealth(
     enabled: row.enabled,
     priority: row.priority,
     categories: row.categories,
+    capabilities: row.capabilities ?? null,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
     health: health
@@ -223,24 +224,27 @@ export const IndexerServiceLive = Layer.effect(
 
           yield* adapter.testConnection().pipe(
             Effect.tapBoth({
-              onSuccess: () =>
-                db
-                  .insert(indexerHealth)
-                  .values({
-                    indexerId: id,
-                    status: "healthy",
-                    responseTimeMs: Date.now() - start,
-                    errorMessage: null,
-                  })
-                  .onConflictDoUpdate({
-                    target: indexerHealth.indexerId,
-                    set: {
+              onSuccess: (caps) =>
+                Effect.all([
+                  db
+                    .insert(indexerHealth)
+                    .values({
+                      indexerId: id,
                       status: "healthy",
                       responseTimeMs: Date.now() - start,
                       errorMessage: null,
-                      lastCheck: new Date(),
-                    },
-                  }),
+                    })
+                    .onConflictDoUpdate({
+                      target: indexerHealth.indexerId,
+                      set: {
+                        status: "healthy",
+                        responseTimeMs: Date.now() - start,
+                        errorMessage: null,
+                        lastCheck: new Date(),
+                      },
+                    }),
+                  db.update(indexers).set({ capabilities: caps }).where(eq(indexers.id, id)),
+                ]),
               onFailure: (err) =>
                 db
                   .insert(indexerHealth)

--- a/src/effect/services/JellyfinAdapter.ts
+++ b/src/effect/services/JellyfinAdapter.ts
@@ -1,0 +1,322 @@
+import { Effect } from "effect"
+
+import type {
+  MediaServerAdapterMetadata,
+  MediaServerConfig,
+  MediaServerConnectionInfo,
+  MediaServerHealth,
+  MediaServerLibrary,
+  MediaServerLibraryType,
+  SyncedItem,
+} from "../domain/mediaServer"
+import { MediaServerError, type MediaServerErrorReason } from "../errors"
+import type { MediaServerAdapter } from "./MediaServerAdapter"
+
+// ── Metadata ──
+
+export const jellyfinMetadata: MediaServerAdapterMetadata = {
+  displayName: "Jellyfin",
+  defaultPort: 8096,
+  authModel: "token",
+}
+
+// ── Helpers ──
+
+function baseUrl(config: MediaServerConfig): string {
+  const scheme = config.useSsl ? "https" : "http"
+  return `${scheme}://${config.host}:${config.port}`
+}
+
+function makeError(
+  config: MediaServerConfig,
+  reason: MediaServerErrorReason,
+  message: string,
+  retryable: boolean,
+): MediaServerError {
+  return new MediaServerError({
+    serverId: config.id,
+    serverName: config.name,
+    reason,
+    message,
+    retryable,
+  })
+}
+
+// ── Jellyfin API response types ──
+
+interface JellyfinSystemInfo {
+  readonly ServerName: string
+  readonly Version: string
+  readonly Id: string
+}
+
+interface JellyfinLibraryFolder {
+  readonly Id: string
+  readonly Name: string
+  readonly CollectionType?: string
+}
+
+interface JellyfinLibraryFolders {
+  readonly Items: ReadonlyArray<JellyfinLibraryFolder>
+}
+
+interface JellyfinItem {
+  readonly Name: string
+  readonly ProductionYear?: number
+  readonly ParentIndexNumber?: number
+  readonly IndexNumber?: number
+  readonly Path?: string
+  readonly ProviderIds?: Partial<Record<string, string>>
+  readonly SeriesId?: string
+}
+
+interface JellyfinItems {
+  readonly Items: ReadonlyArray<JellyfinItem>
+}
+
+// ── Jellyfin library type mapping ──
+
+const JELLYFIN_TYPE_MAP: Record<string, MediaServerLibraryType> = {
+  movies: "movie",
+  tvshows: "show",
+}
+
+// ── Provider ID extraction ──
+
+function extractProviderIds(providerIds: Partial<Record<string, string>> | undefined): {
+  tmdbId: number | null
+  tvdbId: number | null
+  imdbId: string | null
+} {
+  if (!providerIds) {
+    return { tmdbId: null, tvdbId: null, imdbId: null }
+  }
+
+  const tmdbRaw = providerIds["Tmdb"]
+  const tvdbRaw = providerIds["Tvdb"]
+  const imdbRaw = providerIds["Imdb"]
+
+  const tmdbParsed = tmdbRaw ? Number(tmdbRaw) : Number.NaN
+  const tvdbParsed = tvdbRaw ? Number(tvdbRaw) : Number.NaN
+
+  return {
+    tmdbId: Number.isFinite(tmdbParsed) ? tmdbParsed : null,
+    tvdbId: Number.isFinite(tvdbParsed) ? tvdbParsed : null,
+    imdbId: imdbRaw ?? null,
+  }
+}
+
+// ── Factory ──
+
+export function createJellyfinAdapter(config: MediaServerConfig): MediaServerAdapter {
+  const base = baseUrl(config)
+
+  const authHeader = `MediaBrowser Client="ARR Hub", Device="Server", DeviceId="arr-hub", Version="1.0", Token="${config.token}"`
+
+  const jellyfinFetch = (
+    path: string,
+    method: "GET" | "POST" = "GET",
+  ): Effect.Effect<Response, MediaServerError> =>
+    Effect.tryPromise({
+      try: async () => {
+        const controller = new AbortController()
+        const timeout = setTimeout(() => controller.abort(), 15_000)
+        try {
+          const res = await fetch(`${base}${path}`, {
+            method,
+            headers: {
+              Accept: "application/json",
+              Authorization: authHeader,
+            },
+            signal: controller.signal,
+          })
+          if (res.status === 401 || res.status === 403) {
+            throw Object.assign(new Error("auth failed"), { authFailed: true })
+          }
+          if (!res.ok) {
+            throw new Error(`HTTP ${res.status}`)
+          }
+          return res
+        } finally {
+          clearTimeout(timeout)
+        }
+      },
+      catch: (e) => {
+        if (e instanceof Error && e.name === "AbortError") {
+          return makeError(config, "timeout", `request to ${path} timed out after 15s`, true)
+        }
+        if (e instanceof Error && "authFailed" in e) {
+          return makeError(config, "auth_failed", "invalid or expired Jellyfin token", false)
+        }
+        return makeError(
+          config,
+          "connection_refused",
+          e instanceof Error ? e.message : "request failed",
+          true,
+        )
+      },
+    })
+
+  const jellyfinJson = <T>(path: string): Effect.Effect<T, MediaServerError> =>
+    Effect.gen(function* () {
+      const res = yield* jellyfinFetch(path)
+      return yield* Effect.tryPromise({
+        try: () => res.json() as Promise<T>,
+        catch: () =>
+          makeError(config, "invalid_response", `failed to parse JSON from ${path}`, false),
+      })
+    })
+
+  return {
+    testConnection: (): Effect.Effect<MediaServerConnectionInfo, MediaServerError> =>
+      Effect.gen(function* () {
+        const info = yield* jellyfinJson<JellyfinSystemInfo>("/System/Info")
+
+        return {
+          serverName: info.ServerName,
+          version: info.Version,
+          machineId: info.Id,
+        }
+      }),
+
+    getLibraries: () =>
+      Effect.gen(function* () {
+        const folders = yield* jellyfinJson<JellyfinLibraryFolders>("/Library/MediaFolders")
+
+        return folders.Items.flatMap((folder): ReadonlyArray<MediaServerLibrary> => {
+          const collectionType = folder.CollectionType
+          if (!collectionType) return []
+          const type = JELLYFIN_TYPE_MAP[collectionType]
+          if (!type) return []
+          return [{ externalId: folder.Id, name: folder.Name, type }]
+        })
+      }),
+
+    syncLibrary: (libraryId) =>
+      Effect.gen(function* () {
+        // Determine library type from media folders
+        const folders = yield* jellyfinJson<JellyfinLibraryFolders>("/Library/MediaFolders")
+        const folder = folders.Items.find((f) => f.Id === libraryId)
+        if (!folder) {
+          return yield* makeError(
+            config,
+            "library_not_found",
+            `library ${libraryId} not found`,
+            false,
+          )
+        }
+
+        const collectionType = folder.CollectionType
+        if (!collectionType) {
+          return yield* makeError(
+            config,
+            "invalid_response",
+            `library ${libraryId} has no collection type`,
+            false,
+          )
+        }
+
+        const libraryType = JELLYFIN_TYPE_MAP[collectionType]
+        if (!libraryType) {
+          return yield* makeError(
+            config,
+            "invalid_response",
+            `unsupported library type: ${collectionType}`,
+            false,
+          )
+        }
+
+        if (libraryType === "movie") {
+          const result = yield* jellyfinJson<JellyfinItems>(
+            `/Items?parentId=${libraryId}&includeItemTypes=Movie&fields=ProviderIds,Path,MediaSources&recursive=true`,
+          )
+
+          return result.Items.map((item): SyncedItem => {
+            const ids = extractProviderIds(item.ProviderIds)
+            return {
+              kind: "movie",
+              item: {
+                title: item.Name,
+                year: item.ProductionYear ?? null,
+                tmdbId: ids.tmdbId,
+                filePath: item.Path ?? null,
+              },
+            }
+          })
+        }
+
+        // Show library: fetch episodes
+        const result = yield* jellyfinJson<JellyfinItems>(
+          `/Items?parentId=${libraryId}&includeItemTypes=Episode&fields=ProviderIds,Path,MediaSources&recursive=true`,
+        )
+
+        return result.Items.map((item): SyncedItem => {
+          const ids = extractProviderIds(item.ProviderIds)
+          return {
+            kind: "episode",
+            item: {
+              title: item.Name,
+              seasonNumber: item.ParentIndexNumber ?? 0,
+              episodeNumber: item.IndexNumber ?? 0,
+              seriesTvdbId: ids.tvdbId,
+              filePath: item.Path ?? null,
+            },
+          }
+        })
+      }),
+
+    refreshLibrary: (_libraryId, _path) =>
+      Effect.gen(function* () {
+        yield* jellyfinFetch("/Library/Refresh", "POST")
+      }),
+
+    getHealth: (): Effect.Effect<MediaServerHealth, MediaServerError> =>
+      Effect.gen(function* () {
+        const infoResult = yield* jellyfinJson<JellyfinSystemInfo>("/System/Info").pipe(
+          Effect.map(
+            (info) => ({ ok: true, info }) satisfies { ok: true; info: JellyfinSystemInfo },
+          ),
+          Effect.catchAll(() =>
+            Effect.succeed({ ok: false, info: null } satisfies { ok: false; info: null }),
+          ),
+        )
+
+        if (!infoResult.ok) {
+          return {
+            connected: false,
+            serverName: null,
+            version: null,
+            libraryCount: null,
+            errorMessage: "failed to connect",
+          }
+        }
+
+        const foldersResult = yield* jellyfinJson<JellyfinLibraryFolders>(
+          "/Library/MediaFolders",
+        ).pipe(
+          Effect.map(
+            (folders) =>
+              ({ ok: true, folders }) satisfies { ok: true; folders: JellyfinLibraryFolders },
+          ),
+          Effect.catchAll(() =>
+            Effect.succeed({ ok: false, folders: null } satisfies { ok: false; folders: null }),
+          ),
+        )
+
+        const libraryCount = foldersResult.ok
+          ? foldersResult.folders.Items.filter((f) => {
+              const ct = f.CollectionType
+              return ct === "movies" || ct === "tvshows"
+            }).length
+          : null
+
+        return {
+          connected: true,
+          serverName: infoResult.info.ServerName,
+          version: infoResult.info.Version,
+          libraryCount,
+          errorMessage: null,
+        }
+      }),
+  }
+}

--- a/src/effect/services/RootFolderService.ts
+++ b/src/effect/services/RootFolderService.ts
@@ -1,0 +1,131 @@
+import { SqlError } from "@effect/sql/SqlError"
+import { eq } from "drizzle-orm"
+import { Context, Effect, Layer } from "effect"
+
+import { rootFolders } from "#/db/schema"
+
+import { NotFoundError, ValidationError } from "../errors"
+import { Db } from "./Db"
+
+type RootFolder = typeof rootFolders.$inferSelect
+
+interface RootFolderInput {
+  readonly path: string
+}
+
+export class RootFolderService extends Context.Tag("@arr-hub/RootFolderService")<
+  RootFolderService,
+  {
+    readonly add: (input: RootFolderInput) => Effect.Effect<RootFolder, ValidationError | SqlError>
+    readonly list: () => Effect.Effect<ReadonlyArray<RootFolder>, SqlError>
+    readonly getById: (id: number) => Effect.Effect<RootFolder, NotFoundError | SqlError>
+    readonly remove: (id: number) => Effect.Effect<void, NotFoundError | SqlError>
+    readonly refreshSpace: (id: number) => Effect.Effect<RootFolder, NotFoundError | SqlError>
+  }
+>() {}
+
+export const RootFolderServiceLive = Layer.effect(
+  RootFolderService,
+  Effect.gen(function* () {
+    const db = yield* Db
+
+    return {
+      add: (input) =>
+        Effect.gen(function* () {
+          // Normalize path: remove trailing slash
+          const normalizedPath = input.path.replace(/\/+$/, "")
+          if (normalizedPath.length === 0) {
+            return yield* new ValidationError({ message: "root folder path cannot be empty" })
+          }
+
+          // Check for duplicates
+          const existing = yield* db
+            .select({ id: rootFolders.id })
+            .from(rootFolders)
+            .where(eq(rootFolders.path, normalizedPath))
+
+          if (existing.length > 0) {
+            return yield* new ValidationError({
+              message: `root folder already exists: ${normalizedPath}`,
+            })
+          }
+
+          // Check disk space
+          const space = yield* getDiskSpace(normalizedPath)
+
+          const rows = yield* db
+            .insert(rootFolders)
+            .values({
+              path: normalizedPath,
+              freeSpaceBytes: space.freeSpaceBytes,
+              totalSpaceBytes: space.totalSpaceBytes,
+            })
+            .returning()
+
+          return rows[0]
+        }),
+
+      list: () => db.select().from(rootFolders),
+
+      getById: (id) =>
+        Effect.gen(function* () {
+          const rows = yield* db.select().from(rootFolders).where(eq(rootFolders.id, id))
+          const folder = rows[0]
+          if (!folder) return yield* new NotFoundError({ entity: "rootFolder", id })
+          return folder
+        }),
+
+      remove: (id) =>
+        Effect.gen(function* () {
+          const rows = yield* db
+            .delete(rootFolders)
+            .where(eq(rootFolders.id, id))
+            .returning({ id: rootFolders.id })
+
+          if (rows.length === 0) return yield* new NotFoundError({ entity: "rootFolder", id })
+        }),
+
+      refreshSpace: (id) =>
+        Effect.gen(function* () {
+          const rows = yield* db.select().from(rootFolders).where(eq(rootFolders.id, id))
+          const folder = rows[0]
+          if (!folder) return yield* new NotFoundError({ entity: "rootFolder", id })
+
+          const space = yield* getDiskSpace(folder.path)
+
+          const updated = yield* db
+            .update(rootFolders)
+            .set({
+              freeSpaceBytes: space.freeSpaceBytes,
+              totalSpaceBytes: space.totalSpaceBytes,
+            })
+            .where(eq(rootFolders.id, id))
+            .returning()
+
+          return updated[0]
+        }),
+    }
+  }),
+)
+
+/** Get disk space for a path using Node.js fs.statfs. */
+function getDiskSpace(
+  path: string,
+): Effect.Effect<{ freeSpaceBytes: number; totalSpaceBytes: number }, never> {
+  return Effect.tryPromise({
+    try: async () => {
+      const { statfs } = await import("node:fs/promises")
+      try {
+        const stats = await statfs(path)
+        return {
+          freeSpaceBytes: Number(stats.bavail) * Number(stats.bsize),
+          totalSpaceBytes: Number(stats.blocks) * Number(stats.bsize),
+        }
+      } catch {
+        // Path doesn't exist yet or not accessible
+        return { freeSpaceBytes: 0, totalSpaceBytes: 0 }
+      }
+    },
+    catch: () => ({ freeSpaceBytes: 0, totalSpaceBytes: 0 }),
+  }).pipe(Effect.catchAll(() => Effect.succeed({ freeSpaceBytes: 0, totalSpaceBytes: 0 })))
+}

--- a/src/effect/services/TmdbClient.ts
+++ b/src/effect/services/TmdbClient.ts
@@ -1,0 +1,255 @@
+import { Context, Effect, Layer } from "effect"
+
+import { env } from "#/env"
+
+import type { TmdbMovie, TmdbMovieDetails, TmdbSearchResult } from "../domain/tmdb"
+import { MetadataError, type MetadataErrorReason } from "../errors"
+
+// ── Service tag ──
+
+export class TmdbClient extends Context.Tag("@arr-hub/TmdbClient")<
+  TmdbClient,
+  {
+    readonly searchMovies: (
+      query: string,
+      page?: number,
+    ) => Effect.Effect<TmdbSearchResult, MetadataError>
+    readonly getMovie: (tmdbId: number) => Effect.Effect<TmdbMovieDetails, MetadataError>
+    readonly getPopular: (page?: number) => Effect.Effect<TmdbSearchResult, MetadataError>
+    readonly getTrending: (
+      timeWindow?: "day" | "week",
+    ) => Effect.Effect<TmdbSearchResult, MetadataError>
+  }
+>() {}
+
+// ── Constants ──
+
+const BASE_URL = "https://api.themoviedb.org/3"
+const PROVIDER = "tmdb"
+
+// ── Helpers ──
+
+function buildUrl(
+  path: string,
+  apiKey: string,
+  params: Record<string, string | number | undefined>,
+): URL {
+  const url = new URL(`${BASE_URL}${path}`)
+  url.searchParams.set("api_key", apiKey)
+  for (const [k, v] of Object.entries(params)) {
+    if (v !== undefined) url.searchParams.set(k, String(v))
+  }
+  return url
+}
+
+function statusToReason(status: number): MetadataErrorReason {
+  if (status === 401) return "api_key_missing"
+  if (status === 404) return "not_found"
+  if (status === 429) return "rate_limited"
+  return "request_failed"
+}
+
+function statusRetryable(status: number): boolean {
+  return status === 429 || status >= 500
+}
+
+function getStatusFromError(e: unknown): number | undefined {
+  if (typeof e === "object" && e !== null && "status" in e) {
+    const obj: { status: unknown } = e
+    return typeof obj.status === "number" ? obj.status : undefined
+  }
+  return undefined
+}
+
+function fetchJson(url: URL): Effect.Effect<unknown, MetadataError> {
+  return Effect.tryPromise({
+    try: async () => {
+      const controller = new AbortController()
+      const timeout = setTimeout(() => controller.abort(), 15_000)
+      try {
+        const res = await fetch(url.toString(), { signal: controller.signal })
+        if (!res.ok) {
+          throw Object.assign(new Error(`HTTP ${res.status}`), { status: res.status })
+        }
+        return (await res.json()) as unknown
+      } finally {
+        clearTimeout(timeout)
+      }
+    },
+    catch: (e) => {
+      if (e instanceof Error && e.name === "AbortError") {
+        return new MetadataError({
+          provider: PROVIDER,
+          reason: "request_failed",
+          message: "request timed out after 15s",
+          retryable: true,
+        })
+      }
+      const status = getStatusFromError(e)
+      if (status !== undefined) {
+        return new MetadataError({
+          provider: PROVIDER,
+          reason: statusToReason(status),
+          message: `HTTP ${status}`,
+          retryable: statusRetryable(status),
+        })
+      }
+      return new MetadataError({
+        provider: PROVIDER,
+        reason: "request_failed",
+        message: e instanceof Error ? e.message : "unknown error",
+        retryable: false,
+      })
+    },
+  })
+}
+
+// ── Response parsing ──
+
+type Rec = Readonly<Record<string, unknown>>
+
+const EMPTY_REC: Rec = Object.freeze({})
+
+/** Safely coerce unknown JSON value to a string-keyed record. Allocation-free for objects. */
+function toRec(obj: unknown): Rec {
+  if (typeof obj !== "object" || obj === null) return EMPTY_REC
+  // JSON.parse always returns plain objects with string keys, so Object.entries is safe.
+  return Object.fromEntries(Object.entries(obj))
+}
+
+function extractYear(releaseDate: unknown): number | null {
+  if (typeof releaseDate !== "string" || releaseDate.length < 4) return null
+  const parsed = Number.parseInt(releaseDate.slice(0, 4), 10)
+  return Number.isNaN(parsed) ? null : parsed
+}
+
+function toStr(val: unknown): string {
+  return typeof val === "string" ? val : ""
+}
+
+function toStrOrNull(val: unknown): string | null {
+  return typeof val === "string" && val.length > 0 ? val : null
+}
+
+function toNum(val: unknown, fallback: number): number {
+  return typeof val === "number" ? val : fallback
+}
+
+function toNumOrNull(val: unknown): number | null {
+  return typeof val === "number" ? val : null
+}
+
+function toArray(val: unknown): ReadonlyArray<unknown> {
+  return Array.isArray(val) ? val : []
+}
+
+function parseMovie(raw: unknown): TmdbMovie {
+  const r = toRec(raw)
+  const releaseDate = toStrOrNull(r["release_date"])
+  return {
+    id: toNum(r["id"], 0),
+    title: toStr(r["title"]),
+    originalTitle: toStr(r["original_title"]),
+    overview: toStr(r["overview"]),
+    releaseDate,
+    year: extractYear(r["release_date"]),
+    posterPath: toStrOrNull(r["poster_path"]),
+    backdropPath: toStrOrNull(r["backdrop_path"]),
+    popularity: toNum(r["popularity"], 0),
+    voteAverage: toNum(r["vote_average"], 0),
+    voteCount: toNum(r["vote_count"], 0),
+    genreIds: toArray(r["genre_ids"]).filter((v): v is number => typeof v === "number"),
+    originalLanguage: toStr(r["original_language"]),
+  }
+}
+
+function parseSearchResult(raw: unknown): TmdbSearchResult {
+  const r = toRec(raw)
+  return {
+    page: toNum(r["page"], 1),
+    totalPages: toNum(r["total_pages"], 1),
+    totalResults: toNum(r["total_results"], 0),
+    results: toArray(r["results"]).map(parseMovie),
+  }
+}
+
+function parseMovieDetails(raw: unknown): TmdbMovieDetails {
+  const base = parseMovie(raw)
+  const r = toRec(raw)
+  const genres = toArray(r["genres"]).map((g) => {
+    const gr = toRec(g)
+    return { id: toNum(gr["id"], 0), name: toStr(gr["name"]) }
+  })
+  const productionCompanies = toArray(r["production_companies"]).map((c) => {
+    const cr = toRec(c)
+    return {
+      id: toNum(cr["id"], 0),
+      name: toStr(cr["name"]),
+      logoPath: toStrOrNull(cr["logo_path"]),
+      originCountry: toStr(cr["origin_country"]),
+    }
+  })
+  return {
+    ...base,
+    imdbId: toStrOrNull(r["imdb_id"]),
+    runtime: toNumOrNull(r["runtime"]),
+    status: toStr(r["status"]),
+    tagline: toStrOrNull(r["tagline"]),
+    genres,
+    productionCompanies,
+    budget: toNum(r["budget"], 0),
+    revenue: toNum(r["revenue"], 0),
+  }
+}
+
+// ── Live implementation ──
+
+export const TmdbClientLive = Layer.succeed(TmdbClient, {
+  searchMovies: (query, page) =>
+    Effect.gen(function* () {
+      const apiKey = yield* requireApiKey()
+      const url = buildUrl("/search/movie", apiKey, { query, page })
+      const json = yield* fetchJson(url)
+      return parseSearchResult(json)
+    }),
+
+  getMovie: (tmdbId) =>
+    Effect.gen(function* () {
+      const apiKey = yield* requireApiKey()
+      const url = buildUrl(`/movie/${tmdbId}`, apiKey, {})
+      const json = yield* fetchJson(url)
+      return parseMovieDetails(json)
+    }),
+
+  getPopular: (page) =>
+    Effect.gen(function* () {
+      const apiKey = yield* requireApiKey()
+      const url = buildUrl("/movie/popular", apiKey, { page })
+      const json = yield* fetchJson(url)
+      return parseSearchResult(json)
+    }),
+
+  getTrending: (timeWindow) =>
+    Effect.gen(function* () {
+      const apiKey = yield* requireApiKey()
+      const window = timeWindow ?? "week"
+      const url = buildUrl(`/trending/movie/${window}`, apiKey, {})
+      const json = yield* fetchJson(url)
+      return parseSearchResult(json)
+    }),
+})
+
+function requireApiKey(): Effect.Effect<string, MetadataError> {
+  const key = env.TMDB_API_KEY
+  if (key === undefined || key.length === 0) {
+    return Effect.fail(
+      new MetadataError({
+        provider: PROVIDER,
+        reason: "api_key_missing",
+        message: "TMDB_API_KEY not configured",
+        retryable: false,
+      }),
+    )
+  }
+  return Effect.succeed(key)
+}

--- a/src/effect/test/TestDb.ts
+++ b/src/effect/test/TestDb.ts
@@ -143,6 +143,14 @@ const runDdl = Effect.gen(function* () {
     updated_at INTEGER NOT NULL DEFAULT (unixepoch())
   )`
 
+  yield* sql`CREATE TABLE root_folders (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    path TEXT NOT NULL UNIQUE,
+    free_space_bytes INTEGER,
+    total_space_bytes INTEGER,
+    created_at INTEGER NOT NULL DEFAULT (unixepoch())
+  )`
+
   yield* sql`CREATE TABLE indexers (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     name TEXT NOT NULL,
@@ -152,6 +160,7 @@ const runDdl = Effect.gen(function* () {
     enabled INTEGER NOT NULL DEFAULT 1,
     priority INTEGER NOT NULL DEFAULT 50,
     categories TEXT NOT NULL DEFAULT '[]',
+    capabilities TEXT DEFAULT 'null',
     created_at INTEGER NOT NULL DEFAULT (unixepoch()),
     updated_at INTEGER NOT NULL DEFAULT (unixepoch())
   )`

--- a/src/env.ts
+++ b/src/env.ts
@@ -4,6 +4,7 @@ import { z } from "zod"
 export const env = createEnv({
   server: {
     SERVER_URL: z.string().url().optional(),
+    TMDB_API_KEY: z.string().min(1).optional(),
   },
 
   /**

--- a/src/integrations/trpc/init.ts
+++ b/src/integrations/trpc/init.ts
@@ -13,6 +13,7 @@ import type {
   EncryptionError,
   IndexerError,
   MediaServerError,
+  MetadataError,
   NotFoundError,
   ParseFailed,
   ProfileInUseError,
@@ -57,6 +58,7 @@ type DomainError =
   | ParseFailed
   | SchedulerError
   | AcquisitionError
+  | MetadataError
 
 export function domainToTRPC(error: DomainError): TRPCError {
   switch (error._tag) {
@@ -144,6 +146,18 @@ export function domainToTRPC(error: DomainError): TRPCError {
         code: "BAD_REQUEST",
         message: `[movie:${error.movieId}] ${error.stage}: ${error.message}`,
       })
+    case "MetadataError": {
+      const codeMap: Record<string, TRPCError["code"]> = {
+        api_key_missing: "UNAUTHORIZED",
+        not_found: "NOT_FOUND",
+        rate_limited: "TOO_MANY_REQUESTS",
+        request_failed: "BAD_GATEWAY",
+      }
+      return new TRPCError({
+        code: codeMap[error.reason] ?? "BAD_GATEWAY",
+        message: `[${error.provider}] ${error.message}`,
+      })
+    }
   }
 }
 

--- a/src/integrations/trpc/router.ts
+++ b/src/integrations/trpc/router.ts
@@ -7,8 +7,10 @@ import { mediaServersRouter } from "./routers/mediaServers"
 import { moviesRouter } from "./routers/movies"
 import { profilesRouter } from "./routers/profiles"
 import { releasesRouter } from "./routers/releases"
+import { rootFoldersRouter } from "./routers/rootFolders"
 import { schedulerRouter } from "./routers/scheduler"
 import { seriesRouter } from "./routers/series"
+import { tmdbRouter } from "./routers/tmdb"
 
 export const trpcRouter = createTRPCRouter({
   auth: authRouter,
@@ -20,7 +22,9 @@ export const trpcRouter = createTRPCRouter({
   downloadClients: downloadClientsRouter,
   mediaServers: mediaServersRouter,
   releases: releasesRouter,
+  rootFolders: rootFoldersRouter,
   scheduler: schedulerRouter,
+  tmdb: tmdbRouter,
 })
 
 export type TRPCRouter = typeof trpcRouter

--- a/src/integrations/trpc/routers/rootFolders.ts
+++ b/src/integrations/trpc/routers/rootFolders.ts
@@ -1,0 +1,54 @@
+import type { TRPCRouterRecord } from "@trpc/server"
+import { Effect } from "effect"
+import { z } from "zod"
+
+import { RootFolderService } from "#/effect/services/RootFolderService"
+
+import { authedProcedure, runEffect } from "../init"
+
+export const rootFoldersRouter = {
+  add: authedProcedure.input(z.object({ path: z.string() })).mutation(({ input }) =>
+    runEffect(
+      Effect.gen(function* () {
+        const svc = yield* RootFolderService
+        return yield* svc.add(input)
+      }),
+    ),
+  ),
+
+  list: authedProcedure.query(() =>
+    runEffect(
+      Effect.gen(function* () {
+        const svc = yield* RootFolderService
+        return yield* svc.list()
+      }),
+    ),
+  ),
+
+  get: authedProcedure.input(z.object({ id: z.number() })).query(({ input }) =>
+    runEffect(
+      Effect.gen(function* () {
+        const svc = yield* RootFolderService
+        return yield* svc.getById(input.id)
+      }),
+    ),
+  ),
+
+  remove: authedProcedure.input(z.object({ id: z.number() })).mutation(({ input }) =>
+    runEffect(
+      Effect.gen(function* () {
+        const svc = yield* RootFolderService
+        yield* svc.remove(input.id)
+      }),
+    ),
+  ),
+
+  refreshSpace: authedProcedure.input(z.object({ id: z.number() })).mutation(({ input }) =>
+    runEffect(
+      Effect.gen(function* () {
+        const svc = yield* RootFolderService
+        return yield* svc.refreshSpace(input.id)
+      }),
+    ),
+  ),
+} satisfies TRPCRouterRecord

--- a/src/integrations/trpc/routers/tmdb.ts
+++ b/src/integrations/trpc/routers/tmdb.ts
@@ -1,0 +1,51 @@
+import type { TRPCRouterRecord } from "@trpc/server"
+import { Effect } from "effect"
+import { z } from "zod"
+
+import { TmdbClient } from "#/effect/services/TmdbClient"
+
+import { authedProcedure, runEffect } from "../init"
+
+export const tmdbRouter = {
+  searchMovies: authedProcedure
+    .input(z.object({ query: z.string(), page: z.number().int().positive().optional() }))
+    .query(({ input }) =>
+      runEffect(
+        Effect.gen(function* () {
+          const svc = yield* TmdbClient
+          return yield* svc.searchMovies(input.query, input.page)
+        }),
+      ),
+    ),
+
+  getMovie: authedProcedure.input(z.object({ tmdbId: z.number().int() })).query(({ input }) =>
+    runEffect(
+      Effect.gen(function* () {
+        const svc = yield* TmdbClient
+        return yield* svc.getMovie(input.tmdbId)
+      }),
+    ),
+  ),
+
+  popular: authedProcedure
+    .input(z.object({ page: z.number().int().positive().optional() }))
+    .query(({ input }) =>
+      runEffect(
+        Effect.gen(function* () {
+          const svc = yield* TmdbClient
+          return yield* svc.getPopular(input.page)
+        }),
+      ),
+    ),
+
+  trending: authedProcedure
+    .input(z.object({ timeWindow: z.enum(["day", "week"]).optional() }))
+    .query(({ input }) =>
+      runEffect(
+        Effect.gen(function* () {
+          const svc = yield* TmdbClient
+          return yield* svc.getTrending(input.timeWindow)
+        }),
+      ),
+    ),
+} satisfies TRPCRouterRecord


### PR DESCRIPTION
## Summary

Addresses structural issues and missing features identified in the architecture assessment comparing arr-hub to Prowlarr/Seerr vendor codebases.

### Structural fixes
- **S1**: Remove `as QualityName` type assertion in AcquisitionPipeline — replaced with `parseQualityName()` boundary validator
- **S2**: Cache indexer capabilities in DB on successful `testConnection` — enables smarter search queries and UI category filtering

### New features
- **M1**: TMDB API client — `searchMovies`, `getMovie`, `getPopular`, `getTrending` with boundary-parsed domain types, `MetadataError` error type, tRPC router
- **M4**: Root folder management — `root_folders` table, service with disk space monitoring via `statfs`, tRPC router
- **M5**: Jellyfin media server adapter — `MediaBrowser` auth, library enumeration, movie/episode sync with `ProviderIds` extraction, registered in AdapterRegistry
- **M7**: Standard Torznab/Newznab category definitions — 80+ categories with parent/child tree, lookup helpers (`getCategoryById`, `isInCategory`, `normalizeCategory`), pre-filtered `MOVIE_CATEGORIES`/`TV_CATEGORIES` arrays

### Files changed
- 13 modified, 7 new (20 total)
- All 190 tests pass, typecheck clean, no type assertions introduced

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run test` — 190/190 pass
- [x] `bun run fmt:check` passes
- [x] `bun run lint` passes
- [ ] Manual: add TMDB_API_KEY to env, verify movie search returns results
- [ ] Manual: add root folder, verify disk space reported
- [ ] Manual: add Jellyfin server, verify library sync