### PR TITLE
feat: TV acquisition E2E (closes #13)

### DIFF
--- a/drizzle/0001_wise_violations.sql
+++ b/drizzle/0001_wise_violations.sql
@@ -1,0 +1,211 @@
+CREATE TABLE `download_client_health` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`download_client_id` integer NOT NULL,
+	`last_check` integer DEFAULT (unixepoch()) NOT NULL,
+	`status` text DEFAULT 'unknown' NOT NULL,
+	`error_message` text,
+	`response_time_ms` integer,
+	FOREIGN KEY (`download_client_id`) REFERENCES `download_clients`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `download_client_health_download_client_id_unique` ON `download_client_health` (`download_client_id`);--> statement-breakpoint
+CREATE TABLE `download_clients` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`name` text NOT NULL,
+	`type` text NOT NULL,
+	`host` text NOT NULL,
+	`port` integer NOT NULL,
+	`username` text NOT NULL,
+	`password_encrypted` text NOT NULL,
+	`use_ssl` integer DEFAULT false NOT NULL,
+	`category` text,
+	`priority` integer DEFAULT 50 NOT NULL,
+	`enabled` integer DEFAULT true NOT NULL,
+	`settings` text DEFAULT '{"pollIntervalMs":5000}' NOT NULL,
+	`created_at` integer DEFAULT (unixepoch()) NOT NULL,
+	`updated_at` integer DEFAULT (unixepoch()) NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE `download_queue` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`download_client_id` integer NOT NULL,
+	`movie_id` integer,
+	`series_id` integer,
+	`episode_ids` text,
+	`external_id` text NOT NULL,
+	`status` text DEFAULT 'queued' NOT NULL,
+	`title` text NOT NULL,
+	`size_bytes` integer DEFAULT 0 NOT NULL,
+	`progress` real DEFAULT 0 NOT NULL,
+	`eta_seconds` integer,
+	`error_message` text,
+	`added_at` integer DEFAULT (unixepoch()) NOT NULL,
+	`updated_at` integer DEFAULT (unixepoch()) NOT NULL,
+	FOREIGN KEY (`download_client_id`) REFERENCES `download_clients`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`movie_id`) REFERENCES `movies`(`id`) ON UPDATE no action ON DELETE set null,
+	FOREIGN KEY (`series_id`) REFERENCES `series`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `download_queue_external_id_unique` ON `download_queue` (`external_id`);--> statement-breakpoint
+CREATE TABLE `episodes` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`season_id` integer NOT NULL,
+	`tvdb_id` integer NOT NULL,
+	`title` text NOT NULL,
+	`episode_number` integer NOT NULL,
+	`air_date` integer,
+	`overview` text,
+	`has_file` integer DEFAULT false NOT NULL,
+	`file_path` text,
+	`monitored` integer DEFAULT true NOT NULL,
+	`existing_quality_name` text,
+	`existing_quality_rank` integer,
+	`existing_format_score` integer,
+	FOREIGN KEY (`season_id`) REFERENCES `seasons`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `episodes_tvdb_id_unique` ON `episodes` (`tvdb_id`);--> statement-breakpoint
+CREATE UNIQUE INDEX `episodes_season_id_episode_number_unique` ON `episodes` (`season_id`,`episode_number`);--> statement-breakpoint
+CREATE TABLE `indexer_health` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`indexer_id` integer NOT NULL,
+	`last_check` integer DEFAULT (unixepoch()) NOT NULL,
+	`status` text DEFAULT 'unknown' NOT NULL,
+	`error_message` text,
+	`response_time_ms` integer,
+	FOREIGN KEY (`indexer_id`) REFERENCES `indexers`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `indexer_health_indexer_id_unique` ON `indexer_health` (`indexer_id`);--> statement-breakpoint
+CREATE TABLE `indexers` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`name` text NOT NULL,
+	`type` text NOT NULL,
+	`base_url` text NOT NULL,
+	`api_key_encrypted` text NOT NULL,
+	`enabled` integer DEFAULT true NOT NULL,
+	`priority` integer DEFAULT 50 NOT NULL,
+	`categories` text DEFAULT '[]' NOT NULL,
+	`capabilities` text DEFAULT 'null',
+	`created_at` integer DEFAULT (unixepoch()) NOT NULL,
+	`updated_at` integer DEFAULT (unixepoch()) NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE `media_server_health` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`media_server_id` integer NOT NULL,
+	`last_check` integer DEFAULT (unixepoch()) NOT NULL,
+	`status` text DEFAULT 'unknown' NOT NULL,
+	`error_message` text,
+	`response_time_ms` integer,
+	FOREIGN KEY (`media_server_id`) REFERENCES `media_servers`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `media_server_health_media_server_id_unique` ON `media_server_health` (`media_server_id`);--> statement-breakpoint
+CREATE TABLE `media_server_libraries` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`media_server_id` integer NOT NULL,
+	`external_id` text NOT NULL,
+	`name` text NOT NULL,
+	`type` text NOT NULL,
+	`enabled` integer DEFAULT true NOT NULL,
+	`last_synced` integer,
+	FOREIGN KEY (`media_server_id`) REFERENCES `media_servers`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `media_server_libraries_media_server_id_external_id_unique` ON `media_server_libraries` (`media_server_id`,`external_id`);--> statement-breakpoint
+CREATE TABLE `media_servers` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`name` text NOT NULL,
+	`type` text NOT NULL,
+	`host` text NOT NULL,
+	`port` integer NOT NULL,
+	`token_encrypted` text NOT NULL,
+	`use_ssl` integer DEFAULT false NOT NULL,
+	`enabled` integer DEFAULT true NOT NULL,
+	`settings` text DEFAULT '{"syncIntervalMs":3600000}' NOT NULL,
+	`created_at` integer DEFAULT (unixepoch()) NOT NULL,
+	`updated_at` integer DEFAULT (unixepoch()) NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE `release_decisions` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`media_id` integer NOT NULL,
+	`media_type` text NOT NULL,
+	`candidate_title` text NOT NULL,
+	`indexer_id` integer,
+	`indexer_name` text,
+	`quality_rank` integer,
+	`format_score` integer DEFAULT 0 NOT NULL,
+	`decision` text NOT NULL,
+	`reasons` text DEFAULT '[]' NOT NULL,
+	`decided_at` integer DEFAULT (unixepoch()) NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE `root_folders` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`path` text NOT NULL,
+	`free_space_bytes` integer,
+	`total_space_bytes` integer,
+	`created_at` integer DEFAULT (unixepoch()) NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `root_folders_path_unique` ON `root_folders` (`path`);--> statement-breakpoint
+CREATE TABLE `scheduler_config` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`job_type` text NOT NULL,
+	`interval_minutes` integer NOT NULL,
+	`retry_delay_seconds` integer DEFAULT 60 NOT NULL,
+	`max_retries` integer DEFAULT 3 NOT NULL,
+	`backoff_multiplier` real DEFAULT 2 NOT NULL,
+	`enabled` integer DEFAULT true NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `scheduler_config_job_type_unique` ON `scheduler_config` (`job_type`);--> statement-breakpoint
+CREATE TABLE `scheduler_jobs` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`job_type` text NOT NULL,
+	`status` text DEFAULT 'pending' NOT NULL,
+	`dedupe_key` text NOT NULL,
+	`payload` text NOT NULL,
+	`attempts` integer DEFAULT 0 NOT NULL,
+	`max_attempts` integer DEFAULT 3 NOT NULL,
+	`next_run_at` integer DEFAULT (unixepoch()) NOT NULL,
+	`started_at` integer,
+	`completed_at` integer,
+	`error_message` text,
+	`created_at` integer DEFAULT (unixepoch()) NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE `seasons` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`series_id` integer NOT NULL,
+	`season_number` integer NOT NULL,
+	`monitored` integer DEFAULT true NOT NULL,
+	FOREIGN KEY (`series_id`) REFERENCES `series`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `seasons_series_id_season_number_unique` ON `seasons` (`series_id`,`season_number`);--> statement-breakpoint
+CREATE TABLE `series` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`tvdb_id` integer NOT NULL,
+	`title` text NOT NULL,
+	`year` integer,
+	`overview` text,
+	`poster_path` text,
+	`status` text DEFAULT 'wanted' NOT NULL,
+	`network` text,
+	`root_folder_path` text,
+	`monitored` integer DEFAULT true NOT NULL,
+	`quality_profile_id` integer,
+	`season_folder` integer DEFAULT true NOT NULL,
+	`added_at` integer DEFAULT (unixepoch()) NOT NULL,
+	FOREIGN KEY (`quality_profile_id`) REFERENCES `quality_profiles`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `series_tvdb_id_unique` ON `series` (`tvdb_id`);--> statement-breakpoint
+ALTER TABLE `movies` ADD `has_file` integer DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE `movies` ADD `file_path` text;--> statement-breakpoint
+ALTER TABLE `movies` ADD `existing_quality_name` text;--> statement-breakpoint
+ALTER TABLE `movies` ADD `existing_quality_rank` integer;--> statement-breakpoint
+ALTER TABLE `movies` ADD `existing_format_score` integer;

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,2123 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "7f6e0ff9-1c2e-4cf8-9aef-bcf056f14d14",
+  "prevId": "b1b744b6-7747-4eb6-98be-b5380d2f33c7",
+  "tables": {
+    "api_keys": {
+      "name": "api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "api_keys_token_hash_unique": {
+          "name": "api_keys_token_hash_unique",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "api_keys_user_id_users_id_fk": {
+          "name": "api_keys_user_id_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "custom_format_scores": {
+      "name": "custom_format_scores",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "custom_format_id": {
+          "name": "custom_format_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "custom_format_scores_profile_id_custom_format_id_unique": {
+          "name": "custom_format_scores_profile_id_custom_format_id_unique",
+          "columns": [
+            "profile_id",
+            "custom_format_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "custom_format_scores_profile_id_quality_profiles_id_fk": {
+          "name": "custom_format_scores_profile_id_quality_profiles_id_fk",
+          "tableFrom": "custom_format_scores",
+          "tableTo": "quality_profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "custom_format_scores_custom_format_id_custom_formats_id_fk": {
+          "name": "custom_format_scores_custom_format_id_custom_formats_id_fk",
+          "tableFrom": "custom_format_scores",
+          "tableTo": "custom_formats",
+          "columnsFrom": [
+            "custom_format_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "custom_format_specs": {
+      "name": "custom_format_specs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "custom_format_id": {
+          "name": "custom_format_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field": {
+          "name": "field",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "negate": {
+          "name": "negate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "required": {
+          "name": "required",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "custom_format_specs_custom_format_id_custom_formats_id_fk": {
+          "name": "custom_format_specs_custom_format_id_custom_formats_id_fk",
+          "tableFrom": "custom_format_specs",
+          "tableTo": "custom_formats",
+          "columnsFrom": [
+            "custom_format_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "custom_formats": {
+      "name": "custom_formats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "include_when_renaming": {
+          "name": "include_when_renaming",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "custom_formats_name_unique": {
+          "name": "custom_formats_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "download_client_health": {
+      "name": "download_client_health",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "download_client_id": {
+          "name": "download_client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_check": {
+          "name": "last_check",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unknown'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response_time_ms": {
+          "name": "response_time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "download_client_health_download_client_id_unique": {
+          "name": "download_client_health_download_client_id_unique",
+          "columns": [
+            "download_client_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "download_client_health_download_client_id_download_clients_id_fk": {
+          "name": "download_client_health_download_client_id_download_clients_id_fk",
+          "tableFrom": "download_client_health",
+          "tableTo": "download_clients",
+          "columnsFrom": [
+            "download_client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "download_clients": {
+      "name": "download_clients",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "port": {
+          "name": "port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_encrypted": {
+          "name": "password_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "use_ssl": {
+          "name": "use_ssl",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 50
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "settings": {
+          "name": "settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{\"pollIntervalMs\":5000}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "download_queue": {
+      "name": "download_queue",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "download_client_id": {
+          "name": "download_client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "movie_id": {
+          "name": "movie_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "series_id": {
+          "name": "series_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "episode_ids": {
+          "name": "episode_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'queued'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "progress": {
+          "name": "progress",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "eta_seconds": {
+          "name": "eta_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "download_queue_external_id_unique": {
+          "name": "download_queue_external_id_unique",
+          "columns": [
+            "external_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "download_queue_download_client_id_download_clients_id_fk": {
+          "name": "download_queue_download_client_id_download_clients_id_fk",
+          "tableFrom": "download_queue",
+          "tableTo": "download_clients",
+          "columnsFrom": [
+            "download_client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "download_queue_movie_id_movies_id_fk": {
+          "name": "download_queue_movie_id_movies_id_fk",
+          "tableFrom": "download_queue",
+          "tableTo": "movies",
+          "columnsFrom": [
+            "movie_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "download_queue_series_id_series_id_fk": {
+          "name": "download_queue_series_id_series_id_fk",
+          "tableFrom": "download_queue",
+          "tableTo": "series",
+          "columnsFrom": [
+            "series_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "episodes": {
+      "name": "episodes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tvdb_id": {
+          "name": "tvdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "episode_number": {
+          "name": "episode_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "air_date": {
+          "name": "air_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "overview": {
+          "name": "overview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "has_file": {
+          "name": "has_file",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "monitored": {
+          "name": "monitored",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "existing_quality_name": {
+          "name": "existing_quality_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "existing_quality_rank": {
+          "name": "existing_quality_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "existing_format_score": {
+          "name": "existing_format_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "episodes_tvdb_id_unique": {
+          "name": "episodes_tvdb_id_unique",
+          "columns": [
+            "tvdb_id"
+          ],
+          "isUnique": true
+        },
+        "episodes_season_id_episode_number_unique": {
+          "name": "episodes_season_id_episode_number_unique",
+          "columns": [
+            "season_id",
+            "episode_number"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "episodes_season_id_seasons_id_fk": {
+          "name": "episodes_season_id_seasons_id_fk",
+          "tableFrom": "episodes",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "indexer_health": {
+      "name": "indexer_health",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "indexer_id": {
+          "name": "indexer_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_check": {
+          "name": "last_check",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unknown'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response_time_ms": {
+          "name": "response_time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "indexer_health_indexer_id_unique": {
+          "name": "indexer_health_indexer_id_unique",
+          "columns": [
+            "indexer_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "indexer_health_indexer_id_indexers_id_fk": {
+          "name": "indexer_health_indexer_id_indexers_id_fk",
+          "tableFrom": "indexer_health",
+          "tableTo": "indexers",
+          "columnsFrom": [
+            "indexer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "indexers": {
+      "name": "indexers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key_encrypted": {
+          "name": "api_key_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 50
+        },
+        "categories": {
+          "name": "categories",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'null'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media_server_health": {
+      "name": "media_server_health",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "media_server_id": {
+          "name": "media_server_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_check": {
+          "name": "last_check",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unknown'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response_time_ms": {
+          "name": "response_time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "media_server_health_media_server_id_unique": {
+          "name": "media_server_health_media_server_id_unique",
+          "columns": [
+            "media_server_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "media_server_health_media_server_id_media_servers_id_fk": {
+          "name": "media_server_health_media_server_id_media_servers_id_fk",
+          "tableFrom": "media_server_health",
+          "tableTo": "media_servers",
+          "columnsFrom": [
+            "media_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media_server_libraries": {
+      "name": "media_server_libraries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "media_server_id": {
+          "name": "media_server_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "last_synced": {
+          "name": "last_synced",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "media_server_libraries_media_server_id_external_id_unique": {
+          "name": "media_server_libraries_media_server_id_external_id_unique",
+          "columns": [
+            "media_server_id",
+            "external_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "media_server_libraries_media_server_id_media_servers_id_fk": {
+          "name": "media_server_libraries_media_server_id_media_servers_id_fk",
+          "tableFrom": "media_server_libraries",
+          "tableTo": "media_servers",
+          "columnsFrom": [
+            "media_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media_servers": {
+      "name": "media_servers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "port": {
+          "name": "port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_encrypted": {
+          "name": "token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "use_ssl": {
+          "name": "use_ssl",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "settings": {
+          "name": "settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{\"syncIntervalMs\":3600000}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "movies": {
+      "name": "movies",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "tmdb_id": {
+          "name": "tmdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "overview": {
+          "name": "overview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "poster_path": {
+          "name": "poster_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'wanted'"
+        },
+        "quality_profile_id": {
+          "name": "quality_profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "root_folder_path": {
+          "name": "root_folder_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "monitored": {
+          "name": "monitored",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "has_file": {
+          "name": "has_file",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "existing_quality_name": {
+          "name": "existing_quality_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "existing_quality_rank": {
+          "name": "existing_quality_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "existing_format_score": {
+          "name": "existing_format_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "movies_tmdb_id_unique": {
+          "name": "movies_tmdb_id_unique",
+          "columns": [
+            "tmdb_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "movies_quality_profile_id_quality_profiles_id_fk": {
+          "name": "movies_quality_profile_id_quality_profiles_id_fk",
+          "tableFrom": "movies",
+          "tableTo": "quality_profiles",
+          "columnsFrom": [
+            "quality_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "quality_items": {
+      "name": "quality_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quality_name": {
+          "name": "quality_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "group_name": {
+          "name": "group_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "allowed": {
+          "name": "allowed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "quality_items_profile_id_quality_profiles_id_fk": {
+          "name": "quality_items_profile_id_quality_profiles_id_fk",
+          "tableFrom": "quality_items",
+          "tableTo": "quality_profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "quality_profiles": {
+      "name": "quality_profiles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "upgrade_allowed": {
+          "name": "upgrade_allowed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "min_format_score": {
+          "name": "min_format_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cutoff_format_score": {
+          "name": "cutoff_format_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "min_upgrade_format_score": {
+          "name": "min_upgrade_format_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "applied_bundle_id": {
+          "name": "applied_bundle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "applied_bundle_version": {
+          "name": "applied_bundle_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "quality_profiles_name_unique": {
+          "name": "quality_profiles_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "release_decisions": {
+      "name": "release_decisions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "candidate_title": {
+          "name": "candidate_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "indexer_id": {
+          "name": "indexer_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "indexer_name": {
+          "name": "indexer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quality_rank": {
+          "name": "quality_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "format_score": {
+          "name": "format_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reasons": {
+          "name": "reasons",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "root_folders": {
+      "name": "root_folders",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "free_space_bytes": {
+          "name": "free_space_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_space_bytes": {
+          "name": "total_space_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "root_folders_path_unique": {
+          "name": "root_folders_path_unique",
+          "columns": [
+            "path"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scheduler_config": {
+      "name": "scheduler_config",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "job_type": {
+          "name": "job_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "interval_minutes": {
+          "name": "interval_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "retry_delay_seconds": {
+          "name": "retry_delay_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 60
+        },
+        "max_retries": {
+          "name": "max_retries",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 3
+        },
+        "backoff_multiplier": {
+          "name": "backoff_multiplier",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "scheduler_config_job_type_unique": {
+          "name": "scheduler_config_job_type_unique",
+          "columns": [
+            "job_type"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scheduler_jobs": {
+      "name": "scheduler_jobs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "job_type": {
+          "name": "job_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 3
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "seasons": {
+      "name": "seasons",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "series_id": {
+          "name": "series_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "season_number": {
+          "name": "season_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "monitored": {
+          "name": "monitored",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "seasons_series_id_season_number_unique": {
+          "name": "seasons_series_id_season_number_unique",
+          "columns": [
+            "series_id",
+            "season_number"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "seasons_series_id_series_id_fk": {
+          "name": "seasons_series_id_series_id_fk",
+          "tableFrom": "seasons",
+          "tableTo": "series",
+          "columnsFrom": [
+            "series_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "series": {
+      "name": "series",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "tvdb_id": {
+          "name": "tvdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "overview": {
+          "name": "overview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "poster_path": {
+          "name": "poster_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'wanted'"
+        },
+        "network": {
+          "name": "network",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "root_folder_path": {
+          "name": "root_folder_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "monitored": {
+          "name": "monitored",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "quality_profile_id": {
+          "name": "quality_profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "season_folder": {
+          "name": "season_folder",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "series_tvdb_id_unique": {
+          "name": "series_tvdb_id_unique",
+          "columns": [
+            "tvdb_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "series_quality_profile_id_quality_profiles_id_fk": {
+          "name": "series_quality_profile_id_quality_profiles_id_fk",
+          "tableFrom": "series",
+          "tableTo": "quality_profiles",
+          "columnsFrom": [
+            "quality_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "settings": {
+      "name": "settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1772241801884,
       "tag": "0000_ambitious_veda",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1776486454140,
+      "tag": "0001_wise_violations",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -179,6 +179,9 @@ export const episodes = sqliteTable(
     hasFile: integer("has_file", { mode: "boolean" }).notNull().default(false),
     filePath: text("file_path"),
     monitored: integer({ mode: "boolean" }).notNull().default(true),
+    existingQualityName: text("existing_quality_name"),
+    existingQualityRank: integer("existing_quality_rank"),
+    existingFormatScore: integer("existing_format_score"),
   },
   (t) => [unique().on(t.seasonId, t.episodeNumber)],
 )
@@ -286,6 +289,8 @@ export const downloadQueue = sqliteTable("download_queue", {
     .notNull()
     .references(() => downloadClients.id, { onDelete: "cascade" }),
   movieId: integer("movie_id").references(() => movies.id, { onDelete: "set null" }),
+  seriesId: integer("series_id").references(() => series.id, { onDelete: "set null" }),
+  episodeIds: text("episode_ids", { mode: "json" }).$type<ReadonlyArray<number> | null>(),
   externalId: text("external_id").notNull().unique(),
   status: text({ enum: ["queued", "downloading", "importing", "completed", "failed"] })
     .notNull()

--- a/src/effect/domain/release.ts
+++ b/src/effect/domain/release.ts
@@ -41,7 +41,7 @@ export interface RankedDecision {
 
 // ── Evaluation Context ──
 
-export type MediaType = "movie" | "episode"
+export type MediaType = "movie" | "episode" | "season"
 
 export interface ExistingFile {
   readonly qualityName: QualityName
@@ -53,4 +53,9 @@ export interface EvaluationContext {
   readonly mediaId: number
   readonly mediaType: MediaType
   readonly existingFile?: ExistingFile
+}
+
+/** Classify a parsed title: did it look like a season pack (season present, episode absent)? */
+export function isSeasonPack(parsed: ParsedTitle): boolean {
+  return parsed.season !== null && parsed.episode === null
 }

--- a/src/effect/domain/scheduler.ts
+++ b/src/effect/domain/scheduler.ts
@@ -1,6 +1,15 @@
 // ── Scheduler Job Types ──
 
-export type SchedulerJobType = "rss_sync" | "search_missing" | "search_cutoff" | "download_monitor"
+export type SchedulerJobType =
+  | "rss_sync"
+  | "search_missing"
+  | "search_cutoff"
+  | "download_monitor"
+  | "tv_rss_sync"
+  | "tv_search_cutoff"
+  | "tv_search_series"
+  | "tv_search_season"
+  | "tv_search_episode"
 
 /**
  * State machine: pending → running → completed | failed
@@ -15,6 +24,11 @@ export type SchedulerJobPayload =
   | { readonly _tag: "search_missing"; readonly movieId: number }
   | { readonly _tag: "search_cutoff" }
   | { readonly _tag: "download_monitor" }
+  | { readonly _tag: "tv_rss_sync" }
+  | { readonly _tag: "tv_search_cutoff" }
+  | { readonly _tag: "tv_search_series"; readonly seriesId: number }
+  | { readonly _tag: "tv_search_season"; readonly seasonId: number }
+  | { readonly _tag: "tv_search_episode"; readonly episodeId: number }
 
 // ── Dedupe key builders ──
 
@@ -28,6 +42,16 @@ export function dedupeKey(payload: SchedulerJobPayload): string {
       return "search_cutoff"
     case "download_monitor":
       return "download_monitor"
+    case "tv_rss_sync":
+      return "tv_rss_sync"
+    case "tv_search_cutoff":
+      return "tv_search_cutoff"
+    case "tv_search_series":
+      return `tv_search_series:${payload.seriesId}`
+    case "tv_search_season":
+      return `tv_search_season:${payload.seasonId}`
+    case "tv_search_episode":
+      return `tv_search_episode:${payload.episodeId}`
   }
 }
 
@@ -81,7 +105,28 @@ export const DEFAULT_CONFIGS: ReadonlyArray<SchedulerJobConfig> = [
     backoffMultiplier: 1.5,
     enabled: true,
   },
+  {
+    jobType: "tv_rss_sync",
+    intervalMinutes: 20,
+    retryDelaySeconds: 60,
+    maxRetries: 3,
+    backoffMultiplier: 2,
+    enabled: true,
+  },
+  {
+    jobType: "tv_search_cutoff",
+    intervalMinutes: 360,
+    retryDelaySeconds: 120,
+    maxRetries: 3,
+    backoffMultiplier: 2,
+    enabled: true,
+  },
 ]
+
+// ── Air-date gating ──
+
+/** Delay after air date before triggering a search for a new episode. */
+export const DEFAULT_AIR_DATE_DELAY_MINUTES = 30
 
 // ── Job status summary ──
 

--- a/src/effect/errors.ts
+++ b/src/effect/errors.ts
@@ -102,8 +102,11 @@ export class SchedulerError extends Data.TaggedError("SchedulerError")<{
 
 export type AcquisitionStage = "search" | "evaluate" | "grab"
 
+export type AcquisitionMediaKind = "movie" | "series" | "season" | "episode"
+
 export class AcquisitionError extends Data.TaggedError("AcquisitionError")<{
-  readonly movieId: number
+  readonly mediaKind: AcquisitionMediaKind
+  readonly mediaId: number
   readonly stage: AcquisitionStage
   readonly message: string
 }> {}

--- a/src/effect/services/AcquisitionPipeline.test.ts
+++ b/src/effect/services/AcquisitionPipeline.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it } from "@effect/vitest"
+import { eq } from "drizzle-orm"
 import { Effect, Layer } from "effect"
 
-import { qualityProfiles } from "#/db/schema"
-import type { ReleaseCandidate } from "#/effect/domain/indexer"
-import type { RankedDecision } from "#/effect/domain/release"
+import { downloadClients, downloadQueue, qualityProfiles } from "#/db/schema"
+import type { ReleaseCandidate, SearchQuery, SearchResult } from "#/effect/domain/indexer"
+import type { ParsedTitle, RankedDecision } from "#/effect/domain/release"
 import { Db } from "#/effect/services/Db"
 import { TestDbLive } from "#/effect/test/TestDb"
 
@@ -13,6 +14,7 @@ import { DownloadClientService } from "./DownloadClientService"
 import { IndexerService } from "./IndexerService"
 import { MovieService, MovieServiceLive } from "./MovieService"
 import { ReleasePolicyEngine } from "./ReleasePolicyEngine"
+import { SeriesService, SeriesServiceLive } from "./SeriesService"
 
 // ── Mock candidates ──
 
@@ -133,6 +135,7 @@ const BaseLayer = Layer.mergeAll(
   MockReleasePolicyEngine,
   MockIndexerService,
   MovieServiceLive,
+  SeriesServiceLive,
   AdapterRegistryLive,
 ).pipe(Layer.provideMerge(TestDbLive))
 
@@ -145,6 +148,7 @@ const EmptySearchLayer = AcquisitionPipelineLive.pipe(
       MockReleasePolicyEngine,
       MockIndexerServiceEmpty,
       MovieServiceLive,
+      SeriesServiceLive,
       AdapterRegistryLive,
     ).pipe(Layer.provideMerge(TestDbLive)),
   ),
@@ -157,6 +161,7 @@ const RejectedLayer = AcquisitionPipelineLive.pipe(
       MockReleasePolicyEngineRejected,
       MockIndexerService,
       MovieServiceLive,
+      SeriesServiceLive,
       AdapterRegistryLive,
     ).pipe(Layer.provideMerge(TestDbLive)),
   ),
@@ -260,5 +265,454 @@ describe("AcquisitionPipeline", () => {
       expect(result.hash).toBe("hash_abc123")
       expect(result.candidateTitle).toBe("Some.Release")
     }).pipe(Effect.provide(TestLayer)),
+  )
+})
+
+// ── TV mock candidates ──
+
+const packCandidate: ReleaseCandidate = {
+  title: "Test.Show.S01.1080p.BluRay.x264-GROUP",
+  indexerId: 1,
+  indexerName: "test-indexer",
+  indexerPriority: 50,
+  size: 8_000_000_000,
+  seeders: 50,
+  leechers: 5,
+  age: 30,
+  downloadUrl: "magnet:?xt=urn:btih:pack",
+  infoUrl: null,
+  category: "5030",
+  protocol: "torrent",
+  publishedAt: new Date(),
+  infohash: "pack",
+  downloadFactor: 1,
+  uploadFactor: 1,
+}
+
+const episodeCandidate: ReleaseCandidate = {
+  title: "Test.Show.S01E01.1080p.WEB-DL.x264-GROUP",
+  indexerId: 1,
+  indexerName: "test-indexer",
+  indexerPriority: 50,
+  size: 1_500_000_000,
+  seeders: 100,
+  leechers: 10,
+  age: 1,
+  downloadUrl: "magnet:?xt=urn:btih:ep1",
+  infoUrl: null,
+  category: "5030",
+  protocol: "torrent",
+  publishedAt: new Date(),
+  infohash: "ep1",
+  downloadFactor: 1,
+  uploadFactor: 1,
+}
+
+const episodeCandidate2: ReleaseCandidate = {
+  ...episodeCandidate,
+  title: "Test.Show.S01E02.1080p.WEB-DL.x264-GROUP",
+  downloadUrl: "magnet:?xt=urn:btih:ep2",
+  infohash: "ep2",
+}
+
+const packParsed: ParsedTitle = {
+  title: "Test Show",
+  year: null,
+  season: 1,
+  episode: null,
+  resolution: 1080,
+  source: "bluray",
+  modifier: null,
+  codec: "x264",
+  releaseGroup: "GROUP",
+  edition: null,
+  proper: false,
+  qualityName: "Bluray1080p",
+}
+
+const ep1Parsed: ParsedTitle = {
+  title: "Test Show",
+  year: null,
+  season: 1,
+  episode: 1,
+  resolution: 1080,
+  source: "webdl",
+  modifier: null,
+  codec: "x264",
+  releaseGroup: "GROUP",
+  edition: null,
+  proper: false,
+  qualityName: "WEBDL1080p",
+}
+
+const ep2Parsed: ParsedTitle = { ...ep1Parsed, episode: 2 }
+
+// ── TV mock indexer: distinguishes pack vs episode search ──
+
+const MockTvIndexerWithPack = Layer.succeed(IndexerService, {
+  add: () => Effect.die("not implemented"),
+  list: () => Effect.die("not implemented"),
+  getById: () => Effect.die("not implemented"),
+  update: () => Effect.die("not implemented"),
+  remove: () => Effect.die("not implemented"),
+  testConnection: () => Effect.die("not implemented"),
+  search: (q: SearchQuery): Effect.Effect<SearchResult> => {
+    if (q.type === "tv" && q.episode === undefined) {
+      return Effect.succeed({ releases: [packCandidate], errors: [] })
+    }
+    if (q.type === "tv" && q.episode === 1) {
+      return Effect.succeed({ releases: [episodeCandidate], errors: [] })
+    }
+    if (q.type === "tv" && q.episode === 2) {
+      return Effect.succeed({ releases: [episodeCandidate2], errors: [] })
+    }
+    return Effect.succeed({ releases: [], errors: [] })
+  },
+  listTypes: () => [],
+})
+
+const MockTvIndexerEpisodesOnly = Layer.succeed(IndexerService, {
+  add: () => Effect.die("not implemented"),
+  list: () => Effect.die("not implemented"),
+  getById: () => Effect.die("not implemented"),
+  update: () => Effect.die("not implemented"),
+  remove: () => Effect.die("not implemented"),
+  testConnection: () => Effect.die("not implemented"),
+  search: (q: SearchQuery): Effect.Effect<SearchResult> => {
+    if (q.type === "tv" && q.episode === 1) {
+      return Effect.succeed({ releases: [episodeCandidate], errors: [] })
+    }
+    if (q.type === "tv" && q.episode === 2) {
+      return Effect.succeed({ releases: [episodeCandidate2], errors: [] })
+    }
+    return Effect.succeed({ releases: [], errors: [] })
+  },
+  listTypes: () => [],
+})
+
+// ── TV mock policy engine: returns parsed titles based on candidate title ──
+
+const parsedByTitle = new Map<string, ParsedTitle>([
+  [packCandidate.title, packParsed],
+  [episodeCandidate.title, ep1Parsed],
+  [episodeCandidate2.title, ep2Parsed],
+])
+
+const MockTvPolicyEngine = Layer.succeed(ReleasePolicyEngine, {
+  evaluate: (candidates) =>
+    Effect.succeed(
+      candidates.map(
+        (c): RankedDecision => ({
+          candidate: c,
+          parsed: parsedByTitle.get(c.title) ?? null,
+          qualityRank: 10,
+          formatScore: 100,
+          decision: "accepted",
+          reasons: [{ stage: "rank", rule: "accepted", detail: "mock" }],
+        }),
+      ),
+    ),
+  recordDecisions: () => Effect.void,
+  history: () => Effect.succeed([]),
+})
+
+// ── TV mock download client that inserts queue rows (needed to verify link columns) ──
+
+const InsertingDownloadClientService = Layer.effect(
+  DownloadClientService,
+  Effect.gen(function* () {
+    const db = yield* Db
+    let counter = 0
+    return {
+      add: () => Effect.die("not implemented"),
+      list: () =>
+        Effect.succeed([
+          {
+            id: 1,
+            name: "test-qbit",
+            type: "qbittorrent",
+            host: "localhost",
+            port: 8080,
+            username: "admin",
+            useSsl: false,
+            category: null,
+            priority: 50,
+            enabled: true,
+            settings: { pollIntervalMs: 5000 },
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            health: null,
+          },
+        ]),
+      getById: () => Effect.die("not implemented"),
+      update: () => Effect.die("not implemented"),
+      remove: () => Effect.die("not implemented"),
+      testConnection: () => Effect.die("not implemented"),
+      addDownload: () =>
+        Effect.gen(function* () {
+          counter += 1
+          const hash = `hash_${counter}`
+          yield* db
+            .insert(downloadClients)
+            .values({
+              id: 1,
+              name: "test-qbit",
+              type: "qbittorrent",
+              host: "localhost",
+              port: 8080,
+              username: "admin",
+              passwordEncrypted: "x",
+              useSsl: false,
+              priority: 50,
+              enabled: true,
+              settings: { pollIntervalMs: 5000 },
+            })
+            .onConflictDoNothing()
+          yield* db.insert(downloadQueue).values({
+            downloadClientId: 1,
+            externalId: hash,
+            status: "queued",
+            title: "pending",
+            sizeBytes: 0,
+            progress: 0,
+          })
+          return hash
+        }),
+      getQueue: () => Effect.die("not implemented"),
+      removeDownload: () => Effect.die("not implemented"),
+      listTypes: () => [],
+    }
+  }),
+)
+
+// ── TV test layers ──
+
+const TvPackLayer = AcquisitionPipelineLive.pipe(
+  Layer.provideMerge(
+    Layer.mergeAll(
+      InsertingDownloadClientService,
+      MockTvPolicyEngine,
+      MockTvIndexerWithPack,
+      MovieServiceLive,
+      SeriesServiceLive,
+      AdapterRegistryLive,
+    ).pipe(Layer.provideMerge(TestDbLive)),
+  ),
+)
+
+const TvEpisodeOnlyLayer = AcquisitionPipelineLive.pipe(
+  Layer.provideMerge(
+    Layer.mergeAll(
+      InsertingDownloadClientService,
+      MockTvPolicyEngine,
+      MockTvIndexerEpisodesOnly,
+      MovieServiceLive,
+      SeriesServiceLive,
+      AdapterRegistryLive,
+    ).pipe(Layer.provideMerge(TestDbLive)),
+  ),
+)
+
+// ── TV helpers ──
+
+function addTestSeries(opts: {
+  profileId: number | null
+  monitored?: boolean
+  seasonMonitored?: boolean
+  epMonitored?: boolean
+  epCount?: number
+}) {
+  return Effect.gen(function* () {
+    if (opts.profileId !== null) {
+      const db = yield* Db
+      yield* db.insert(qualityProfiles).values({ name: "test-profile" })
+    }
+    const svc = yield* SeriesService
+    const epCount = opts.epCount ?? 2
+    const eps = Array.from({ length: epCount }, (_, i) => ({
+      tvdbId: 10_000 + i + 1,
+      title: `Episode ${i + 1}`,
+      episodeNumber: i + 1,
+      monitored: opts.epMonitored ?? true,
+    }))
+    return yield* svc.add({
+      tvdbId: 500,
+      title: "Test Show",
+      qualityProfileId: opts.profileId,
+      monitored: opts.monitored ?? true,
+      seasons: [
+        {
+          seasonNumber: 1,
+          monitored: opts.seasonMonitored ?? true,
+          episodes: eps,
+        },
+      ],
+    })
+  })
+}
+
+// ── TV tests ──
+
+describe("AcquisitionPipeline TV", () => {
+  it.effect("searchAndGrabEpisode grabs best per-episode release", () =>
+    Effect.gen(function* () {
+      const series = yield* addTestSeries({ profileId: 1 })
+      const epId = series.seasons[0].episodes[0].id
+      const pipeline = yield* AcquisitionPipeline
+      const result = yield* pipeline.searchAndGrabEpisode(epId)
+      if (result === null) throw new Error("expected grab result, got null")
+      expect(result.candidateTitle).toBe(episodeCandidate.title)
+
+      const db = yield* Db
+      const rows = yield* db
+        .select()
+        .from(downloadQueue)
+        .where(eq(downloadQueue.externalId, result.hash))
+      expect(rows).toHaveLength(1)
+      expect(rows[0].seriesId).toBe(series.series.id)
+      expect(rows[0].episodeIds).toEqual([epId])
+    }).pipe(Effect.provide(TvPackLayer)),
+  )
+
+  it.effect("searchAndGrabEpisode returns null when no releases", () =>
+    Effect.gen(function* () {
+      // Mock only returns for episodes 1 and 2 — seed episode 3 to hit empty path
+      const db = yield* Db
+      yield* db.insert(qualityProfiles).values({ name: "test-profile" })
+      const svc = yield* SeriesService
+      const s = yield* svc.add({
+        tvdbId: 501,
+        title: "Other Show",
+        qualityProfileId: 1,
+        monitored: true,
+        seasons: [
+          {
+            seasonNumber: 1,
+            monitored: true,
+            episodes: [{ tvdbId: 99_003, title: "Ep3", episodeNumber: 3, monitored: true }],
+          },
+        ],
+      })
+      const pipeline = yield* AcquisitionPipeline
+      const result = yield* pipeline.searchAndGrabEpisode(s.seasons[0].episodes[0].id)
+      expect(result).toBeNull()
+    }).pipe(Effect.provide(TvEpisodeOnlyLayer)),
+  )
+
+  it.effect("searchAndGrabEpisode fails for unmonitored episode", () =>
+    Effect.gen(function* () {
+      const series = yield* addTestSeries({ profileId: 1, epMonitored: false })
+      const epId = series.seasons[0].episodes[0].id
+      const pipeline = yield* AcquisitionPipeline
+      const error = yield* Effect.flip(pipeline.searchAndGrabEpisode(epId))
+      expect(error._tag).toBe("AcquisitionError")
+    }).pipe(Effect.provide(TvPackLayer)),
+  )
+
+  it.effect("searchAndGrabEpisode fails when series has no quality profile", () =>
+    Effect.gen(function* () {
+      const series = yield* addTestSeries({ profileId: null })
+      const epId = series.seasons[0].episodes[0].id
+      const pipeline = yield* AcquisitionPipeline
+      const error = yield* Effect.flip(pipeline.searchAndGrabEpisode(epId))
+      expect(error._tag).toBe("AcquisitionError")
+    }).pipe(Effect.provide(TvPackLayer)),
+  )
+
+  it.effect("searchAndGrabSeason prefers season pack when available", () =>
+    Effect.gen(function* () {
+      const series = yield* addTestSeries({ profileId: 1, epCount: 2 })
+      const seasonId = series.seasons[0].season.id
+      const pipeline = yield* AcquisitionPipeline
+      const results = yield* pipeline.searchAndGrabSeason(seasonId)
+
+      // Pack-first → 1 grab result covering all wanted episodes
+      expect(results).toHaveLength(1)
+      expect(results[0].candidateTitle).toBe(packCandidate.title)
+
+      // downloadQueue row should contain both episode ids
+      const db = yield* Db
+      const rows = yield* db.select().from(downloadQueue)
+      expect(rows).toHaveLength(1)
+      expect(rows[0].seriesId).toBe(series.series.id)
+      const epIds = series.seasons[0].episodes.map((e) => e.id).toSorted()
+      expect((rows[0].episodeIds ?? []).toSorted()).toEqual(epIds)
+    }).pipe(Effect.provide(TvPackLayer)),
+  )
+
+  it.effect("searchAndGrabSeason falls back to per-episode when no pack", () =>
+    Effect.gen(function* () {
+      const series = yield* addTestSeries({ profileId: 1, epCount: 2 })
+      const seasonId = series.seasons[0].season.id
+      const pipeline = yield* AcquisitionPipeline
+      const results = yield* pipeline.searchAndGrabSeason(seasonId)
+
+      // Per-episode → 2 grab results
+      expect(results).toHaveLength(2)
+      const titles = results.map((r) => r.candidateTitle).toSorted()
+      expect(titles).toEqual([episodeCandidate.title, episodeCandidate2.title].toSorted())
+    }).pipe(Effect.provide(TvEpisodeOnlyLayer)),
+  )
+
+  it.effect("searchAndGrabSeason returns empty when no wanted episodes", () =>
+    Effect.gen(function* () {
+      const series = yield* addTestSeries({ profileId: 1, epMonitored: false })
+      const seasonId = series.seasons[0].season.id
+      const pipeline = yield* AcquisitionPipeline
+      const results = yield* pipeline.searchAndGrabSeason(seasonId)
+      expect(results).toHaveLength(0)
+    }).pipe(Effect.provide(TvPackLayer)),
+  )
+
+  it.effect("searchAndGrabSeason fails for unmonitored season", () =>
+    Effect.gen(function* () {
+      const series = yield* addTestSeries({ profileId: 1, seasonMonitored: false })
+      const seasonId = series.seasons[0].season.id
+      const pipeline = yield* AcquisitionPipeline
+      const error = yield* Effect.flip(pipeline.searchAndGrabSeason(seasonId))
+      expect(error._tag).toBe("AcquisitionError")
+      if (error._tag === "AcquisitionError") {
+        expect(error.mediaKind).toBe("season")
+      }
+    }).pipe(Effect.provide(TvPackLayer)),
+  )
+
+  it.effect("searchAndGrabSeries iterates monitored seasons", () =>
+    Effect.gen(function* () {
+      const series = yield* addTestSeries({ profileId: 1, epCount: 2 })
+      const pipeline = yield* AcquisitionPipeline
+      const results = yield* pipeline.searchAndGrabSeries(series.series.id)
+      // Pack-first across 1 season → 1 grab
+      expect(results).toHaveLength(1)
+      expect(results[0].candidateTitle).toBe(packCandidate.title)
+    }).pipe(Effect.provide(TvPackLayer)),
+  )
+
+  it.effect("searchAndGrabSeries fails for unmonitored series", () =>
+    Effect.gen(function* () {
+      const series = yield* addTestSeries({ profileId: 1, monitored: false })
+      const pipeline = yield* AcquisitionPipeline
+      const error = yield* Effect.flip(pipeline.searchAndGrabSeries(series.series.id))
+      expect(error._tag).toBe("AcquisitionError")
+      if (error._tag === "AcquisitionError") {
+        expect(error.mediaKind).toBe("series")
+      }
+    }).pipe(Effect.provide(TvPackLayer)),
+  )
+
+  it.effect("grabEpisode links queue to series and episode", () =>
+    Effect.gen(function* () {
+      const series = yield* addTestSeries({ profileId: 1 })
+      const epId = series.seasons[0].episodes[0].id
+      const pipeline = yield* AcquisitionPipeline
+      const result = yield* pipeline.grabEpisode(epId, "magnet:?xt=test", "Custom.Release.Title")
+      expect(result.candidateTitle).toBe("Custom.Release.Title")
+
+      const db = yield* Db
+      const rows = yield* db.select().from(downloadQueue)
+      expect(rows).toHaveLength(1)
+      expect(rows[0].seriesId).toBe(series.series.id)
+      expect(rows[0].episodeIds).toEqual([epId])
+    }).pipe(Effect.provide(TvPackLayer)),
   )
 })

--- a/src/effect/services/AcquisitionPipeline.ts
+++ b/src/effect/services/AcquisitionPipeline.ts
@@ -2,16 +2,22 @@ import { SqlError } from "@effect/sql/SqlError"
 import { eq } from "drizzle-orm"
 import { Context, Effect, Layer } from "effect"
 
-import { downloadQueue } from "#/db/schema"
+import { downloadQueue, episodes as episodesTable, seasons as seasonsTable } from "#/db/schema"
 import type { IndexerProtocol } from "#/effect/domain/indexer"
 import { parseQualityName } from "#/effect/domain/quality"
-import type { ExistingFile, RankedDecision } from "#/effect/domain/release"
+import {
+  type EvaluationContext,
+  type ExistingFile,
+  type ParsedTitle,
+  type RankedDecision,
+  isSeasonPack,
+} from "#/effect/domain/release"
 import {
   AcquisitionError,
   type DownloadClientError,
   type EncryptionError,
   type IndexerError,
-  type NotFoundError,
+  NotFoundError,
   type ParseFailed,
   ValidationError,
 } from "#/effect/errors"
@@ -22,6 +28,7 @@ import { DownloadClientService } from "./DownloadClientService"
 import { IndexerService } from "./IndexerService"
 import { MovieService } from "./MovieService"
 import { ReleasePolicyEngine } from "./ReleasePolicyEngine"
+import { SeriesService } from "./SeriesService"
 
 // ── Result types ──
 
@@ -29,6 +36,13 @@ export interface GrabResult {
   readonly hash: string
   readonly candidateTitle: string
 }
+
+/** Episodes in a season that still need a file (monitored + no hasFile). */
+const wantedEpisodes = (eps: ReadonlyArray<typeof episodesTable.$inferSelect>) =>
+  eps.filter((e) => e.monitored && !e.hasFile)
+
+/** Build indexer search term from a series title. Identity for now — override later if needed. */
+const searchTermForSeries = (title: string) => title
 
 type PipelineError =
   | AcquisitionError
@@ -57,6 +71,31 @@ export class AcquisitionPipeline extends Context.Tag("@arr-hub/AcquisitionPipeli
       downloadUrl: string,
       candidateTitle: string,
     ) => Effect.Effect<GrabResult, PipelineError>
+
+    // ── TV ──
+
+    /** Search + evaluate + grab best release for a single episode. */
+    readonly searchAndGrabEpisode: (
+      episodeId: number,
+    ) => Effect.Effect<GrabResult | null, PipelineError>
+    /** Search + evaluate only for an episode (interactive UI). */
+    readonly searchAndEvaluateEpisode: (
+      episodeId: number,
+    ) => Effect.Effect<ReadonlyArray<RankedDecision>, PipelineError>
+    /** Grab a specific release URL for an episode. */
+    readonly grabEpisode: (
+      episodeId: number,
+      downloadUrl: string,
+      candidateTitle: string,
+    ) => Effect.Effect<GrabResult, PipelineError>
+    /** Search a season — pack-first, falls back to per-episode if no pack accepted. */
+    readonly searchAndGrabSeason: (
+      seasonId: number,
+    ) => Effect.Effect<ReadonlyArray<GrabResult>, PipelineError>
+    /** Iterate all seasons with wanted episodes. */
+    readonly searchAndGrabSeries: (
+      seriesId: number,
+    ) => Effect.Effect<ReadonlyArray<GrabResult>, PipelineError>
   }
 >() {}
 
@@ -67,6 +106,7 @@ export const AcquisitionPipelineLive = Layer.effect(
   Effect.gen(function* () {
     const db = yield* Db
     const movieService = yield* MovieService
+    const seriesService = yield* SeriesService
     const indexerService = yield* IndexerService
     const policyEngine = yield* ReleasePolicyEngine
     const downloadClientService = yield* DownloadClientService
@@ -109,7 +149,8 @@ export const AcquisitionPipelineLive = Layer.effect(
 
         if (!movie.monitored) {
           return yield* new AcquisitionError({
-            movieId,
+            mediaKind: "movie",
+            mediaId: movieId,
             stage: "search",
             message: "movie not monitored",
           })
@@ -117,7 +158,8 @@ export const AcquisitionPipelineLive = Layer.effect(
 
         if (movie.qualityProfileId === null) {
           return yield* new AcquisitionError({
-            movieId,
+            mediaKind: "movie",
+            mediaId: movieId,
             stage: "search",
             message: "no quality profile assigned",
           })
@@ -130,29 +172,249 @@ export const AcquisitionPipelineLive = Layer.effect(
     const linkQueueToMovie = (hash: string, movieId: number) =>
       db.update(downloadQueue).set({ movieId }).where(eq(downloadQueue.externalId, hash))
 
-    /** Parse existing file info from movie row, validating quality name at boundary. */
-    const existingFileFromMovie = (movie: {
+    /** Link queue row to series + episodes (individual or season pack). */
+    const linkQueueToTv = (hash: string, seriesId: number, episodeIds: ReadonlyArray<number>) =>
+      db
+        .update(downloadQueue)
+        .set({ seriesId, episodeIds })
+        .where(eq(downloadQueue.externalId, hash))
+
+    /** Parse existing file columns into domain ExistingFile, validating quality at boundary. */
+    const existingFileFromRow = (row: {
       hasFile: boolean
       existingQualityName: string | null
       existingQualityRank: number | null
       existingFormatScore: number | null
     }): ExistingFile | undefined => {
-      if (
-        !movie.hasFile ||
-        movie.existingQualityName === null ||
-        movie.existingQualityRank === null
-      )
+      if (!row.hasFile || row.existingQualityName === null || row.existingQualityRank === null)
         return undefined
-      const qualityName = parseQualityName(movie.existingQualityName)
+      const qualityName = parseQualityName(row.existingQualityName)
       if (!qualityName) return undefined
       return {
         qualityName,
-        qualityRank: movie.existingQualityRank,
-        formatScore: movie.existingFormatScore ?? 0,
+        qualityRank: row.existingQualityRank,
+        formatScore: row.existingFormatScore ?? 0,
       }
     }
 
+    /** Load episode + its season + series, guarded for monitored + profile. */
+    const loadEpisodeContext = (episodeId: number) =>
+      Effect.gen(function* () {
+        const epRows = yield* db.select().from(episodesTable).where(eq(episodesTable.id, episodeId))
+        const episode = epRows[0]
+        if (!episode) return yield* new NotFoundError({ entity: "episode", id: episodeId })
+
+        const seasonRows = yield* db
+          .select()
+          .from(seasonsTable)
+          .where(eq(seasonsTable.id, episode.seasonId))
+        const season = seasonRows[0]
+        if (!season) return yield* new NotFoundError({ entity: "season", id: episode.seasonId })
+
+        const seriesDetails = yield* seriesService.getById(season.seriesId)
+        const s = seriesDetails.series
+
+        if (!s.monitored) {
+          return yield* new AcquisitionError({
+            mediaKind: "episode",
+            mediaId: episodeId,
+            stage: "search",
+            message: "series not monitored",
+          })
+        }
+        if (!season.monitored) {
+          return yield* new AcquisitionError({
+            mediaKind: "episode",
+            mediaId: episodeId,
+            stage: "search",
+            message: "season not monitored",
+          })
+        }
+        if (!episode.monitored) {
+          return yield* new AcquisitionError({
+            mediaKind: "episode",
+            mediaId: episodeId,
+            stage: "search",
+            message: "episode not monitored",
+          })
+        }
+        if (s.qualityProfileId === null) {
+          return yield* new AcquisitionError({
+            mediaKind: "episode",
+            mediaId: episodeId,
+            stage: "search",
+            message: "no quality profile assigned",
+          })
+        }
+
+        return {
+          episode,
+          season,
+          series: s,
+          qualityProfileId: s.qualityProfileId,
+        }
+      })
+
+    /** Load season + series + all episodes for that season; guard monitored + profile. */
+    const loadSeasonContext = (seasonId: number) =>
+      Effect.gen(function* () {
+        const seasonRows = yield* db
+          .select()
+          .from(seasonsTable)
+          .where(eq(seasonsTable.id, seasonId))
+        const season = seasonRows[0]
+        if (!season) return yield* new NotFoundError({ entity: "season", id: seasonId })
+
+        const seriesDetails = yield* seriesService.getById(season.seriesId)
+        const s = seriesDetails.series
+
+        if (!s.monitored) {
+          return yield* new AcquisitionError({
+            mediaKind: "season",
+            mediaId: seasonId,
+            stage: "search",
+            message: "series not monitored",
+          })
+        }
+        if (!season.monitored) {
+          return yield* new AcquisitionError({
+            mediaKind: "season",
+            mediaId: seasonId,
+            stage: "search",
+            message: "season not monitored",
+          })
+        }
+        if (s.qualityProfileId === null) {
+          return yield* new AcquisitionError({
+            mediaKind: "season",
+            mediaId: seasonId,
+            stage: "search",
+            message: "no quality profile assigned",
+          })
+        }
+
+        const eps = yield* db
+          .select()
+          .from(episodesTable)
+          .where(eq(episodesTable.seasonId, seasonId))
+
+        return {
+          season,
+          series: s,
+          qualityProfileId: s.qualityProfileId,
+          episodes: eps,
+        }
+      })
+
+    /**
+     * Composable step: given a best decision for a season search, map its parsed title to
+     * the concrete set of episodes the pack covers (all wanted eps in the season).
+     * For non-pack candidates, returns just the single episode matching parsed.episode.
+     */
+    const mapCandidateToEpisodes = (
+      parsed: ParsedTitle | null,
+      seasonEps: ReadonlyArray<typeof episodesTable.$inferSelect>,
+    ): ReadonlyArray<number> => {
+      if (parsed && isSeasonPack(parsed)) {
+        return wantedEpisodes(seasonEps).map((e) => e.id)
+      }
+      if (parsed && parsed.episode !== null) {
+        const match = seasonEps.find((e) => e.episodeNumber === parsed.episode)
+        return match ? [match.id] : []
+      }
+      return []
+    }
+
+    const grabSeason = (
+      seasonId: number,
+    ): Effect.Effect<ReadonlyArray<GrabResult>, PipelineError> =>
+      Effect.gen(function* () {
+        const ctx = yield* loadSeasonContext(seasonId)
+        const wanted = wantedEpisodes(ctx.episodes)
+        if (wanted.length === 0) return []
+
+        const { releases: packReleases } = yield* indexerService.search({
+          type: "tv",
+          term: searchTermForSeries(ctx.series.title),
+          tvdbId: ctx.series.tvdbId,
+          season: ctx.season.seasonNumber,
+        })
+
+        if (packReleases.length > 0) {
+          const packEvalCtx: EvaluationContext = {
+            mediaId: ctx.season.id,
+            mediaType: "season",
+          }
+
+          const packDecisions = yield* policyEngine.evaluate(
+            packReleases,
+            ctx.qualityProfileId,
+            packEvalCtx,
+          )
+          yield* policyEngine.recordDecisions(packDecisions, packEvalCtx)
+
+          const packBest = packDecisions.find(
+            (d) =>
+              (d.decision === "accepted" || d.decision === "upgrade") &&
+              d.parsed !== null &&
+              isSeasonPack(d.parsed) &&
+              d.parsed.season === ctx.season.seasonNumber,
+          )
+
+          if (packBest) {
+            const client = yield* pickClient(packBest.candidate.protocol)
+            const hash = yield* downloadClientService.addDownload(
+              client.id,
+              packBest.candidate.downloadUrl,
+            )
+
+            const coveredEpisodeIds = mapCandidateToEpisodes(packBest.parsed, ctx.episodes)
+            yield* linkQueueToTv(hash, ctx.series.id, coveredEpisodeIds)
+
+            return [{ hash, candidateTitle: packBest.candidate.title }]
+          }
+        }
+
+        const results: Array<GrabResult> = []
+        for (const ep of wanted) {
+          const { releases } = yield* indexerService.search({
+            type: "tv",
+            term: searchTermForSeries(ctx.series.title),
+            tvdbId: ctx.series.tvdbId,
+            season: ctx.season.seasonNumber,
+            episode: ep.episodeNumber,
+          })
+
+          if (releases.length === 0) continue
+
+          const evalCtx: EvaluationContext = {
+            mediaId: ep.id,
+            mediaType: "episode",
+            existingFile: existingFileFromRow(ep),
+          }
+
+          const decisions = yield* policyEngine.evaluate(releases, ctx.qualityProfileId, evalCtx)
+          yield* policyEngine.recordDecisions(decisions, evalCtx)
+
+          const best = decisions.find((d) => d.decision === "accepted" || d.decision === "upgrade")
+          if (!best) continue
+
+          const client = yield* pickClient(best.candidate.protocol)
+          const hash = yield* downloadClientService.addDownload(
+            client.id,
+            best.candidate.downloadUrl,
+          )
+          yield* linkQueueToTv(hash, ctx.series.id, [ep.id])
+
+          results.push({ hash, candidateTitle: best.candidate.title })
+        }
+
+        return results
+      })
+
     return {
+      // ── Movies ──
+
       searchAndGrab: (movieId) =>
         Effect.gen(function* () {
           const movie = yield* loadMovie(movieId)
@@ -170,7 +432,7 @@ export const AcquisitionPipelineLive = Layer.effect(
           const decisions = yield* policyEngine.evaluate(releases, movie.qualityProfileId, {
             mediaId: movie.id,
             mediaType: "movie",
-            existingFile: existingFileFromMovie(movie),
+            existingFile: existingFileFromRow(movie),
           })
 
           // Record decisions
@@ -211,7 +473,7 @@ export const AcquisitionPipelineLive = Layer.effect(
           const decisions = yield* policyEngine.evaluate(releases, movie.qualityProfileId, {
             mediaId: movie.id,
             mediaType: "movie",
-            existingFile: existingFileFromMovie(movie),
+            existingFile: existingFileFromRow(movie),
           })
 
           yield* policyEngine.recordDecisions(decisions, {
@@ -233,6 +495,125 @@ export const AcquisitionPipelineLive = Layer.effect(
           yield* linkQueueToMovie(hash, movie.id)
 
           return { hash, candidateTitle }
+        }),
+
+      // ── TV: single episode ──
+
+      searchAndGrabEpisode: (episodeId) =>
+        Effect.gen(function* () {
+          const ctx = yield* loadEpisodeContext(episodeId)
+
+          const { releases } = yield* indexerService.search({
+            type: "tv",
+            term: searchTermForSeries(ctx.series.title),
+            tvdbId: ctx.series.tvdbId,
+            season: ctx.season.seasonNumber,
+            episode: ctx.episode.episodeNumber,
+          })
+
+          if (releases.length === 0) return null
+
+          const evalCtx: EvaluationContext = {
+            mediaId: ctx.episode.id,
+            mediaType: "episode",
+            existingFile: existingFileFromRow(ctx.episode),
+          }
+
+          const decisions = yield* policyEngine.evaluate(releases, ctx.qualityProfileId, evalCtx)
+
+          yield* policyEngine.recordDecisions(decisions, evalCtx)
+
+          const best = decisions.find((d) => d.decision === "accepted" || d.decision === "upgrade")
+          if (!best) return null
+
+          const client = yield* pickClient(best.candidate.protocol)
+          const hash = yield* downloadClientService.addDownload(
+            client.id,
+            best.candidate.downloadUrl,
+          )
+
+          yield* linkQueueToTv(hash, ctx.series.id, [ctx.episode.id])
+
+          return { hash, candidateTitle: best.candidate.title }
+        }),
+
+      searchAndEvaluateEpisode: (episodeId) =>
+        Effect.gen(function* () {
+          const ctx = yield* loadEpisodeContext(episodeId)
+
+          const { releases } = yield* indexerService.search({
+            type: "tv",
+            term: searchTermForSeries(ctx.series.title),
+            tvdbId: ctx.series.tvdbId,
+            season: ctx.season.seasonNumber,
+            episode: ctx.episode.episodeNumber,
+          })
+
+          const evalCtx: EvaluationContext = {
+            mediaId: ctx.episode.id,
+            mediaType: "episode",
+            existingFile: existingFileFromRow(ctx.episode),
+          }
+
+          const decisions = yield* policyEngine.evaluate(releases, ctx.qualityProfileId, evalCtx)
+          yield* policyEngine.recordDecisions(decisions, evalCtx)
+          return decisions
+        }),
+
+      grabEpisode: (episodeId, downloadUrl, candidateTitle) =>
+        Effect.gen(function* () {
+          const ctx = yield* loadEpisodeContext(episodeId)
+          const client = yield* pickClient()
+          const hash = yield* downloadClientService.addDownload(client.id, downloadUrl)
+          yield* linkQueueToTv(hash, ctx.series.id, [ctx.episode.id])
+          return { hash, candidateTitle }
+        }),
+
+      // ── TV: season ──
+
+      searchAndGrabSeason: grabSeason,
+
+      // ── TV: series ──
+
+      searchAndGrabSeries: (seriesId) =>
+        Effect.gen(function* () {
+          const details = yield* seriesService.getById(seriesId)
+          const s = details.series
+          if (!s.monitored) {
+            return yield* new AcquisitionError({
+              mediaKind: "series",
+              mediaId: seriesId,
+              stage: "search",
+              message: "series not monitored",
+            })
+          }
+          if (s.qualityProfileId === null) {
+            return yield* new AcquisitionError({
+              mediaKind: "series",
+              mediaId: seriesId,
+              stage: "search",
+              message: "no quality profile assigned",
+            })
+          }
+
+          const results: Array<GrabResult> = []
+          for (const sWithEps of details.seasons) {
+            const seasonRow = sWithEps.season
+            if (!seasonRow.monitored) continue
+            const wanted = wantedEpisodes(sWithEps.episodes)
+            if (wanted.length === 0) continue
+
+            const seasonResults = yield* grabSeason(seasonRow.id).pipe(
+              Effect.catchAll((err) =>
+                Effect.logWarning(
+                  `searchAndGrabSeries: season ${seasonRow.id} failed: ${JSON.stringify(err)}`,
+                ).pipe(Effect.as<ReadonlyArray<GrabResult>>([])),
+              ),
+            )
+            results.push(...seasonResults)
+          }
+
+          return results
         }),
     }
   }),

--- a/src/effect/services/DownloadMonitor.test.ts
+++ b/src/effect/services/DownloadMonitor.test.ts
@@ -1,7 +1,19 @@
 import { describe, expect, it } from "@effect/vitest"
-import { Effect, Layer } from "effect"
+import { eq } from "drizzle-orm"
+import { Effect, Layer, Ref } from "effect"
 
-import { downloadClients, downloadQueue, movies, qualityProfiles } from "#/db/schema"
+import {
+  downloadClients,
+  downloadQueue,
+  episodes,
+  mediaServerLibraries,
+  mediaServers,
+  movies,
+  qualityProfiles,
+  releaseDecisions,
+  seasons,
+  series,
+} from "#/db/schema"
 import { Db } from "#/effect/services/Db"
 import { TestDbLive } from "#/effect/test/TestDb"
 
@@ -148,5 +160,231 @@ describe("DownloadMonitor", () => {
       const completions = yield* monitor.checkCompletions()
       expect(completions).toHaveLength(0)
     }).pipe(Effect.provide(TestLayer)),
+  )
+})
+
+// ── TV completion tests ──
+
+interface RefreshCall {
+  readonly serverId: number
+  readonly libraryId: string
+}
+
+const makeTrackingMediaServer = (ref: Ref.Ref<ReadonlyArray<RefreshCall>>) =>
+  Layer.succeed(MediaServerService, {
+    add: () => Effect.die("not implemented"),
+    list: () => Effect.succeed([]),
+    getById: () => Effect.die("not implemented"),
+    update: () => Effect.die("not implemented"),
+    remove: () => Effect.die("not implemented"),
+    testConnection: () => Effect.die("not implemented"),
+    getLibraries: () => Effect.die("not implemented"),
+    syncLibrary: () => Effect.die("not implemented"),
+    refreshLibrary: (serverId, libraryId) =>
+      Ref.update(ref, (calls) => [...calls, { serverId, libraryId }]),
+    listTypes: () => [],
+  })
+
+function seedTvData() {
+  return Effect.gen(function* () {
+    const db = yield* Db
+
+    yield* db.insert(qualityProfiles).values({ name: "test-profile" })
+
+    yield* db.insert(downloadClients).values({
+      name: "test-qbit",
+      type: "qbittorrent",
+      host: "localhost",
+      port: 8080,
+      username: "admin",
+      passwordEncrypted: "encrypted",
+    })
+
+    yield* db.insert(series).values({
+      tvdbId: 100,
+      title: "Test Show",
+      status: "wanted",
+      monitored: true,
+      qualityProfileId: 1,
+    })
+
+    yield* db.insert(seasons).values({ seriesId: 1, seasonNumber: 1, monitored: true })
+
+    yield* db.insert(episodes).values([
+      { seasonId: 1, tvdbId: 1001, title: "Ep1", episodeNumber: 1, monitored: true },
+      { seasonId: 1, tvdbId: 1002, title: "Ep2", episodeNumber: 2, monitored: true },
+    ])
+
+    return { seriesId: 1, episodeIds: [1, 2] as const }
+  })
+}
+
+describe("DownloadMonitor TV", () => {
+  it.effect("applies episode completion: sets hasFile + quality, deletes queue row", () =>
+    Effect.gen(function* () {
+      const { seriesId, episodeIds } = yield* seedTvData()
+      const db = yield* Db
+
+      // Pre-record a decision so applyEpisodeCompletion can backfill quality
+      yield* db.insert(releaseDecisions).values({
+        mediaId: episodeIds[0],
+        mediaType: "episode",
+        candidateTitle: "Test.Show.S01E01.1080p.WEB-DL-GRP",
+        qualityRank: 15,
+        formatScore: 200,
+        decision: "accepted",
+      })
+
+      yield* db.insert(downloadQueue).values({
+        downloadClientId: 1,
+        seriesId,
+        episodeIds: [episodeIds[0]],
+        externalId: "tv_hash_1",
+        status: "completed",
+        title: "Test.Show.S01E01.1080p.WEB-DL-GRP",
+        sizeBytes: 1_500_000_000,
+        progress: 1.0,
+      })
+
+      const monitor = yield* DownloadMonitor
+      const completions = yield* monitor.checkCompletions()
+
+      expect(completions).toHaveLength(1)
+      expect(completions[0].movieId).toBeNull()
+      expect(completions[0].seriesId).toBe(seriesId)
+      expect(completions[0].episodeIds).toEqual([episodeIds[0]])
+
+      const epRows = yield* db.select().from(episodes).where(eq(episodes.id, episodeIds[0]))
+      expect(epRows[0].hasFile).toBe(true)
+      expect(epRows[0].existingQualityRank).toBe(15)
+      expect(epRows[0].existingFormatScore).toBe(200)
+
+      const queueRows = yield* db.select().from(downloadQueue)
+      expect(queueRows).toHaveLength(0)
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.effect("applies season-pack completion across all episode ids", () =>
+    Effect.gen(function* () {
+      const { seriesId, episodeIds } = yield* seedTvData()
+      const db = yield* Db
+
+      yield* db.insert(releaseDecisions).values({
+        mediaId: 1, // season id
+        mediaType: "season",
+        candidateTitle: "Test.Show.S01.1080p.BluRay-GRP",
+        qualityRank: 20,
+        formatScore: 300,
+        decision: "accepted",
+      })
+
+      yield* db.insert(downloadQueue).values({
+        downloadClientId: 1,
+        seriesId,
+        episodeIds: [...episodeIds],
+        externalId: "tv_hash_pack",
+        status: "completed",
+        title: "Test.Show.S01.1080p.BluRay-GRP",
+        sizeBytes: 8_000_000_000,
+        progress: 1.0,
+      })
+
+      const monitor = yield* DownloadMonitor
+      const completions = yield* monitor.checkCompletions()
+
+      expect(completions).toHaveLength(1)
+      expect(completions[0].episodeIds).toEqual([...episodeIds])
+
+      const epRows = yield* db.select().from(episodes)
+      for (const row of epRows) {
+        expect(row.hasFile).toBe(true)
+        expect(row.existingQualityRank).toBe(20)
+        expect(row.existingFormatScore).toBe(300)
+      }
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.effect("ignores queue rows with seriesId but empty episodeIds", () =>
+    Effect.gen(function* () {
+      const { seriesId } = yield* seedTvData()
+      const db = yield* Db
+
+      yield* db.insert(downloadQueue).values({
+        downloadClientId: 1,
+        seriesId,
+        episodeIds: [],
+        externalId: "tv_hash_empty",
+        status: "completed",
+        title: "Orphan",
+        sizeBytes: 0,
+        progress: 1.0,
+      })
+
+      const monitor = yield* DownloadMonitor
+      const completions = yield* monitor.checkCompletions()
+      expect(completions).toHaveLength(0)
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.effect("triggers show library refresh on TV completion", () =>
+    Effect.gen(function* () {
+      const ref = yield* Ref.make<ReadonlyArray<RefreshCall>>([])
+      const TrackingLayer = DownloadMonitorLive.pipe(
+        Layer.provideMerge(
+          Layer.mergeAll(MockDownloadClientService, makeTrackingMediaServer(ref)).pipe(
+            Layer.provideMerge(TestDbLive),
+          ),
+        ),
+      )
+
+      yield* Effect.gen(function* () {
+        const { seriesId, episodeIds } = yield* seedTvData()
+        const db = yield* Db
+
+        yield* db.insert(mediaServers).values({
+          name: "plex",
+          type: "plex",
+          host: "localhost",
+          port: 32400,
+          tokenEncrypted: "x",
+          enabled: true,
+        })
+        yield* db.insert(mediaServerLibraries).values([
+          {
+            mediaServerId: 1,
+            externalId: "show-lib",
+            name: "TV",
+            type: "show",
+            enabled: true,
+          },
+          {
+            mediaServerId: 1,
+            externalId: "movie-lib",
+            name: "Movies",
+            type: "movie",
+            enabled: true,
+          },
+        ])
+
+        yield* db.insert(downloadQueue).values({
+          downloadClientId: 1,
+          seriesId,
+          episodeIds: [episodeIds[0]],
+          externalId: "tv_refresh",
+          status: "completed",
+          title: "Test.Show.S01E01.720p.HDTV-GRP",
+          sizeBytes: 500_000_000,
+          progress: 1.0,
+        })
+
+        const monitor = yield* DownloadMonitor
+        yield* monitor.checkCompletions()
+
+        const calls = yield* Ref.get(ref)
+        // Only show library should refresh (no movie completion happened)
+        expect(calls).toHaveLength(1)
+        expect(calls[0].libraryId).toBe("show-lib")
+      }).pipe(Effect.provide(TrackingLayer))
+    }),
   )
 })

--- a/src/effect/services/DownloadMonitor.ts
+++ b/src/effect/services/DownloadMonitor.ts
@@ -1,14 +1,16 @@
 import { SqlError } from "@effect/sql/SqlError"
-import { and, eq, isNotNull } from "drizzle-orm"
+import { and, eq, inArray, isNotNull, or } from "drizzle-orm"
 import { Context, Effect, Layer } from "effect"
 
 import {
   downloadQueue,
+  episodes,
   movies,
   releaseDecisions,
   mediaServers,
   mediaServerLibraries,
 } from "#/db/schema"
+import type { MediaType } from "#/effect/domain/release"
 import type {
   DownloadClientError,
   EncryptionError,
@@ -24,7 +26,9 @@ import { MediaServerService } from "./MediaServerService"
 // ── Types ──
 
 export interface CompletionResult {
-  readonly movieId: number
+  readonly movieId: number | null
+  readonly seriesId: number | null
+  readonly episodeIds: ReadonlyArray<number>
   readonly externalId: string
 }
 
@@ -35,6 +39,77 @@ type MonitorError =
   | MediaServerError
   | EncryptionError
   | SqlError
+
+// ── Decision lookup helper ──
+
+type DbHandle = Context.Tag.Service<typeof Db>
+
+function decisionFor(db: DbHandle, mediaId: number, mediaType: MediaType, candidateTitle: string) {
+  return Effect.gen(function* () {
+    const rows = yield* db
+      .select({
+        qualityRank: releaseDecisions.qualityRank,
+        formatScore: releaseDecisions.formatScore,
+      })
+      .from(releaseDecisions)
+      .where(
+        and(
+          eq(releaseDecisions.mediaId, mediaId),
+          eq(releaseDecisions.mediaType, mediaType),
+          eq(releaseDecisions.candidateTitle, candidateTitle),
+        ),
+      )
+      .limit(1)
+    return rows[0]
+  })
+}
+
+function applyMovieCompletion(db: DbHandle, movieId: number, candidateTitle: string) {
+  return Effect.gen(function* () {
+    const decision = yield* decisionFor(db, movieId, "movie", candidateTitle)
+    yield* db
+      .update(movies)
+      .set({
+        status: "available",
+        hasFile: true,
+        existingQualityRank: decision?.qualityRank ?? null,
+        existingFormatScore: decision?.formatScore ?? null,
+      })
+      .where(eq(movies.id, movieId))
+  })
+}
+
+function applyEpisodeCompletion(
+  db: DbHandle,
+  episodeIds: ReadonlyArray<number>,
+  candidateTitle: string,
+) {
+  return Effect.gen(function* () {
+    // Decision was recorded either per-episode ("episode" mediaType, any of episodeIds)
+    // or per-season ("season" mediaType). Look up by candidateTitle across both.
+    const anyDecision = yield* db
+      .select({
+        qualityRank: releaseDecisions.qualityRank,
+        formatScore: releaseDecisions.formatScore,
+      })
+      .from(releaseDecisions)
+      .where(eq(releaseDecisions.candidateTitle, candidateTitle))
+      .limit(1)
+    const decision = anyDecision[0]
+
+    for (const episodeId of episodeIds) {
+      yield* db
+        .update(episodes)
+        .set({
+          hasFile: true,
+          existingQualityRank: decision?.qualityRank ?? null,
+          existingFormatScore: decision?.formatScore ?? null,
+          existingQualityName: null,
+        })
+        .where(eq(episodes.id, episodeId))
+    }
+  })
+}
 
 // ── Service tag ──
 
@@ -60,74 +135,71 @@ export const DownloadMonitorLive = Layer.effect(
           // 1. Poll all clients — upserts downloadQueue
           yield* downloadClientService.getQueue()
 
-          // 2. Query completed downloads linked to a movie
+          // 2. Query completed downloads linked to either movie OR series
           const completedRows = yield* db
             .select({
               id: downloadQueue.id,
               movieId: downloadQueue.movieId,
+              seriesId: downloadQueue.seriesId,
+              episodeIds: downloadQueue.episodeIds,
               externalId: downloadQueue.externalId,
               title: downloadQueue.title,
             })
             .from(downloadQueue)
-            .where(and(eq(downloadQueue.status, "completed"), isNotNull(downloadQueue.movieId)))
+            .where(
+              and(
+                eq(downloadQueue.status, "completed"),
+                or(isNotNull(downloadQueue.movieId), isNotNull(downloadQueue.seriesId)),
+              ),
+            )
 
           const completions: Array<CompletionResult> = []
+          let touchedMovie = false
+          let touchedTv = false
 
           for (const row of completedRows) {
-            const movieId = row.movieId
-            if (movieId === null) continue
-
-            // 3. Look up release decision for quality info
-            const decisionRows = yield* db
-              .select({
-                qualityRank: releaseDecisions.qualityRank,
-                formatScore: releaseDecisions.formatScore,
-                candidateTitle: releaseDecisions.candidateTitle,
+            if (row.movieId !== null) {
+              yield* applyMovieCompletion(db, row.movieId, row.title)
+              yield* db.delete(downloadQueue).where(eq(downloadQueue.id, row.id))
+              completions.push({
+                movieId: row.movieId,
+                seriesId: null,
+                episodeIds: [],
+                externalId: row.externalId,
               })
-              .from(releaseDecisions)
-              .where(
-                and(
-                  eq(releaseDecisions.mediaId, movieId),
-                  eq(releaseDecisions.mediaType, "movie"),
-                  eq(releaseDecisions.candidateTitle, row.title),
-                ),
-              )
-              .limit(1)
-
-            const decision = decisionRows[0]
-
-            // 4. Update movie status
-            yield* db
-              .update(movies)
-              .set({
-                status: "available",
-                hasFile: true,
-                existingQualityRank: decision?.qualityRank ?? null,
-                existingFormatScore: decision?.formatScore ?? null,
+              touchedMovie = true
+            } else if (row.seriesId !== null && row.episodeIds && row.episodeIds.length > 0) {
+              yield* applyEpisodeCompletion(db, row.episodeIds, row.title)
+              yield* db.delete(downloadQueue).where(eq(downloadQueue.id, row.id))
+              completions.push({
+                movieId: null,
+                seriesId: row.seriesId,
+                episodeIds: row.episodeIds,
+                externalId: row.externalId,
               })
-              .where(eq(movies.id, movieId))
-
-            // 5. Remove completed queue row
-            yield* db.delete(downloadQueue).where(eq(downloadQueue.id, row.id))
-
-            completions.push({ movieId, externalId: row.externalId })
+              touchedTv = true
+            }
           }
 
-          // 6. Trigger Plex library scan for enabled servers with movie libraries
-          if (completions.length > 0) {
+          // 3. Trigger Plex library scans
+          if (touchedMovie || touchedTv) {
             const servers = yield* db
               .select()
               .from(mediaServers)
               .where(eq(mediaServers.enabled, true))
 
             for (const server of servers) {
+              const libTypes: Array<"movie" | "show"> = []
+              if (touchedMovie) libTypes.push("movie")
+              if (touchedTv) libTypes.push("show")
+
               const libs = yield* db
                 .select()
                 .from(mediaServerLibraries)
                 .where(
                   and(
                     eq(mediaServerLibraries.mediaServerId, server.id),
-                    eq(mediaServerLibraries.type, "movie"),
+                    inArray(mediaServerLibraries.type, libTypes),
                     eq(mediaServerLibraries.enabled, true),
                   ),
                 )

--- a/src/effect/services/SchedulerLoop.ts
+++ b/src/effect/services/SchedulerLoop.ts
@@ -1,8 +1,12 @@
-import { desc, eq } from "drizzle-orm"
+import { and, desc, eq, isNotNull, isNull, lte, or } from "drizzle-orm"
 import { Effect, Schedule } from "effect"
 
-import { schedulerConfig, schedulerJobs } from "#/db/schema"
-import type { SchedulerJobPayload, SchedulerJobType } from "#/effect/domain/scheduler"
+import { episodes, schedulerConfig, schedulerJobs, seasons, series } from "#/db/schema"
+import {
+  DEFAULT_AIR_DATE_DELAY_MINUTES,
+  type SchedulerJobPayload,
+  type SchedulerJobType,
+} from "#/effect/domain/scheduler"
 
 import { AcquisitionPipeline } from "./AcquisitionPipeline"
 import { Db } from "./Db"
@@ -95,6 +99,73 @@ const tick = Effect.gen(function* () {
         }
         break
       }
+      case "tv_rss_sync": {
+        // For each monitored, wanted episode whose air_date is sufficiently past, search.
+        const airCutoff = new Date(Date.now() - DEFAULT_AIR_DATE_DELAY_MINUTES * 60_000)
+        const wantedEpisodes = yield* db
+          .select({ id: episodes.id })
+          .from(episodes)
+          .innerJoin(seasons, eq(episodes.seasonId, seasons.id))
+          .innerJoin(series, eq(seasons.seriesId, series.id))
+          .where(
+            and(
+              eq(episodes.hasFile, false),
+              eq(episodes.monitored, true),
+              eq(seasons.monitored, true),
+              eq(series.monitored, true),
+              isNotNull(series.qualityProfileId),
+              or(isNull(episodes.airDate), lte(episodes.airDate, airCutoff)),
+            ),
+          )
+        for (const row of wantedEpisodes) {
+          yield* pipeline
+            .searchAndGrabEpisode(row.id)
+            .pipe(
+              Effect.catchAll((e) =>
+                Effect.logWarning(`tv_rss_sync episode ${row.id} failed: ${e._tag}`),
+              ),
+            )
+        }
+        break
+      }
+      case "tv_search_cutoff": {
+        const availableEps = yield* db
+          .select({ id: episodes.id })
+          .from(episodes)
+          .innerJoin(seasons, eq(episodes.seasonId, seasons.id))
+          .innerJoin(series, eq(seasons.seriesId, series.id))
+          .where(
+            and(
+              eq(episodes.hasFile, true),
+              eq(episodes.monitored, true),
+              eq(seasons.monitored, true),
+              eq(series.monitored, true),
+              isNotNull(series.qualityProfileId),
+            ),
+          )
+        for (const row of availableEps) {
+          yield* pipeline
+            .searchAndGrabEpisode(row.id)
+            .pipe(
+              Effect.catchAll((e) =>
+                Effect.logWarning(`tv_search_cutoff episode ${row.id} failed: ${e._tag}`),
+              ),
+            )
+        }
+        break
+      }
+      case "tv_search_series": {
+        yield* pipeline.searchAndGrabSeries(payload.seriesId)
+        break
+      }
+      case "tv_search_season": {
+        yield* pipeline.searchAndGrabSeason(payload.seasonId)
+        break
+      }
+      case "tv_search_episode": {
+        yield* pipeline.searchAndGrabEpisode(payload.episodeId)
+        break
+      }
     }
 
     yield* scheduler.complete(job.id)
@@ -121,6 +192,14 @@ function payloadForType(jobType: SchedulerJobType): SchedulerJobPayload | null {
       return { _tag: "search_cutoff" }
     case "search_missing":
       // Manual-only — don't auto-enqueue
+      return null
+    case "tv_rss_sync":
+      return { _tag: "tv_rss_sync" }
+    case "tv_search_cutoff":
+      return { _tag: "tv_search_cutoff" }
+    case "tv_search_series":
+    case "tv_search_season":
+    case "tv_search_episode":
       return null
   }
 }

--- a/src/effect/services/SchedulerService.test.ts
+++ b/src/effect/services/SchedulerService.test.ts
@@ -22,9 +22,16 @@ describe("SchedulerService", () => {
       Effect.gen(function* () {
         const svc = yield* SchedulerService
         const configs = yield* svc.getConfig()
-        expect(configs).toHaveLength(4)
+        expect(configs).toHaveLength(6)
         const types = configs.map((c) => c.jobType).toSorted()
-        expect(types).toEqual(["download_monitor", "rss_sync", "search_cutoff", "search_missing"])
+        expect(types).toEqual([
+          "download_monitor",
+          "rss_sync",
+          "search_cutoff",
+          "search_missing",
+          "tv_rss_sync",
+          "tv_search_cutoff",
+        ])
       }),
     ).pipe(Effect.provide(TestLayer)),
   )
@@ -35,7 +42,7 @@ describe("SchedulerService", () => {
       yield* svc.seedConfig()
       yield* svc.seedConfig()
       const configs = yield* svc.getConfig()
-      expect(configs).toHaveLength(4)
+      expect(configs).toHaveLength(6)
     }).pipe(Effect.provide(TestLayer)),
   )
 
@@ -252,7 +259,7 @@ describe("SchedulerService", () => {
         yield* svc.enqueue({ _tag: "rss_sync" })
 
         const summaries = yield* svc.status()
-        expect(summaries).toHaveLength(4)
+        expect(summaries).toHaveLength(6)
 
         const rss = summaries.find((s) => s.jobType === "rss_sync")
         expect(rss?.activeCount).toBe(1)

--- a/src/effect/services/TitleParserService.test.ts
+++ b/src/effect/services/TitleParserService.test.ts
@@ -202,6 +202,50 @@ describe("TitleParserService", () => {
     }).pipe(Effect.provide(TestLayer)),
   )
 
+  // ── Season packs ──
+
+  it.effect("parses season pack: Show.S01 (season only, no episode)", () =>
+    Effect.gen(function* () {
+      const svc = yield* TitleParserService
+      const p = yield* svc.parse("Test.Show.S01.1080p.BluRay.x264-GROUP")
+      expect(p.title).toBe("Test Show")
+      expect(p.season).toBe(1)
+      expect(p.episode).toBeNull()
+      expect(p.resolution).toBe(1080)
+      expect(p.qualityName).toBe("Bluray1080p")
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.effect("parses season pack: 'Season 1' verbose form", () =>
+    Effect.gen(function* () {
+      const svc = yield* TitleParserService
+      const p = yield* svc.parse("Test.Show.Season.1.1080p.WEB-DL-GRP")
+      expect(p.title).toBe("Test Show")
+      expect(p.season).toBe(1)
+      expect(p.episode).toBeNull()
+      expect(p.qualityName).toBe("WEBDL1080p")
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.effect("does NOT match season pack when S##E## present", () =>
+    Effect.gen(function* () {
+      const svc = yield* TitleParserService
+      const p = yield* svc.parse("Show.S02E05.1080p.WEB-DL-GRP")
+      expect(p.season).toBe(2)
+      expect(p.episode).toBe(5)
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.effect("title boundary respects S## season-only token", () =>
+    Effect.gen(function* () {
+      const svc = yield* TitleParserService
+      const p = yield* svc.parse("My.Long.Show.Name.S03.720p.HDTV-GRP")
+      expect(p.title).toBe("My Long Show Name")
+      expect(p.season).toBe(3)
+      expect(p.episode).toBeNull()
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
   // ── Error ──
 
   it.effect("rejects empty title", () =>

--- a/src/effect/services/TitleParserService.ts
+++ b/src/effect/services/TitleParserService.ts
@@ -8,6 +8,7 @@ import { ParseFailed } from "#/effect/errors"
 
 const SEASON_EPISODE = /S(\d{1,2})E(\d{1,3})/i
 const SEASON_EPISODE_ALT = /(\d{1,2})x(\d{2,3})/i
+const SEASON_ONLY = /(?:^|[.\-_ ])(?:Season[.\-_ ]?(\d{1,2})|S(\d{1,2}))(?![.\-_ ]?E?\d)/i
 
 const YEAR_RE = /(?:^|[.\-_ (])((?:19|20)\d{2})(?=[.\-_ )]|$)/
 
@@ -63,6 +64,7 @@ function findFirstQualityTokenIndex(raw: string): number {
     EDITION_RE,
     SEASON_EPISODE,
     SEASON_EPISODE_ALT,
+    SEASON_ONLY,
   ]
 
   let earliest = raw.length
@@ -184,6 +186,13 @@ export const TitleParserServiceLive = Layer.succeed(TitleParserService, {
         if (altMatch) {
           season = parseInt(altMatch[1], 10)
           episode = parseInt(altMatch[2], 10)
+        } else {
+          // Season pack: "Series.S01" or "Series Season 1"
+          const packMatch = SEASON_ONLY.exec(trimmed)
+          if (packMatch) {
+            const num = packMatch[1] ?? packMatch[2]
+            if (num) season = parseInt(num, 10)
+          }
         }
       }
 

--- a/src/effect/services/TitleParserService.ts
+++ b/src/effect/services/TitleParserService.ts
@@ -8,7 +8,7 @@ import { ParseFailed } from "#/effect/errors"
 
 const SEASON_EPISODE = /S(\d{1,2})E(\d{1,3})/i
 const SEASON_EPISODE_ALT = /(\d{1,2})x(\d{2,3})/i
-const SEASON_ONLY = /(?:^|[.\-_ ])(?:Season[.\-_ ]?(\d{1,2})|S(\d{1,2}))(?![.\-_ ]?E?\d)/i
+const SEASON_ONLY = /(?:^|[.\-_ ])(?:Season[.\-_ ]?(\d{1,2})|S(\d{1,2}))(?![.\-_ ]?[Ex]\d)/i
 
 const YEAR_RE = /(?:^|[.\-_ (])((?:19|20)\d{2})(?=[.\-_ )]|$)/
 

--- a/src/effect/test/TestDb.ts
+++ b/src/effect/test/TestDb.ts
@@ -134,6 +134,9 @@ const runDdl = Effect.gen(function* () {
     has_file INTEGER NOT NULL DEFAULT 0,
     file_path TEXT,
     monitored INTEGER NOT NULL DEFAULT 1,
+    existing_quality_name TEXT,
+    existing_quality_rank INTEGER,
+    existing_format_score INTEGER,
     UNIQUE(season_id, episode_number)
   )`
 
@@ -204,6 +207,8 @@ const runDdl = Effect.gen(function* () {
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     download_client_id INTEGER NOT NULL REFERENCES download_clients(id) ON DELETE CASCADE,
     movie_id INTEGER REFERENCES movies(id) ON DELETE SET NULL,
+    series_id INTEGER REFERENCES series(id) ON DELETE SET NULL,
+    episode_ids TEXT,
     external_id TEXT NOT NULL UNIQUE,
     status TEXT NOT NULL DEFAULT 'queued',
     title TEXT NOT NULL,

--- a/src/integrations/trpc/init.ts
+++ b/src/integrations/trpc/init.ts
@@ -144,7 +144,7 @@ export function domainToTRPC(error: DomainError): TRPCError {
     case "AcquisitionError":
       return new TRPCError({
         code: "BAD_REQUEST",
-        message: `[movie:${error.movieId}] ${error.stage}: ${error.message}`,
+        message: `[${error.mediaKind}:${error.mediaId}] ${error.stage}: ${error.message}`,
       })
     case "MetadataError": {
       const codeMap: Record<string, TRPCError["code"]> = {

--- a/src/integrations/trpc/routers/series.ts
+++ b/src/integrations/trpc/routers/series.ts
@@ -2,6 +2,7 @@ import type { TRPCRouterRecord } from "@trpc/server"
 import { Effect } from "effect"
 import { z } from "zod"
 
+import { AcquisitionPipeline } from "#/effect/services/AcquisitionPipeline"
 import { SeriesService } from "#/effect/services/SeriesService"
 
 import { authedProcedure, runEffect } from "../init"
@@ -145,4 +146,65 @@ export const seriesRouter = {
       }),
     ),
   ),
+
+  // ── Acquisition ──
+
+  searchSeries: authedProcedure.input(z.object({ id: z.number() })).mutation(({ input }) =>
+    runEffect(
+      Effect.gen(function* () {
+        const pipeline = yield* AcquisitionPipeline
+        return yield* pipeline.searchAndGrabSeries(input.id)
+      }),
+    ),
+  ),
+
+  searchSeason: authedProcedure.input(z.object({ seasonId: z.number() })).mutation(({ input }) =>
+    runEffect(
+      Effect.gen(function* () {
+        const pipeline = yield* AcquisitionPipeline
+        return yield* pipeline.searchAndGrabSeason(input.seasonId)
+      }),
+    ),
+  ),
+
+  searchEpisode: authedProcedure.input(z.object({ episodeId: z.number() })).mutation(({ input }) =>
+    runEffect(
+      Effect.gen(function* () {
+        const pipeline = yield* AcquisitionPipeline
+        return yield* pipeline.searchAndGrabEpisode(input.episodeId)
+      }),
+    ),
+  ),
+
+  evaluateEpisode: authedProcedure
+    .input(z.object({ episodeId: z.number() }))
+    .mutation(({ input }) =>
+      runEffect(
+        Effect.gen(function* () {
+          const pipeline = yield* AcquisitionPipeline
+          return yield* pipeline.searchAndEvaluateEpisode(input.episodeId)
+        }),
+      ),
+    ),
+
+  grabEpisode: authedProcedure
+    .input(
+      z.object({
+        episodeId: z.number(),
+        downloadUrl: z.string(),
+        candidateTitle: z.string(),
+      }),
+    )
+    .mutation(({ input }) =>
+      runEffect(
+        Effect.gen(function* () {
+          const pipeline = yield* AcquisitionPipeline
+          return yield* pipeline.grabEpisode(
+            input.episodeId,
+            input.downloadUrl,
+            input.candidateTitle,
+          )
+        }),
+      ),
+    ),
 } satisfies TRPCRouterRecord


### PR DESCRIPTION
## Summary
Wires the TV module into the acquisition pipeline so monitored episodes flow through the same search → evaluate → grab → download → complete path as movies, with season-pack detection layered on top.

- **Scheduler** — 5 new TV job types (`tv_rss_sync`, `tv_search_cutoff`, `tv_search_series`, `tv_search_season`, `tv_search_episode`) with default configs for the recurring ones. `tv_rss_sync` filters by air-date cutoff so unaired episodes are skipped.
- **Pipeline** — `searchAndGrabEpisode`, `searchAndEvaluateEpisode`, `grabEpisode`, `searchAndGrabSeason`, `searchAndGrabSeries`. Season flow is pack-first: if an accepted season pack is found it's grabbed and the queue row is linked to all wanted episodes; otherwise per-episode search is run.
- **Season pack detection** — `TitleParserService` now recognises `Series.S01` / `Series Season 1` variants. `isSeasonPack(parsed)` is a composable domain helper.
- **Schema** — `download_queue` gets `series_id` + `episode_ids` (JSON). `episodes` gets `existing_quality_name/rank/format_score` so upgrade decisions work per episode.
- **DownloadMonitor** — completions now fan out to movie or episode rows, and Plex refresh targets `show` libraries when TV completed (alongside `movie`).
- **AcquisitionError** — generalised with `mediaKind: movie|series|season|episode` so the same error type covers all acquisition failures.
- **tRPC** — `series.searchSeries`, `searchSeason`, `searchEpisode`, `evaluateEpisode`, `grabEpisode`.

## Test plan
- [x] `bun run typecheck` clean
- [x] `bun run lint` — 0 errors (2 pre-existing warnings)
- [x] `bun run test` — 201/201 passing (11 new TV cases)
- [x] `bun run db:generate` produces migration `0001_wise_violations.sql`

Closes #13