### PR TITLE
feat: Plex WebSocket session monitor (closes #22)

### DIFF
--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -322,7 +322,7 @@ export const mediaServers = sqliteTable("media_servers", {
   settings: text({ mode: "json" })
     .$type<MediaServerSettings>()
     .notNull()
-    .default(sql`'{"syncIntervalMs":3600000}'`),
+    .default(sql`'{"syncIntervalMs":3600000,"monitoringEnabled":true}'`),
   createdAt: integer("created_at", { mode: "timestamp" })
     .notNull()
     .default(sql`(unixepoch())`),

--- a/src/effect/domain/mediaServer.ts
+++ b/src/effect/domain/mediaServer.ts
@@ -14,6 +14,7 @@ export type MediaServerLibraryType = "movie" | "show"
 
 export interface MediaServerSettings {
   readonly syncIntervalMs: number
+  readonly monitoringEnabled: boolean
 }
 
 /** Config shape used by the adapter factory — no DB concerns. */
@@ -99,6 +100,50 @@ export interface MediaServerWithHealth {
   } | null
 }
 
+export interface SyncResult {
+  readonly matched: number
+  readonly unmatched: number
+  readonly libraryId: string
+}
+
+// ── Active sessions (Plex-shaped today; Jellyfin returns []) ──
+
+export type SessionState = "playing" | "paused" | "buffering"
+
+export type SessionMediaType = "movie" | "episode"
+
+export type TranscodeDecision = "direct_play" | "direct_stream" | "transcode"
+
+export interface MediaServerSession {
+  readonly mediaServerId: number
+  readonly sessionKey: string
+  readonly ratingKey: string
+  readonly userId: string
+  readonly username: string
+  readonly userThumb: string | null
+  readonly state: SessionState
+  readonly mediaType: SessionMediaType
+  readonly title: string
+  readonly parentTitle: string | null
+  readonly grandparentTitle: string | null
+  readonly year: number | null
+  readonly thumb: string | null
+  readonly viewOffset: number
+  readonly duration: number
+  readonly progressPercent: number
+  readonly transcodeDecision: TranscodeDecision
+  readonly videoResolution: string | null
+  readonly audioCodec: string | null
+  readonly player: string
+  readonly platform: string
+  readonly product: string | null
+  readonly ipAddress: string | null
+  readonly bandwidth: number | null
+  readonly isLocal: boolean
+  readonly startedAt: Date
+  readonly updatedAt: Date
+}
+
 export interface MediaServerLibraryWithSync {
   readonly id: number
   readonly mediaServerId: number
@@ -107,10 +152,4 @@ export interface MediaServerLibraryWithSync {
   readonly type: MediaServerLibraryType
   readonly enabled: boolean
   readonly lastSynced: Date | null
-}
-
-export interface SyncResult {
-  readonly matched: number
-  readonly unmatched: number
-  readonly libraryId: string
 }

--- a/src/effect/layers.ts
+++ b/src/effect/layers.ts
@@ -11,6 +11,7 @@ import { DownloadMonitorLive } from "./services/DownloadMonitor"
 import { IndexerServiceLive } from "./services/IndexerService"
 import { MediaServerServiceLive } from "./services/MediaServerService"
 import { MovieServiceLive } from "./services/MovieService"
+import { PlexSessionMonitorLive } from "./services/PlexSessionMonitor"
 import { ProfileDefaultsEngineLive } from "./services/ProfileDefaultsEngine"
 import { ProfileServiceLive } from "./services/ProfileService"
 import { ReleasePolicyEngineLive } from "./services/ReleasePolicyEngine"
@@ -26,6 +27,7 @@ export const AppLive = Layer.mergeAll(
   SchedulerServiceLive,
   AcquisitionPipelineLive,
   DownloadMonitorLive,
+  PlexSessionMonitorLive,
 ).pipe(
   Layer.provideMerge(
     Layer.mergeAll(

--- a/src/effect/runtime.ts
+++ b/src/effect/runtime.ts
@@ -6,6 +6,7 @@ import { resolveInitialAdminPassword } from "./bootstrap"
 import { AppLive } from "./layers"
 import { CryptoService } from "./services/CryptoService"
 import { Db } from "./services/Db"
+import { PlexSessionMonitor } from "./services/PlexSessionMonitor"
 import { ProfileDefaultsEngine } from "./services/ProfileDefaultsEngine"
 import { createSchedulerLoop } from "./services/SchedulerLoop"
 import { SchedulerService } from "./services/SchedulerService"
@@ -36,6 +37,9 @@ const seed = Effect.gen(function* () {
 
   const scheduler = yield* SchedulerService
   yield* scheduler.seedConfig()
+
+  const sessionMonitor = yield* PlexSessionMonitor
+  yield* sessionMonitor.startAllEnabled()
 })
 
 AppRuntime.runPromise(seed).then(

--- a/src/effect/services/JellyfinAdapter.ts
+++ b/src/effect/services/JellyfinAdapter.ts
@@ -7,6 +7,7 @@ import type {
   MediaServerHealth,
   MediaServerLibrary,
   MediaServerLibraryType,
+  MediaServerSession,
   SyncedItem,
 } from "../domain/mediaServer"
 import { MediaServerError, type MediaServerErrorReason } from "../errors"
@@ -269,6 +270,9 @@ export function createJellyfinAdapter(config: MediaServerConfig): MediaServerAda
       Effect.gen(function* () {
         yield* jellyfinFetch("/Library/Refresh", "POST")
       }),
+
+    getActiveSessions: (): Effect.Effect<ReadonlyArray<MediaServerSession>, MediaServerError> =>
+      Effect.succeed([]),
 
     getHealth: (): Effect.Effect<MediaServerHealth, MediaServerError> =>
       Effect.gen(function* () {

--- a/src/effect/services/MediaServerAdapter.ts
+++ b/src/effect/services/MediaServerAdapter.ts
@@ -4,6 +4,7 @@ import type {
   MediaServerConnectionInfo,
   MediaServerHealth,
   MediaServerLibrary,
+  MediaServerSession,
   ParsedGuid,
   SyncedItem,
 } from "../domain/mediaServer"
@@ -22,6 +23,11 @@ export interface MediaServerAdapter {
     path: string,
   ) => Effect.Effect<void, MediaServerError>
   readonly getHealth: () => Effect.Effect<MediaServerHealth, MediaServerError>
+  /** Snapshot of currently-active streams. Adapters without monitoring support return []. */
+  readonly getActiveSessions: () => Effect.Effect<
+    ReadonlyArray<MediaServerSession>,
+    MediaServerError
+  >
 }
 
 // ── GUID extraction (from Sonarr/Radarr PlexParser.cs pattern) ──

--- a/src/effect/services/MediaServerService.test.ts
+++ b/src/effect/services/MediaServerService.test.ts
@@ -46,11 +46,12 @@ describe("MediaServerService", () => {
         ...validInput,
         useSsl: true,
         enabled: false,
-        settings: { syncIntervalMs: 7200000 },
+        settings: { syncIntervalMs: 7200000, monitoringEnabled: false },
       })
       expect(server.useSsl).toBe(true)
       expect(server.enabled).toBe(false)
       expect(server.settings.syncIntervalMs).toBe(7200000)
+      expect(server.settings.monitoringEnabled).toBe(false)
     }).pipe(Effect.provide(TestLayer)),
   )
 

--- a/src/effect/services/MediaServerService.ts
+++ b/src/effect/services/MediaServerService.ts
@@ -220,7 +220,7 @@ export const MediaServerServiceLive = Layer.effect(
               tokenEncrypted: encrypted,
               useSsl: input.useSsl ?? false,
               enabled: input.enabled ?? true,
-              settings: input.settings ?? { syncIntervalMs: 3600000 },
+              settings: input.settings ?? { syncIntervalMs: 3600000, monitoringEnabled: true },
             })
             .returning()
 

--- a/src/effect/services/PlexAdapter.ts
+++ b/src/effect/services/PlexAdapter.ts
@@ -7,7 +7,11 @@ import type {
   MediaServerHealth,
   MediaServerLibrary,
   MediaServerLibraryType,
+  MediaServerSession,
+  SessionMediaType,
+  SessionState,
   SyncedItem,
+  TranscodeDecision,
 } from "../domain/mediaServer"
 import { MediaServerError, type MediaServerErrorReason } from "../errors"
 import type { MediaServerAdapter } from "./MediaServerAdapter"
@@ -93,6 +97,140 @@ interface PlexMetadata {
 interface PlexLibraryItems {
   readonly MediaContainer: {
     readonly Metadata?: ReadonlyArray<PlexMetadata>
+  }
+}
+
+// ── /status/sessions ──
+
+interface PlexSessionUser {
+  readonly id?: string
+  readonly title?: string
+  readonly thumb?: string
+}
+
+interface PlexSessionPlayer {
+  readonly state?: string
+  readonly title?: string
+  readonly platform?: string
+  readonly product?: string
+  readonly address?: string
+  readonly local?: boolean
+}
+
+interface PlexSessionSession {
+  readonly id?: string
+  readonly bandwidth?: number
+}
+
+interface PlexSessionStream {
+  readonly streamType: number
+  readonly codec?: string
+}
+
+interface PlexSessionMediaPart {
+  readonly Stream?: ReadonlyArray<PlexSessionStream>
+}
+
+interface PlexSessionMedia {
+  readonly videoResolution?: string
+  readonly audioCodec?: string
+  readonly Part?: ReadonlyArray<PlexSessionMediaPart>
+}
+
+interface PlexSessionTranscode {
+  readonly videoDecision?: string
+  readonly audioDecision?: string
+}
+
+interface PlexSessionMetadata {
+  readonly sessionKey: string
+  readonly ratingKey: string
+  readonly type: string
+  readonly title: string
+  readonly parentTitle?: string
+  readonly grandparentTitle?: string
+  readonly year?: number
+  readonly thumb?: string
+  readonly viewOffset?: number
+  readonly duration?: number
+  readonly addedAt?: number
+  readonly User?: PlexSessionUser
+  readonly Player?: PlexSessionPlayer
+  readonly Session?: PlexSessionSession
+  readonly Media?: ReadonlyArray<PlexSessionMedia>
+  readonly TranscodeSession?: PlexSessionTranscode
+}
+
+interface PlexStatusSessions {
+  readonly MediaContainer: {
+    readonly Metadata?: ReadonlyArray<PlexSessionMetadata>
+  }
+}
+
+const SESSION_STATE_MAP: Record<string, SessionState> = {
+  playing: "playing",
+  paused: "paused",
+  buffering: "buffering",
+}
+
+const SESSION_TYPE_MAP: Record<string, SessionMediaType> = {
+  movie: "movie",
+  episode: "episode",
+}
+
+function mapTranscodeDecision(transcode: PlexSessionTranscode | undefined): TranscodeDecision {
+  if (!transcode) return "direct_play"
+  const isTranscoded =
+    transcode.videoDecision === "transcode" || transcode.audioDecision === "transcode"
+  if (isTranscoded) return "transcode"
+  const isCopied = transcode.videoDecision === "copy" || transcode.audioDecision === "copy"
+  if (isCopied) return "direct_stream"
+  return "direct_play"
+}
+
+function mapPlexSession(
+  serverId: number,
+  m: PlexSessionMetadata,
+  now: Date,
+): MediaServerSession | null {
+  const state = SESSION_STATE_MAP[m.Player?.state ?? "playing"]
+  const mediaType = SESSION_TYPE_MAP[m.type]
+  if (!state || !mediaType) return null
+
+  const media = m.Media?.[0]
+  const audioStream = media?.Part?.[0]?.Stream?.find((s) => s.streamType === 2)
+  const duration = m.duration ?? 0
+  const viewOffset = m.viewOffset ?? 0
+  const startedAt = m.addedAt ? new Date(m.addedAt * 1000) : now
+
+  return {
+    mediaServerId: serverId,
+    sessionKey: m.sessionKey,
+    ratingKey: m.ratingKey,
+    userId: m.User?.id ?? "",
+    username: m.User?.title ?? "",
+    userThumb: m.User?.thumb ?? null,
+    state,
+    mediaType,
+    title: m.title,
+    parentTitle: m.parentTitle ?? null,
+    grandparentTitle: m.grandparentTitle ?? null,
+    year: m.year ?? null,
+    thumb: m.thumb ?? null,
+    viewOffset,
+    duration,
+    progressPercent: duration > 0 ? Math.min(100, (viewOffset / duration) * 100) : 0,
+    transcodeDecision: mapTranscodeDecision(m.TranscodeSession),
+    videoResolution: media?.videoResolution ?? null,
+    audioCodec: media?.audioCodec ?? audioStream?.codec ?? null,
+    player: m.Player?.title ?? "",
+    platform: m.Player?.platform ?? "",
+    product: m.Player?.product ?? null,
+    ipAddress: m.Player?.address ?? null,
+    bandwidth: m.Session?.bandwidth ?? null,
+    isLocal: m.Player?.local ?? false,
+    startedAt,
+    updatedAt: now,
   }
 }
 
@@ -256,6 +394,17 @@ export function createPlexAdapter(config: MediaServerConfig): MediaServerAdapter
     refreshLibrary: (libraryId, path) =>
       Effect.gen(function* () {
         yield* plexFetch(`/library/sections/${libraryId}/refresh?path=${encodeURIComponent(path)}`)
+      }),
+
+    getActiveSessions: (): Effect.Effect<ReadonlyArray<MediaServerSession>, MediaServerError> =>
+      Effect.gen(function* () {
+        const sessions = yield* plexJson<PlexStatusSessions>("/status/sessions")
+        const metadata = sessions.MediaContainer.Metadata ?? []
+        const now = new Date()
+        return metadata.flatMap((m): ReadonlyArray<MediaServerSession> => {
+          const mapped = mapPlexSession(config.id, m, now)
+          return mapped ? [mapped] : []
+        })
       }),
 
     getHealth: (): Effect.Effect<MediaServerHealth, MediaServerError> =>

--- a/src/effect/services/PlexSessionMonitor.test.ts
+++ b/src/effect/services/PlexSessionMonitor.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it } from "@effect/vitest"
+import { Effect, Layer } from "effect"
+
+import type { MediaServerSession } from "#/effect/domain/mediaServer"
+import { AdapterRegistryLive } from "#/effect/services/AdapterRegistry"
+import { CryptoServiceLive } from "#/effect/services/CryptoService"
+import { MediaServerService, MediaServerServiceLive } from "#/effect/services/MediaServerService"
+import { TestDbLive } from "#/effect/test/TestDb"
+
+import {
+  buildWsUrl,
+  isPlayingNotification,
+  PlexSessionMonitor,
+  PlexSessionMonitorLive,
+  reconcileSessions,
+  snapshotSessions,
+} from "./PlexSessionMonitor"
+
+// ── Pure helper unit tests ──
+
+const mkSession = (sessionKey: string, serverId = 1): MediaServerSession => ({
+  mediaServerId: serverId,
+  sessionKey,
+  ratingKey: `rk-${sessionKey}`,
+  userId: "u1",
+  username: "alice",
+  userThumb: null,
+  state: "playing",
+  mediaType: "movie",
+  title: `Title ${sessionKey}`,
+  parentTitle: null,
+  grandparentTitle: null,
+  year: 2024,
+  thumb: null,
+  viewOffset: 0,
+  duration: 100,
+  progressPercent: 0,
+  transcodeDecision: "direct_play",
+  videoResolution: "1080",
+  audioCodec: "aac",
+  player: "PlexWeb",
+  platform: "Chrome",
+  product: "Plex Web",
+  ipAddress: null,
+  bandwidth: null,
+  isLocal: true,
+  startedAt: new Date(0),
+  updatedAt: new Date(0),
+})
+
+describe("reconcileSessions", () => {
+  it("seeds sessions when prev is empty", () => {
+    const { map, stopped } = reconcileSessions(new Map(), 1, [mkSession("a"), mkSession("b")])
+    expect(stopped).toEqual([])
+    expect(map.get(1)?.size).toBe(2)
+  })
+
+  it("detects sessions removed from next as stopped", () => {
+    const prev = new Map([
+      [
+        1,
+        new Map([
+          ["a", mkSession("a")],
+          ["b", mkSession("b")],
+        ]),
+      ],
+    ])
+    const { stopped } = reconcileSessions(prev, 1, [mkSession("a")])
+    expect(stopped.map((s) => s.sessionKey)).toEqual(["b"])
+  })
+
+  it("scopes reconciliation per server", () => {
+    const prev = new Map([
+      [1, new Map([["a", mkSession("a", 1)]])],
+      [2, new Map([["x", mkSession("x", 2)]])],
+    ])
+    const { map, stopped } = reconcileSessions(prev, 1, [])
+    expect(stopped.map((s) => s.sessionKey)).toEqual(["a"])
+    expect(map.get(2)?.size).toBe(1)
+    expect(map.get(1)?.size).toBe(0)
+  })
+
+  it("upserts existing keys with new state", () => {
+    const prev = new Map([[1, new Map([["a", { ...mkSession("a"), state: "playing" as const }]])]])
+    const updated: MediaServerSession = { ...mkSession("a"), state: "paused" }
+    const { map, stopped } = reconcileSessions(prev, 1, [updated])
+    expect(stopped).toEqual([])
+    expect(map.get(1)?.get("a")?.state).toBe("paused")
+  })
+})
+
+describe("snapshotSessions", () => {
+  it("flattens all servers into one array", () => {
+    const state = new Map([
+      [1, new Map([["a", mkSession("a", 1)]])],
+      [
+        2,
+        new Map([
+          ["x", mkSession("x", 2)],
+          ["y", mkSession("y", 2)],
+        ]),
+      ],
+    ])
+    expect(snapshotSessions(state)).toHaveLength(3)
+  })
+})
+
+describe("buildWsUrl", () => {
+  it("uses ws:// when useSsl is false", () => {
+    expect(buildWsUrl({ host: "192.168.1.5", port: 32400, useSsl: false, token: "tok" })).toBe(
+      "ws://192.168.1.5:32400/:/websockets/notifications?X-Plex-Token=tok",
+    )
+  })
+
+  it("uses wss:// when useSsl is true", () => {
+    expect(buildWsUrl({ host: "h", port: 1, useSsl: true, token: "t" })).toMatch(/^wss:/)
+  })
+
+  it("URL-encodes the token", () => {
+    expect(buildWsUrl({ host: "h", port: 1, useSsl: false, token: "a/b+c" })).toContain(
+      "X-Plex-Token=a%2Fb%2Bc",
+    )
+  })
+})
+
+describe("isPlayingNotification", () => {
+  it("accepts a playing event with a state notification", () => {
+    const raw = JSON.stringify({
+      NotificationContainer: {
+        type: "playing",
+        PlaySessionStateNotification: [{ sessionKey: "1", state: "playing" }],
+      },
+    })
+    expect(isPlayingNotification(raw)).toBe(true)
+  })
+
+  it("rejects non-playing event types", () => {
+    const raw = JSON.stringify({
+      NotificationContainer: { type: "timeline", TimelineEntry: [{}] },
+    })
+    expect(isPlayingNotification(raw)).toBe(false)
+  })
+
+  it("rejects malformed JSON", () => {
+    expect(isPlayingNotification("not json")).toBe(false)
+  })
+
+  it("rejects playing event with no notifications", () => {
+    const raw = JSON.stringify({
+      NotificationContainer: { type: "playing", PlaySessionStateNotification: [] },
+    })
+    expect(isPlayingNotification(raw)).toBe(false)
+  })
+})
+
+// ── Service lifecycle tests ──
+
+const TestLayer = PlexSessionMonitorLive.pipe(
+  Layer.provideMerge(MediaServerServiceLive),
+  Layer.provideMerge(CryptoServiceLive),
+  Layer.provideMerge(AdapterRegistryLive),
+  Layer.provideMerge(TestDbLive),
+)
+
+describe("PlexSessionMonitor service", () => {
+  it.scoped("getActive returns [] when no servers monitored", () =>
+    Effect.gen(function* () {
+      const monitor = yield* PlexSessionMonitor
+      expect(yield* monitor.getActive()).toEqual([])
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.scoped("start fails for unknown server", () =>
+    Effect.gen(function* () {
+      const monitor = yield* PlexSessionMonitor
+      const error = yield* Effect.flip(monitor.start(99999))
+      expect(error._tag).toBe("NotFoundError")
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.scoped("startAllEnabled is no-op when no monitoring-enabled servers exist", () =>
+    Effect.gen(function* () {
+      const monitor = yield* PlexSessionMonitor
+      yield* monitor.startAllEnabled()
+      expect(yield* monitor.getActive()).toEqual([])
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.scoped("startAllEnabled skips servers with monitoringEnabled=false", () =>
+    Effect.gen(function* () {
+      const svc = yield* MediaServerService
+      yield* svc.add({
+        name: "Plex Off",
+        type: "plex",
+        host: "127.0.0.1",
+        port: 32400,
+        token: "tok",
+        settings: { syncIntervalMs: 60000, monitoringEnabled: false },
+      })
+      const monitor = yield* PlexSessionMonitor
+      yield* monitor.startAllEnabled()
+      // Nothing started → still empty after stopAll for cleanup.
+      expect(yield* monitor.getActive()).toEqual([])
+      yield* monitor.stopAll()
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.scoped("getActiveForServer returns [] for unknown server id", () =>
+    Effect.gen(function* () {
+      const monitor = yield* PlexSessionMonitor
+      expect(yield* monitor.getActiveForServer(42)).toEqual([])
+    }).pipe(Effect.provide(TestLayer)),
+  )
+})

--- a/src/effect/services/PlexSessionMonitor.ts
+++ b/src/effect/services/PlexSessionMonitor.ts
@@ -1,0 +1,359 @@
+import { SqlError } from "@effect/sql/SqlError"
+import { eq } from "drizzle-orm"
+import { Context, Effect, Fiber, Layer, Ref, Runtime, Schedule } from "effect"
+
+import { mediaServers } from "#/db/schema"
+
+import type { MediaServerConfig, MediaServerSession } from "../domain/mediaServer"
+import {
+  MediaServerError,
+  NotFoundError,
+  type EncryptionError,
+  type ValidationError,
+} from "../errors"
+import { AdapterRegistry } from "./AdapterRegistry"
+import { CryptoService } from "./CryptoService"
+import { Db } from "./Db"
+import type { MediaServerAdapter } from "./MediaServerAdapter"
+
+// ── Notification payload (Plex `/:/websockets/notifications`) ──
+
+interface PlaySessionStateNotification {
+  readonly sessionKey: string
+  readonly state?: string
+}
+
+interface NotificationContainer {
+  readonly type?: string
+  readonly PlaySessionStateNotification?: ReadonlyArray<PlaySessionStateNotification>
+}
+
+interface NotificationEnvelope {
+  readonly NotificationContainer?: NotificationContainer
+}
+
+// ── Types ──
+
+type ServerSessions = ReadonlyMap<string, MediaServerSession>
+type SessionMap = ReadonlyMap<number, ServerSessions>
+type FiberMap = Map<number, Fiber.RuntimeFiber<void, never>>
+
+type StartError = NotFoundError | ValidationError | EncryptionError | MediaServerError | SqlError
+
+// ── Service tag ──
+
+export class PlexSessionMonitor extends Context.Tag("@arr-hub/PlexSessionMonitor")<
+  PlexSessionMonitor,
+  {
+    readonly start: (serverId: number) => Effect.Effect<void, StartError>
+    readonly stop: (serverId: number) => Effect.Effect<void>
+    readonly startAllEnabled: () => Effect.Effect<void, SqlError>
+    readonly stopAll: () => Effect.Effect<void>
+    readonly getActive: () => Effect.Effect<ReadonlyArray<MediaServerSession>>
+    readonly getActiveForServer: (
+      serverId: number,
+    ) => Effect.Effect<ReadonlyArray<MediaServerSession>>
+  }
+>() {}
+
+// ── Pure helpers (exported for unit tests) ──
+
+export function buildWsUrl(config: {
+  readonly host: string
+  readonly port: number
+  readonly useSsl: boolean
+  readonly token: string
+}): string {
+  const scheme = config.useSsl ? "wss" : "ws"
+  return `${scheme}://${config.host}:${config.port}/:/websockets/notifications?X-Plex-Token=${encodeURIComponent(config.token)}`
+}
+
+/** Pure reconciliation: returns next map + sessions that disappeared (stopped). */
+export function reconcileSessions(
+  prev: SessionMap,
+  serverId: number,
+  next: ReadonlyArray<MediaServerSession>,
+): { readonly map: SessionMap; readonly stopped: ReadonlyArray<MediaServerSession> } {
+  const prevForServer = prev.get(serverId) ?? new Map<string, MediaServerSession>()
+  const nextForServer = new Map<string, MediaServerSession>()
+  for (const s of next) nextForServer.set(s.sessionKey, s)
+
+  const stopped: Array<MediaServerSession> = []
+  for (const [key, session] of prevForServer) {
+    if (!nextForServer.has(key)) stopped.push(session)
+  }
+
+  const map = new Map(prev)
+  map.set(serverId, nextForServer)
+  return { map, stopped }
+}
+
+export function snapshotSessions(state: SessionMap): ReadonlyArray<MediaServerSession> {
+  const out: Array<MediaServerSession> = []
+  for (const serverMap of state.values()) {
+    for (const s of serverMap.values()) out.push(s)
+  }
+  return out
+}
+
+/** Returns true when the WS payload represents a play-state notification (worth refreshing for). */
+export function isPlayingNotification(raw: string): boolean {
+  let envelope: NotificationEnvelope
+  try {
+    envelope = JSON.parse(raw) as NotificationEnvelope
+  } catch {
+    return false
+  }
+  const container = envelope.NotificationContainer
+  return container?.type === "playing" && (container.PlaySessionStateNotification?.length ?? 0) > 0
+}
+
+// ── Live implementation ──
+
+export const PlexSessionMonitorLive = Layer.scoped(
+  PlexSessionMonitor,
+  Effect.gen(function* () {
+    const db = yield* Db
+    const crypto = yield* CryptoService
+    const registry = yield* AdapterRegistry
+
+    const sessionsRef = yield* Ref.make<SessionMap>(new Map())
+    const fibersRef = yield* Ref.make<FiberMap>(new Map())
+
+    const refreshFromAdapter = (
+      serverId: number,
+      adapter: MediaServerAdapter,
+    ): Effect.Effect<void, MediaServerError> =>
+      Effect.gen(function* () {
+        const sessions = yield* adapter.getActiveSessions()
+        const stopped = yield* Ref.modify(sessionsRef, (prev) => {
+          const result = reconcileSessions(prev, serverId, sessions)
+          return [result.stopped, result.map]
+        })
+        // Integration point for #23 (Playback Session History): write `stopped` to history.
+        if (stopped.length > 0) {
+          yield* Effect.log(`[plex-monitor] server=${serverId} sessions ended: ${stopped.length}`)
+        }
+      })
+
+    const handleMessage = (
+      serverId: number,
+      adapter: MediaServerAdapter,
+      raw: string,
+    ): Effect.Effect<void, never> =>
+      Effect.gen(function* () {
+        if (!isPlayingNotification(raw)) return
+        yield* refreshFromAdapter(serverId, adapter).pipe(
+          Effect.catchAll((e) =>
+            Effect.logWarning(`[plex-monitor] server=${serverId} refresh failed: ${e.reason}`),
+          ),
+        )
+      })
+
+    const loadConfig = (
+      serverId: number,
+    ): Effect.Effect<MediaServerConfig, NotFoundError | EncryptionError | SqlError> =>
+      Effect.gen(function* () {
+        const rows = yield* db.select().from(mediaServers).where(eq(mediaServers.id, serverId))
+        const row = rows[0]
+        if (!row) return yield* new NotFoundError({ entity: "media_server", id: serverId })
+        const token = yield* crypto.decrypt(row.tokenEncrypted)
+        return {
+          id: row.id,
+          name: row.name,
+          type: row.type,
+          host: row.host,
+          port: row.port,
+          token,
+          useSsl: row.useSsl,
+          settings: row.settings,
+        }
+      })
+
+    const connectWebSocket = (
+      config: MediaServerConfig,
+      adapter: MediaServerAdapter,
+      runtime: Runtime.Runtime<never>,
+    ): Effect.Effect<void, MediaServerError> =>
+      Effect.async<void, MediaServerError>((resume) => {
+        let ws: WebSocket
+        try {
+          ws = new WebSocket(buildWsUrl(config))
+        } catch (e) {
+          resume(
+            Effect.fail(
+              new MediaServerError({
+                serverId: config.id,
+                serverName: config.name,
+                reason: "connection_refused",
+                message: e instanceof Error ? e.message : "websocket construction failed",
+                retryable: true,
+              }),
+            ),
+          )
+          return
+        }
+
+        let resolved = false
+        const finish = (effect: Effect.Effect<void, MediaServerError>) => {
+          if (resolved) return
+          resolved = true
+          resume(effect)
+        }
+
+        ws.addEventListener("open", () => {
+          Runtime.runFork(runtime)(
+            Effect.log(`[plex-monitor] WS open server=${config.id} (${config.name})`),
+          )
+          // Cold-start reconcile on connect.
+          Runtime.runFork(runtime)(
+            refreshFromAdapter(config.id, adapter).pipe(
+              Effect.catchAll((e) =>
+                Effect.logWarning(`[plex-monitor] cold-start failed: ${e.reason}`),
+              ),
+            ),
+          )
+        })
+
+        ws.addEventListener("message", (ev) => {
+          const data =
+            typeof ev.data === "string"
+              ? ev.data
+              : ev.data instanceof ArrayBuffer
+                ? new TextDecoder().decode(ev.data)
+                : String(ev.data)
+          Runtime.runFork(runtime)(handleMessage(config.id, adapter, data))
+        })
+
+        ws.addEventListener("error", () => {
+          finish(
+            Effect.fail(
+              new MediaServerError({
+                serverId: config.id,
+                serverName: config.name,
+                reason: "connection_refused",
+                message: "websocket error",
+                retryable: true,
+              }),
+            ),
+          )
+        })
+
+        ws.addEventListener("close", () => {
+          finish(
+            Effect.fail(
+              new MediaServerError({
+                serverId: config.id,
+                serverName: config.name,
+                reason: "connection_refused",
+                message: "websocket closed",
+                retryable: true,
+              }),
+            ),
+          )
+        })
+
+        return Effect.sync(() => {
+          if (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING) {
+            ws.close()
+          }
+        })
+      })
+
+    const monitorServer = (serverId: number): Effect.Effect<void, never> =>
+      Effect.gen(function* () {
+        const runtime = yield* Effect.runtime<never>()
+        const reconnect = Schedule.exponential("1 seconds", 2).pipe(
+          Schedule.either(Schedule.spaced("30 seconds")),
+        )
+
+        yield* Effect.gen(function* () {
+          const config = yield* loadConfig(serverId)
+          const factory = yield* registry.getMediaServerFactory(config.type)
+          const adapter = factory(config)
+          yield* connectWebSocket(config, adapter, runtime)
+        }).pipe(
+          Effect.catchAll((e) =>
+            Effect.logWarning(`[plex-monitor] server=${serverId} error: ${String(e)}`),
+          ),
+          Effect.tap(() =>
+            Ref.update(sessionsRef, (prev) => {
+              const next = new Map(prev)
+              next.delete(serverId)
+              return next
+            }),
+          ),
+          Effect.repeat(reconnect),
+          Effect.asVoid,
+          Effect.catchAllCause((c) =>
+            Effect.logError(`[plex-monitor] server=${serverId} fatal: ${String(c)}`),
+          ),
+        )
+      })
+
+    const start: (serverId: number) => Effect.Effect<void, StartError> = (serverId) =>
+      Effect.gen(function* () {
+        const existing = (yield* Ref.get(fibersRef)).get(serverId)
+        if (existing) return
+        // Validate server + adapter exist before forking the fiber.
+        const config = yield* loadConfig(serverId)
+        yield* registry.getMediaServerFactory(config.type)
+        const fiber = yield* Effect.forkDaemon(monitorServer(serverId))
+        yield* Ref.update(fibersRef, (m) => {
+          const next = new Map(m)
+          next.set(serverId, fiber)
+          return next
+        })
+      })
+
+    const stop: (serverId: number) => Effect.Effect<void> = (serverId) =>
+      Effect.gen(function* () {
+        const fiber = (yield* Ref.get(fibersRef)).get(serverId)
+        if (!fiber) return
+        yield* Fiber.interrupt(fiber)
+        yield* Ref.update(fibersRef, (m) => {
+          const next = new Map(m)
+          next.delete(serverId)
+          return next
+        })
+        yield* Ref.update(sessionsRef, (prev) => {
+          const next = new Map(prev)
+          next.delete(serverId)
+          return next
+        })
+      })
+
+    const stopAll: () => Effect.Effect<void> = () =>
+      Effect.gen(function* () {
+        const fibers = yield* Ref.get(fibersRef)
+        yield* Effect.forEach(fibers.values(), (f) => Fiber.interrupt(f), { discard: true })
+        yield* Ref.set(fibersRef, new Map())
+        yield* Ref.set(sessionsRef, new Map())
+      })
+
+    const startAllEnabled: () => Effect.Effect<void, SqlError> = () =>
+      Effect.gen(function* () {
+        const rows = yield* db.select().from(mediaServers).where(eq(mediaServers.enabled, true))
+        for (const row of rows) {
+          if (!row.settings.monitoringEnabled) continue
+          yield* start(row.id).pipe(
+            Effect.catchAll((e) =>
+              Effect.logWarning(`[plex-monitor] start server=${row.id} failed: ${String(e)}`),
+            ),
+          )
+        }
+      })
+
+    yield* Effect.addFinalizer(() => stopAll())
+
+    return {
+      start,
+      stop,
+      startAllEnabled,
+      stopAll,
+      getActive: () => Ref.get(sessionsRef).pipe(Effect.map(snapshotSessions)),
+      getActiveForServer: (serverId) =>
+        Ref.get(sessionsRef).pipe(Effect.map((m) => Array.from(m.get(serverId)?.values() ?? []))),
+    }
+  }),
+)

--- a/src/effect/test/TestDb.ts
+++ b/src/effect/test/TestDb.ts
@@ -229,7 +229,7 @@ const runDdl = Effect.gen(function* () {
     token_encrypted TEXT NOT NULL,
     use_ssl INTEGER NOT NULL DEFAULT 0,
     enabled INTEGER NOT NULL DEFAULT 1,
-    settings TEXT NOT NULL DEFAULT '{"syncIntervalMs":3600000}',
+    settings TEXT NOT NULL DEFAULT '{"syncIntervalMs":3600000,"monitoringEnabled":true}',
     created_at INTEGER NOT NULL DEFAULT (unixepoch()),
     updated_at INTEGER NOT NULL DEFAULT (unixepoch())
   )`

--- a/src/integrations/trpc/routers/mediaServers.ts
+++ b/src/integrations/trpc/routers/mediaServers.ts
@@ -3,8 +3,14 @@ import { Effect } from "effect"
 import { z } from "zod"
 
 import { MediaServerService } from "#/effect/services/MediaServerService"
+import { PlexSessionMonitor } from "#/effect/services/PlexSessionMonitor"
 
 import { authedProcedure, runEffect } from "../init"
+
+const settingsSchema = z.object({
+  syncIntervalMs: z.number().int().min(60000),
+  monitoringEnabled: z.boolean(),
+})
 
 const mediaServerInputSchema = z.object({
   name: z.string(),
@@ -14,7 +20,7 @@ const mediaServerInputSchema = z.object({
   token: z.string(),
   useSsl: z.boolean().optional(),
   enabled: z.boolean().optional(),
-  settings: z.object({ syncIntervalMs: z.number().int().min(60000) }).optional(),
+  settings: settingsSchema.optional(),
 })
 
 const mediaServerUpdateSchema = z.object({
@@ -25,7 +31,7 @@ const mediaServerUpdateSchema = z.object({
   token: z.string().optional(),
   useSsl: z.boolean().optional(),
   enabled: z.boolean().optional(),
-  settings: z.object({ syncIntervalMs: z.number().int().min(60000) }).optional(),
+  settings: settingsSchema.optional(),
 })
 
 export const mediaServersRouter = {
@@ -124,4 +130,17 @@ export const mediaServersRouter = {
       }),
     ),
   ),
+
+  activeSessions: authedProcedure
+    .input(z.object({ serverId: z.number().optional() }).optional())
+    .query(({ input }) =>
+      runEffect(
+        Effect.gen(function* () {
+          const monitor = yield* PlexSessionMonitor
+          return input?.serverId
+            ? yield* monitor.getActiveForServer(input.serverId)
+            : yield* monitor.getActive()
+        }),
+      ),
+    ),
 } satisfies TRPCRouterRecord


### PR DESCRIPTION
## Summary
- Adds `PlexSessionMonitor` service: per-server WebSocket fibers consuming Plex `/:/websockets/notifications`, with exponential-backoff reconnect.
- Pure helpers (`reconcileSessions`, `snapshotSessions`, `buildWsUrl`, `isPlayingNotification`) extracted for unit testing — no test-only escape hatches on the service.
- New `MediaServerSession` domain type + `getActiveSessions` on the adapter interface (Plex impl maps `/status/sessions`; Jellyfin stubbed).
- `monitoringEnabled` setting added to media servers; `startAllEnabled` runs at boot.
- `mediaServers.activeSessions` tRPC query (optional `serverId` filter).

Lays groundwork for #23–#27.

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint` (no new warnings)
- [x] `bun run test` — 226/226 pass, including 17 new monitor tests
- [ ] Manual: connect a real Plex server, start playback, hit `mediaServers.activeSessions`