### PR TITLE
feat: playback session history (closes #23)

### DIFF
--- a/drizzle/0002_yellow_may_parker.sql
+++ b/drizzle/0002_yellow_may_parker.sql
@@ -1,0 +1,52 @@
+CREATE TABLE `session_history` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`media_server_id` integer NOT NULL,
+	`plex_user_id` text NOT NULL,
+	`plex_username` text NOT NULL,
+	`rating_key` text NOT NULL,
+	`media_type` text NOT NULL,
+	`title` text NOT NULL,
+	`parent_title` text,
+	`grandparent_title` text,
+	`year` integer,
+	`thumb` text,
+	`started_at` integer NOT NULL,
+	`stopped_at` integer NOT NULL,
+	`duration` integer NOT NULL,
+	`view_offset` integer NOT NULL,
+	`paused_duration_sec` integer DEFAULT 0 NOT NULL,
+	`transcode_decision` text NOT NULL,
+	`video_resolution` text,
+	`audio_codec` text,
+	`player` text NOT NULL,
+	`platform` text NOT NULL,
+	`product` text,
+	`ip_address` text,
+	`bandwidth` integer,
+	`is_local` integer NOT NULL,
+	`movie_id` integer,
+	`episode_id` integer,
+	FOREIGN KEY (`media_server_id`) REFERENCES `media_servers`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`movie_id`) REFERENCES `movies`(`id`) ON UPDATE no action ON DELETE set null,
+	FOREIGN KEY (`episode_id`) REFERENCES `episodes`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_media_servers` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`name` text NOT NULL,
+	`type` text NOT NULL,
+	`host` text NOT NULL,
+	`port` integer NOT NULL,
+	`token_encrypted` text NOT NULL,
+	`use_ssl` integer DEFAULT false NOT NULL,
+	`enabled` integer DEFAULT true NOT NULL,
+	`settings` text DEFAULT '{"syncIntervalMs":3600000,"monitoringEnabled":true}' NOT NULL,
+	`created_at` integer DEFAULT (unixepoch()) NOT NULL,
+	`updated_at` integer DEFAULT (unixepoch()) NOT NULL
+);
+--> statement-breakpoint
+INSERT INTO `__new_media_servers`("id", "name", "type", "host", "port", "token_encrypted", "use_ssl", "enabled", "settings", "created_at", "updated_at") SELECT "id", "name", "type", "host", "port", "token_encrypted", "use_ssl", "enabled", "settings", "created_at", "updated_at" FROM `media_servers`;--> statement-breakpoint
+DROP TABLE `media_servers`;--> statement-breakpoint
+ALTER TABLE `__new_media_servers` RENAME TO `media_servers`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;

--- a/drizzle/meta/0002_snapshot.json
+++ b/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,2363 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "51f8f04b-5124-491d-ba31-d142fed4053f",
+  "prevId": "7f6e0ff9-1c2e-4cf8-9aef-bcf056f14d14",
+  "tables": {
+    "api_keys": {
+      "name": "api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "api_keys_token_hash_unique": {
+          "name": "api_keys_token_hash_unique",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "api_keys_user_id_users_id_fk": {
+          "name": "api_keys_user_id_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "custom_format_scores": {
+      "name": "custom_format_scores",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "custom_format_id": {
+          "name": "custom_format_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "custom_format_scores_profile_id_custom_format_id_unique": {
+          "name": "custom_format_scores_profile_id_custom_format_id_unique",
+          "columns": [
+            "profile_id",
+            "custom_format_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "custom_format_scores_profile_id_quality_profiles_id_fk": {
+          "name": "custom_format_scores_profile_id_quality_profiles_id_fk",
+          "tableFrom": "custom_format_scores",
+          "tableTo": "quality_profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "custom_format_scores_custom_format_id_custom_formats_id_fk": {
+          "name": "custom_format_scores_custom_format_id_custom_formats_id_fk",
+          "tableFrom": "custom_format_scores",
+          "tableTo": "custom_formats",
+          "columnsFrom": [
+            "custom_format_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "custom_format_specs": {
+      "name": "custom_format_specs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "custom_format_id": {
+          "name": "custom_format_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field": {
+          "name": "field",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "negate": {
+          "name": "negate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "required": {
+          "name": "required",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "custom_format_specs_custom_format_id_custom_formats_id_fk": {
+          "name": "custom_format_specs_custom_format_id_custom_formats_id_fk",
+          "tableFrom": "custom_format_specs",
+          "tableTo": "custom_formats",
+          "columnsFrom": [
+            "custom_format_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "custom_formats": {
+      "name": "custom_formats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "include_when_renaming": {
+          "name": "include_when_renaming",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "custom_formats_name_unique": {
+          "name": "custom_formats_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "download_client_health": {
+      "name": "download_client_health",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "download_client_id": {
+          "name": "download_client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_check": {
+          "name": "last_check",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unknown'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response_time_ms": {
+          "name": "response_time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "download_client_health_download_client_id_unique": {
+          "name": "download_client_health_download_client_id_unique",
+          "columns": [
+            "download_client_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "download_client_health_download_client_id_download_clients_id_fk": {
+          "name": "download_client_health_download_client_id_download_clients_id_fk",
+          "tableFrom": "download_client_health",
+          "tableTo": "download_clients",
+          "columnsFrom": [
+            "download_client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "download_clients": {
+      "name": "download_clients",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "port": {
+          "name": "port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_encrypted": {
+          "name": "password_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "use_ssl": {
+          "name": "use_ssl",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 50
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "settings": {
+          "name": "settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{\"pollIntervalMs\":5000}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "download_queue": {
+      "name": "download_queue",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "download_client_id": {
+          "name": "download_client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "movie_id": {
+          "name": "movie_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "series_id": {
+          "name": "series_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "episode_ids": {
+          "name": "episode_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'queued'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "progress": {
+          "name": "progress",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "eta_seconds": {
+          "name": "eta_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "download_queue_external_id_unique": {
+          "name": "download_queue_external_id_unique",
+          "columns": [
+            "external_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "download_queue_download_client_id_download_clients_id_fk": {
+          "name": "download_queue_download_client_id_download_clients_id_fk",
+          "tableFrom": "download_queue",
+          "tableTo": "download_clients",
+          "columnsFrom": [
+            "download_client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "download_queue_movie_id_movies_id_fk": {
+          "name": "download_queue_movie_id_movies_id_fk",
+          "tableFrom": "download_queue",
+          "tableTo": "movies",
+          "columnsFrom": [
+            "movie_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "download_queue_series_id_series_id_fk": {
+          "name": "download_queue_series_id_series_id_fk",
+          "tableFrom": "download_queue",
+          "tableTo": "series",
+          "columnsFrom": [
+            "series_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "episodes": {
+      "name": "episodes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tvdb_id": {
+          "name": "tvdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "episode_number": {
+          "name": "episode_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "air_date": {
+          "name": "air_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "overview": {
+          "name": "overview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "has_file": {
+          "name": "has_file",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "monitored": {
+          "name": "monitored",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "existing_quality_name": {
+          "name": "existing_quality_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "existing_quality_rank": {
+          "name": "existing_quality_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "existing_format_score": {
+          "name": "existing_format_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "episodes_tvdb_id_unique": {
+          "name": "episodes_tvdb_id_unique",
+          "columns": [
+            "tvdb_id"
+          ],
+          "isUnique": true
+        },
+        "episodes_season_id_episode_number_unique": {
+          "name": "episodes_season_id_episode_number_unique",
+          "columns": [
+            "season_id",
+            "episode_number"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "episodes_season_id_seasons_id_fk": {
+          "name": "episodes_season_id_seasons_id_fk",
+          "tableFrom": "episodes",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "indexer_health": {
+      "name": "indexer_health",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "indexer_id": {
+          "name": "indexer_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_check": {
+          "name": "last_check",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unknown'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response_time_ms": {
+          "name": "response_time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "indexer_health_indexer_id_unique": {
+          "name": "indexer_health_indexer_id_unique",
+          "columns": [
+            "indexer_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "indexer_health_indexer_id_indexers_id_fk": {
+          "name": "indexer_health_indexer_id_indexers_id_fk",
+          "tableFrom": "indexer_health",
+          "tableTo": "indexers",
+          "columnsFrom": [
+            "indexer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "indexers": {
+      "name": "indexers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key_encrypted": {
+          "name": "api_key_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 50
+        },
+        "categories": {
+          "name": "categories",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'null'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media_server_health": {
+      "name": "media_server_health",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "media_server_id": {
+          "name": "media_server_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_check": {
+          "name": "last_check",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unknown'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response_time_ms": {
+          "name": "response_time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "media_server_health_media_server_id_unique": {
+          "name": "media_server_health_media_server_id_unique",
+          "columns": [
+            "media_server_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "media_server_health_media_server_id_media_servers_id_fk": {
+          "name": "media_server_health_media_server_id_media_servers_id_fk",
+          "tableFrom": "media_server_health",
+          "tableTo": "media_servers",
+          "columnsFrom": [
+            "media_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media_server_libraries": {
+      "name": "media_server_libraries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "media_server_id": {
+          "name": "media_server_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "last_synced": {
+          "name": "last_synced",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "media_server_libraries_media_server_id_external_id_unique": {
+          "name": "media_server_libraries_media_server_id_external_id_unique",
+          "columns": [
+            "media_server_id",
+            "external_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "media_server_libraries_media_server_id_media_servers_id_fk": {
+          "name": "media_server_libraries_media_server_id_media_servers_id_fk",
+          "tableFrom": "media_server_libraries",
+          "tableTo": "media_servers",
+          "columnsFrom": [
+            "media_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media_servers": {
+      "name": "media_servers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "port": {
+          "name": "port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_encrypted": {
+          "name": "token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "use_ssl": {
+          "name": "use_ssl",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "settings": {
+          "name": "settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{\"syncIntervalMs\":3600000,\"monitoringEnabled\":true}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "movies": {
+      "name": "movies",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "tmdb_id": {
+          "name": "tmdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "overview": {
+          "name": "overview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "poster_path": {
+          "name": "poster_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'wanted'"
+        },
+        "quality_profile_id": {
+          "name": "quality_profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "root_folder_path": {
+          "name": "root_folder_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "monitored": {
+          "name": "monitored",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "has_file": {
+          "name": "has_file",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "existing_quality_name": {
+          "name": "existing_quality_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "existing_quality_rank": {
+          "name": "existing_quality_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "existing_format_score": {
+          "name": "existing_format_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "movies_tmdb_id_unique": {
+          "name": "movies_tmdb_id_unique",
+          "columns": [
+            "tmdb_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "movies_quality_profile_id_quality_profiles_id_fk": {
+          "name": "movies_quality_profile_id_quality_profiles_id_fk",
+          "tableFrom": "movies",
+          "tableTo": "quality_profiles",
+          "columnsFrom": [
+            "quality_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "quality_items": {
+      "name": "quality_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quality_name": {
+          "name": "quality_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "group_name": {
+          "name": "group_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "allowed": {
+          "name": "allowed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "quality_items_profile_id_quality_profiles_id_fk": {
+          "name": "quality_items_profile_id_quality_profiles_id_fk",
+          "tableFrom": "quality_items",
+          "tableTo": "quality_profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "quality_profiles": {
+      "name": "quality_profiles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "upgrade_allowed": {
+          "name": "upgrade_allowed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "min_format_score": {
+          "name": "min_format_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cutoff_format_score": {
+          "name": "cutoff_format_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "min_upgrade_format_score": {
+          "name": "min_upgrade_format_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "applied_bundle_id": {
+          "name": "applied_bundle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "applied_bundle_version": {
+          "name": "applied_bundle_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "quality_profiles_name_unique": {
+          "name": "quality_profiles_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "release_decisions": {
+      "name": "release_decisions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "candidate_title": {
+          "name": "candidate_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "indexer_id": {
+          "name": "indexer_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "indexer_name": {
+          "name": "indexer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quality_rank": {
+          "name": "quality_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "format_score": {
+          "name": "format_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reasons": {
+          "name": "reasons",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "root_folders": {
+      "name": "root_folders",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "free_space_bytes": {
+          "name": "free_space_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_space_bytes": {
+          "name": "total_space_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "root_folders_path_unique": {
+          "name": "root_folders_path_unique",
+          "columns": [
+            "path"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scheduler_config": {
+      "name": "scheduler_config",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "job_type": {
+          "name": "job_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "interval_minutes": {
+          "name": "interval_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "retry_delay_seconds": {
+          "name": "retry_delay_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 60
+        },
+        "max_retries": {
+          "name": "max_retries",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 3
+        },
+        "backoff_multiplier": {
+          "name": "backoff_multiplier",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "scheduler_config_job_type_unique": {
+          "name": "scheduler_config_job_type_unique",
+          "columns": [
+            "job_type"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scheduler_jobs": {
+      "name": "scheduler_jobs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "job_type": {
+          "name": "job_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 3
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "seasons": {
+      "name": "seasons",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "series_id": {
+          "name": "series_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "season_number": {
+          "name": "season_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "monitored": {
+          "name": "monitored",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "seasons_series_id_season_number_unique": {
+          "name": "seasons_series_id_season_number_unique",
+          "columns": [
+            "series_id",
+            "season_number"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "seasons_series_id_series_id_fk": {
+          "name": "seasons_series_id_series_id_fk",
+          "tableFrom": "seasons",
+          "tableTo": "series",
+          "columnsFrom": [
+            "series_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "series": {
+      "name": "series",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "tvdb_id": {
+          "name": "tvdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "overview": {
+          "name": "overview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "poster_path": {
+          "name": "poster_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'wanted'"
+        },
+        "network": {
+          "name": "network",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "root_folder_path": {
+          "name": "root_folder_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "monitored": {
+          "name": "monitored",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "quality_profile_id": {
+          "name": "quality_profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "season_folder": {
+          "name": "season_folder",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "series_tvdb_id_unique": {
+          "name": "series_tvdb_id_unique",
+          "columns": [
+            "tvdb_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "series_quality_profile_id_quality_profiles_id_fk": {
+          "name": "series_quality_profile_id_quality_profiles_id_fk",
+          "tableFrom": "series",
+          "tableTo": "quality_profiles",
+          "columnsFrom": [
+            "quality_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_history": {
+      "name": "session_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "media_server_id": {
+          "name": "media_server_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plex_user_id": {
+          "name": "plex_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plex_username": {
+          "name": "plex_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rating_key": {
+          "name": "rating_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_title": {
+          "name": "parent_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "grandparent_title": {
+          "name": "grandparent_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thumb": {
+          "name": "thumb",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stopped_at": {
+          "name": "stopped_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "view_offset": {
+          "name": "view_offset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "paused_duration_sec": {
+          "name": "paused_duration_sec",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "transcode_decision": {
+          "name": "transcode_decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "video_resolution": {
+          "name": "video_resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "audio_codec": {
+          "name": "audio_codec",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "player": {
+          "name": "player",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "product": {
+          "name": "product",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bandwidth": {
+          "name": "bandwidth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_local": {
+          "name": "is_local",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "movie_id": {
+          "name": "movie_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "episode_id": {
+          "name": "episode_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_history_media_server_id_media_servers_id_fk": {
+          "name": "session_history_media_server_id_media_servers_id_fk",
+          "tableFrom": "session_history",
+          "tableTo": "media_servers",
+          "columnsFrom": [
+            "media_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_history_movie_id_movies_id_fk": {
+          "name": "session_history_movie_id_movies_id_fk",
+          "tableFrom": "session_history",
+          "tableTo": "movies",
+          "columnsFrom": [
+            "movie_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "session_history_episode_id_episodes_id_fk": {
+          "name": "session_history_episode_id_episodes_id_fk",
+          "tableFrom": "session_history",
+          "tableTo": "episodes",
+          "columnsFrom": [
+            "episode_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "settings": {
+      "name": "settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1776486454140,
       "tag": "0001_wise_violations",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1776488365165,
+      "tag": "0002_yellow_may_parker",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -363,6 +363,40 @@ export const mediaServerLibraries = sqliteTable(
   (t) => [unique().on(t.mediaServerId, t.externalId)],
 )
 
+export const sessionHistory = sqliteTable("session_history", {
+  id: integer().primaryKey({ autoIncrement: true }),
+  mediaServerId: integer("media_server_id")
+    .notNull()
+    .references(() => mediaServers.id, { onDelete: "cascade" }),
+  plexUserId: text("plex_user_id").notNull(),
+  plexUsername: text("plex_username").notNull(),
+  ratingKey: text("rating_key").notNull(),
+  mediaType: text("media_type", { enum: ["movie", "episode"] }).notNull(),
+  title: text().notNull(),
+  parentTitle: text("parent_title"),
+  grandparentTitle: text("grandparent_title"),
+  year: integer(),
+  thumb: text(),
+  startedAt: integer("started_at", { mode: "timestamp" }).notNull(),
+  stoppedAt: integer("stopped_at", { mode: "timestamp" }).notNull(),
+  duration: integer().notNull(),
+  viewOffset: integer("view_offset").notNull(),
+  pausedDurationSec: integer("paused_duration_sec").notNull().default(0),
+  transcodeDecision: text("transcode_decision", {
+    enum: ["direct_play", "direct_stream", "transcode"],
+  }).notNull(),
+  videoResolution: text("video_resolution"),
+  audioCodec: text("audio_codec"),
+  player: text().notNull(),
+  platform: text().notNull(),
+  product: text(),
+  ipAddress: text("ip_address"),
+  bandwidth: integer(),
+  isLocal: integer("is_local", { mode: "boolean" }).notNull(),
+  movieId: integer("movie_id").references(() => movies.id, { onDelete: "set null" }),
+  episodeId: integer("episode_id").references(() => episodes.id, { onDelete: "set null" }),
+})
+
 // ── Release Decisions ──
 
 export const releaseDecisions = sqliteTable("release_decisions", {

--- a/src/effect/domain/mediaServer.ts
+++ b/src/effect/domain/mediaServer.ts
@@ -142,6 +142,9 @@ export interface MediaServerSession {
   readonly isLocal: boolean
   readonly startedAt: Date
   readonly updatedAt: Date
+  /** Parsed from media-server metadata (Plex Guid / Jellyfin ProviderIds); used to FK-link history rows. */
+  readonly tmdbId: number | null
+  readonly tvdbId: number | null
 }
 
 export interface MediaServerLibraryWithSync {

--- a/src/effect/layers.ts
+++ b/src/effect/layers.ts
@@ -18,6 +18,7 @@ import { ReleasePolicyEngineLive } from "./services/ReleasePolicyEngine"
 import { RootFolderServiceLive } from "./services/RootFolderService"
 import { SchedulerServiceLive } from "./services/SchedulerService"
 import { SeriesServiceLive } from "./services/SeriesService"
+import { SessionHistoryServiceLive } from "./services/SessionHistoryService"
 import { TitleParserServiceLive } from "./services/TitleParserService"
 import { TmdbClientLive } from "./services/TmdbClient"
 
@@ -37,6 +38,7 @@ export const AppLive = Layer.mergeAll(
       DownloadClientServiceLive,
       MediaServerServiceLive,
       ReleasePolicyEngineLive,
+      SessionHistoryServiceLive,
     ),
   ),
   Layer.provideMerge(TitleParserServiceLive),

--- a/src/effect/services/PlexAdapter.ts
+++ b/src/effect/services/PlexAdapter.ts
@@ -154,6 +154,7 @@ interface PlexSessionMetadata {
   readonly viewOffset?: number
   readonly duration?: number
   readonly addedAt?: number
+  readonly Guid?: ReadonlyArray<PlexGuid>
   readonly User?: PlexSessionUser
   readonly Player?: PlexSessionPlayer
   readonly Session?: PlexSessionSession
@@ -202,6 +203,7 @@ function mapPlexSession(
   const duration = m.duration ?? 0
   const viewOffset = m.viewOffset ?? 0
   const startedAt = m.addedAt ? new Date(m.addedAt * 1000) : now
+  const guids = parseGuids(m.Guid ?? [])
 
   return {
     mediaServerId: serverId,
@@ -231,6 +233,8 @@ function mapPlexSession(
     isLocal: m.Player?.local ?? false,
     startedAt,
     updatedAt: now,
+    tmdbId: guids.tmdbId,
+    tvdbId: guids.tvdbId,
   }
 }
 

--- a/src/effect/services/PlexSessionMonitor.test.ts
+++ b/src/effect/services/PlexSessionMonitor.test.ts
@@ -5,6 +5,7 @@ import type { MediaServerSession } from "#/effect/domain/mediaServer"
 import { AdapterRegistryLive } from "#/effect/services/AdapterRegistry"
 import { CryptoServiceLive } from "#/effect/services/CryptoService"
 import { MediaServerService, MediaServerServiceLive } from "#/effect/services/MediaServerService"
+import { SessionHistoryServiceLive } from "#/effect/services/SessionHistoryService"
 import { TestDbLive } from "#/effect/test/TestDb"
 
 import {
@@ -46,6 +47,8 @@ const mkSession = (sessionKey: string, serverId = 1): MediaServerSession => ({
   isLocal: true,
   startedAt: new Date(0),
   updatedAt: new Date(0),
+  tmdbId: null,
+  tvdbId: null,
 })
 
 describe("reconcileSessions", () => {
@@ -157,6 +160,7 @@ describe("isPlayingNotification", () => {
 
 const TestLayer = PlexSessionMonitorLive.pipe(
   Layer.provideMerge(MediaServerServiceLive),
+  Layer.provideMerge(SessionHistoryServiceLive),
   Layer.provideMerge(CryptoServiceLive),
   Layer.provideMerge(AdapterRegistryLive),
   Layer.provideMerge(TestDbLive),

--- a/src/effect/services/PlexSessionMonitor.ts
+++ b/src/effect/services/PlexSessionMonitor.ts
@@ -15,6 +15,7 @@ import { AdapterRegistry } from "./AdapterRegistry"
 import { CryptoService } from "./CryptoService"
 import { Db } from "./Db"
 import type { MediaServerAdapter } from "./MediaServerAdapter"
+import { SessionHistoryService } from "./SessionHistoryService"
 
 // ── Notification payload (Plex `/:/websockets/notifications`) ──
 
@@ -116,6 +117,7 @@ export const PlexSessionMonitorLive = Layer.scoped(
     const db = yield* Db
     const crypto = yield* CryptoService
     const registry = yield* AdapterRegistry
+    const history = yield* SessionHistoryService
 
     const sessionsRef = yield* Ref.make<SessionMap>(new Map())
     const fibersRef = yield* Ref.make<FiberMap>(new Map())
@@ -130,9 +132,15 @@ export const PlexSessionMonitorLive = Layer.scoped(
           const result = reconcileSessions(prev, serverId, sessions)
           return [result.stopped, result.map]
         })
-        // Integration point for #23 (Playback Session History): write `stopped` to history.
         if (stopped.length > 0) {
           yield* Effect.log(`[plex-monitor] server=${serverId} sessions ended: ${stopped.length}`)
+          yield* history
+            .writeHistory(stopped)
+            .pipe(
+              Effect.catchAll((e) =>
+                Effect.logWarning(`[plex-monitor] history write failed: ${String(e)}`),
+              ),
+            )
         }
       })
 

--- a/src/effect/services/SessionHistoryService.test.ts
+++ b/src/effect/services/SessionHistoryService.test.ts
@@ -1,0 +1,216 @@
+import { SqlClient } from "@effect/sql"
+import { describe, expect, it } from "@effect/vitest"
+import { Effect, Layer } from "effect"
+
+import type { MediaServerSession } from "#/effect/domain/mediaServer"
+import { SeriesService, SeriesServiceLive } from "#/effect/services/SeriesService"
+import { TestDbLive } from "#/effect/test/TestDb"
+
+import { MovieService, MovieServiceLive } from "./MovieService"
+import { SessionHistoryService, SessionHistoryServiceLive } from "./SessionHistoryService"
+
+const TestLayer = SessionHistoryServiceLive.pipe(
+  Layer.provideMerge(MovieServiceLive),
+  Layer.provideMerge(SeriesServiceLive),
+  Layer.provideMerge(TestDbLive),
+)
+
+/** Insert a media_servers row directly — avoids pulling CryptoService into the test layer. */
+const seedMediaServer = Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient
+  yield* sql`INSERT INTO media_servers (name, type, host, port, token_encrypted) VALUES ('plex', 'plex', '127.0.0.1', 32400, 'enc:tok')`
+  return 1
+})
+
+const baseSession = (overrides: Partial<MediaServerSession> = {}): MediaServerSession => ({
+  mediaServerId: 1,
+  sessionKey: "sk-1",
+  ratingKey: "rk-1",
+  userId: "u-1",
+  username: "alice",
+  userThumb: null,
+  state: "playing",
+  mediaType: "movie",
+  title: "The Movie",
+  parentTitle: null,
+  grandparentTitle: null,
+  year: 2024,
+  thumb: null,
+  viewOffset: 60_000,
+  duration: 100_000,
+  progressPercent: 60,
+  transcodeDecision: "direct_play",
+  videoResolution: "1080",
+  audioCodec: "aac",
+  player: "PlexWeb",
+  platform: "Chrome",
+  product: "Plex Web",
+  ipAddress: "10.0.0.1",
+  bandwidth: 5000,
+  isLocal: true,
+  startedAt: new Date(1_700_000_000_000),
+  updatedAt: new Date(1_700_000_060_000),
+  tmdbId: null,
+  tvdbId: null,
+  ...overrides,
+})
+
+describe("SessionHistoryService", () => {
+  it.effect("writeHistory persists a row with no FK match when GUIDs are null", () =>
+    Effect.gen(function* () {
+      yield* seedMediaServer
+      const svc = yield* SessionHistoryService
+      const rows = yield* svc.writeHistory([baseSession()])
+      expect(rows).toHaveLength(1)
+      expect(rows[0].title).toBe("The Movie")
+      expect(rows[0].movieId).toBeNull()
+      expect(rows[0].episodeId).toBeNull()
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.effect("writeHistory links movieId via tmdbId match", () =>
+    Effect.gen(function* () {
+      yield* seedMediaServer
+      const movies = yield* MovieService
+      const movie = yield* movies.add({ tmdbId: 9999, title: "Matched", year: 2024 })
+
+      const svc = yield* SessionHistoryService
+      const rows = yield* svc.writeHistory([baseSession({ tmdbId: 9999 })])
+      expect(rows[0].movieId).toBe(movie.id)
+      expect(rows[0].episodeId).toBeNull()
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.effect("writeHistory links episodeId via tvdbId match", () =>
+    Effect.gen(function* () {
+      yield* seedMediaServer
+      const seriesSvc = yield* SeriesService
+      const added = yield* seriesSvc.add({
+        tvdbId: 123,
+        title: "Show",
+        seasons: [
+          {
+            seasonNumber: 1,
+            episodes: [{ tvdbId: 4242, title: "Pilot", episodeNumber: 1 }],
+          },
+        ],
+      })
+      const epId = added.seasons[0].episodes[0].id
+
+      const svc = yield* SessionHistoryService
+      const rows = yield* svc.writeHistory([
+        baseSession({ mediaType: "episode", tvdbId: 4242, title: "Pilot" }),
+      ])
+      expect(rows[0].episodeId).toBe(epId)
+      expect(rows[0].movieId).toBeNull()
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.effect("writeHistory drops sessions below the watched threshold", () =>
+    Effect.gen(function* () {
+      yield* seedMediaServer
+      const svc = yield* SessionHistoryService
+      const rows = yield* svc.writeHistory([baseSession({ viewOffset: 0, duration: 100_000 })])
+      expect(rows).toHaveLength(0)
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.effect("writeHistory drops sessions with zero duration", () =>
+    Effect.gen(function* () {
+      yield* seedMediaServer
+      const svc = yield* SessionHistoryService
+      const rows = yield* svc.writeHistory([baseSession({ duration: 0 })])
+      expect(rows).toHaveLength(0)
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.effect("listHistory returns rows newest-first with cursor pagination", () =>
+    Effect.gen(function* () {
+      yield* seedMediaServer
+      const svc = yield* SessionHistoryService
+      yield* svc.writeHistory([
+        baseSession({ sessionKey: "a", title: "A" }),
+        baseSession({ sessionKey: "b", title: "B" }),
+        baseSession({ sessionKey: "c", title: "C" }),
+      ])
+
+      const page1 = yield* svc.listHistory({ limit: 2 })
+      expect(page1.items).toHaveLength(2)
+      expect(page1.items[0].title).toBe("C")
+      expect(page1.items[1].title).toBe("B")
+      expect(page1.nextCursor).not.toBeNull()
+
+      const page2 = yield* svc.listHistory({ limit: 2, cursor: page1.nextCursor })
+      expect(page2.items).toHaveLength(1)
+      expect(page2.items[0].title).toBe("A")
+      expect(page2.nextCursor).toBeNull()
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.effect("listHistory filters by userId and mediaType", () =>
+    Effect.gen(function* () {
+      yield* seedMediaServer
+      const svc = yield* SessionHistoryService
+      yield* svc.writeHistory([
+        baseSession({ sessionKey: "a", userId: "alice", mediaType: "movie" }),
+        baseSession({ sessionKey: "b", userId: "bob", mediaType: "movie" }),
+        baseSession({ sessionKey: "c", userId: "alice", mediaType: "episode" }),
+      ])
+
+      const movies = yield* svc.listHistory({ filters: { mediaType: "movie" } })
+      expect(movies.items).toHaveLength(2)
+
+      const aliceOnly = yield* svc.listHistory({ filters: { userId: "alice" } })
+      expect(aliceOnly.items).toHaveLength(2)
+
+      const aliceMovies = yield* svc.listHistory({
+        filters: { userId: "alice", mediaType: "movie" },
+      })
+      expect(aliceMovies.items).toHaveLength(1)
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.effect("getHistoryForMedia returns watch events for a movie", () =>
+    Effect.gen(function* () {
+      yield* seedMediaServer
+      const movies = yield* MovieService
+      const movie = yield* movies.add({ tmdbId: 1, title: "Solo", year: 2024 })
+
+      const svc = yield* SessionHistoryService
+      yield* svc.writeHistory([
+        baseSession({ tmdbId: 1, sessionKey: "a" }),
+        baseSession({ tmdbId: 1, sessionKey: "b" }),
+        baseSession({ tmdbId: 999, sessionKey: "c" }),
+      ])
+
+      const events = yield* svc.getHistoryForMedia({ kind: "movie", movieId: movie.id })
+      expect(events).toHaveLength(2)
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.effect("getHistoryForMedia returns watch events for an episode", () =>
+    Effect.gen(function* () {
+      yield* seedMediaServer
+      const seriesSvc = yield* SeriesService
+      const added = yield* seriesSvc.add({
+        tvdbId: 200,
+        title: "Show",
+        seasons: [
+          {
+            seasonNumber: 1,
+            episodes: [{ tvdbId: 5000, title: "Pilot", episodeNumber: 1 }],
+          },
+        ],
+      })
+      const epId = added.seasons[0].episodes[0].id
+
+      const svc = yield* SessionHistoryService
+      yield* svc.writeHistory([
+        baseSession({ mediaType: "episode", tvdbId: 5000, sessionKey: "a" }),
+      ])
+
+      const events = yield* svc.getHistoryForMedia({ kind: "episode", episodeId: epId })
+      expect(events).toHaveLength(1)
+    }).pipe(Effect.provide(TestLayer)),
+  )
+})

--- a/src/effect/services/SessionHistoryService.ts
+++ b/src/effect/services/SessionHistoryService.ts
@@ -1,0 +1,191 @@
+import { SqlError } from "@effect/sql/SqlError"
+import { and, between, desc, eq, lt, type SQL } from "drizzle-orm"
+import { Context, Effect, Layer } from "effect"
+
+import { episodes, movies, sessionHistory } from "#/db/schema"
+
+import type { MediaServerSession, SessionMediaType } from "../domain/mediaServer"
+import { Db } from "./Db"
+
+// ── Types ──
+
+export type SessionHistoryRow = typeof sessionHistory.$inferSelect
+
+export interface ListHistoryFilters {
+  readonly userId?: string
+  readonly mediaType?: SessionMediaType
+  readonly mediaServerId?: number
+  readonly start?: Date
+  readonly end?: Date
+}
+
+export interface ListHistoryQuery {
+  readonly filters?: ListHistoryFilters
+  readonly cursor?: number | null
+  readonly limit?: number
+}
+
+export interface ListHistoryResult {
+  readonly items: ReadonlyArray<SessionHistoryRow>
+  readonly nextCursor: number | null
+}
+
+export type MediaRef =
+  | { readonly kind: "movie"; readonly movieId: number }
+  | { readonly kind: "episode"; readonly episodeId: number }
+
+const DEFAULT_LIMIT = 50
+const MAX_LIMIT = 200
+
+// ── Service ──
+
+export class SessionHistoryService extends Context.Tag("@arr-hub/SessionHistoryService")<
+  SessionHistoryService,
+  {
+    /** Persist stopped sessions. Each row is FK-linked to a movie/episode when GUIDs match. */
+    readonly writeHistory: (
+      sessions: ReadonlyArray<MediaServerSession>,
+    ) => Effect.Effect<ReadonlyArray<SessionHistoryRow>, SqlError>
+    readonly listHistory: (query?: ListHistoryQuery) => Effect.Effect<ListHistoryResult, SqlError>
+    readonly getHistoryForMedia: (
+      ref: MediaRef,
+    ) => Effect.Effect<ReadonlyArray<SessionHistoryRow>, SqlError>
+  }
+>() {}
+
+// ── Helpers ──
+
+/** Below this watched fraction we drop the row — likely a quick scrub or accidental open. */
+const MIN_WATCHED_FRACTION = 0.01
+
+function shouldRecord(session: MediaServerSession): boolean {
+  if (session.duration <= 0) return false
+  return session.viewOffset / session.duration >= MIN_WATCHED_FRACTION
+}
+
+// ── Live ──
+
+export const SessionHistoryServiceLive = Layer.effect(
+  SessionHistoryService,
+  Effect.gen(function* () {
+    const db = yield* Db
+
+    const resolveMovieId = (tmdbId: number | null): Effect.Effect<number | null, SqlError> =>
+      tmdbId === null
+        ? Effect.succeed(null)
+        : Effect.gen(function* () {
+            const rows = yield* db
+              .select({ id: movies.id })
+              .from(movies)
+              .where(eq(movies.tmdbId, tmdbId))
+            return rows[0]?.id ?? null
+          })
+
+    const resolveEpisodeId = (tvdbId: number | null): Effect.Effect<number | null, SqlError> =>
+      tvdbId === null
+        ? Effect.succeed(null)
+        : Effect.gen(function* () {
+            const rows = yield* db
+              .select({ id: episodes.id })
+              .from(episodes)
+              .where(eq(episodes.tvdbId, tvdbId))
+            return rows[0]?.id ?? null
+          })
+
+    return {
+      writeHistory: (sessions) =>
+        Effect.gen(function* () {
+          const out: Array<SessionHistoryRow> = []
+          const stoppedAt = new Date()
+
+          for (const s of sessions) {
+            if (!shouldRecord(s)) continue
+
+            const movieId = s.mediaType === "movie" ? yield* resolveMovieId(s.tmdbId) : null
+            const episodeId = s.mediaType === "episode" ? yield* resolveEpisodeId(s.tvdbId) : null
+
+            const [row] = yield* db
+              .insert(sessionHistory)
+              .values({
+                mediaServerId: s.mediaServerId,
+                plexUserId: s.userId,
+                plexUsername: s.username,
+                ratingKey: s.ratingKey,
+                mediaType: s.mediaType,
+                title: s.title,
+                parentTitle: s.parentTitle,
+                grandparentTitle: s.grandparentTitle,
+                year: s.year,
+                thumb: s.thumb,
+                startedAt: s.startedAt,
+                stoppedAt,
+                duration: s.duration,
+                viewOffset: s.viewOffset,
+                pausedDurationSec: 0,
+                transcodeDecision: s.transcodeDecision,
+                videoResolution: s.videoResolution,
+                audioCodec: s.audioCodec,
+                player: s.player,
+                platform: s.platform,
+                product: s.product,
+                ipAddress: s.ipAddress,
+                bandwidth: s.bandwidth,
+                isLocal: s.isLocal,
+                movieId,
+                episodeId,
+              })
+              .returning()
+            out.push(row)
+          }
+
+          return out
+        }),
+
+      listHistory: (query) =>
+        Effect.gen(function* () {
+          const limit = Math.min(MAX_LIMIT, Math.max(1, query?.limit ?? DEFAULT_LIMIT))
+          const conditions: Array<SQL> = []
+          const filters = query?.filters
+
+          if (filters?.userId) conditions.push(eq(sessionHistory.plexUserId, filters.userId))
+          if (filters?.mediaType) conditions.push(eq(sessionHistory.mediaType, filters.mediaType))
+          if (filters?.mediaServerId !== undefined)
+            conditions.push(eq(sessionHistory.mediaServerId, filters.mediaServerId))
+          if (filters?.start && filters?.end)
+            conditions.push(between(sessionHistory.stoppedAt, filters.start, filters.end))
+
+          if (query?.cursor !== undefined && query.cursor !== null)
+            conditions.push(lt(sessionHistory.id, query.cursor))
+
+          const where = conditions.length > 0 ? and(...conditions) : undefined
+
+          const rows = yield* db
+            .select()
+            .from(sessionHistory)
+            .where(where)
+            .orderBy(desc(sessionHistory.id))
+            .limit(limit + 1)
+
+          const hasMore = rows.length > limit
+          const items = hasMore ? rows.slice(0, limit) : rows
+          const nextCursor = hasMore ? (items[items.length - 1]?.id ?? null) : null
+
+          return { items, nextCursor }
+        }),
+
+      getHistoryForMedia: (ref) =>
+        Effect.gen(function* () {
+          const where =
+            ref.kind === "movie"
+              ? eq(sessionHistory.movieId, ref.movieId)
+              : eq(sessionHistory.episodeId, ref.episodeId)
+
+          return yield* db
+            .select()
+            .from(sessionHistory)
+            .where(where)
+            .orderBy(desc(sessionHistory.stoppedAt))
+        }),
+    }
+  }),
+)

--- a/src/effect/test/TestDb.ts
+++ b/src/effect/test/TestDb.ts
@@ -254,6 +254,36 @@ const runDdl = Effect.gen(function* () {
     UNIQUE(media_server_id, external_id)
   )`
 
+  yield* sql`CREATE TABLE session_history (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    media_server_id INTEGER NOT NULL REFERENCES media_servers(id) ON DELETE CASCADE,
+    plex_user_id TEXT NOT NULL,
+    plex_username TEXT NOT NULL,
+    rating_key TEXT NOT NULL,
+    media_type TEXT NOT NULL,
+    title TEXT NOT NULL,
+    parent_title TEXT,
+    grandparent_title TEXT,
+    year INTEGER,
+    thumb TEXT,
+    started_at INTEGER NOT NULL,
+    stopped_at INTEGER NOT NULL,
+    duration INTEGER NOT NULL,
+    view_offset INTEGER NOT NULL,
+    paused_duration_sec INTEGER NOT NULL DEFAULT 0,
+    transcode_decision TEXT NOT NULL,
+    video_resolution TEXT,
+    audio_codec TEXT,
+    player TEXT NOT NULL,
+    platform TEXT NOT NULL,
+    product TEXT,
+    ip_address TEXT,
+    bandwidth INTEGER,
+    is_local INTEGER NOT NULL,
+    movie_id INTEGER REFERENCES movies(id) ON DELETE SET NULL,
+    episode_id INTEGER REFERENCES episodes(id) ON DELETE SET NULL
+  )`
+
   yield* sql`CREATE TABLE release_decisions (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     media_id INTEGER NOT NULL,

--- a/src/integrations/trpc/router.ts
+++ b/src/integrations/trpc/router.ts
@@ -2,6 +2,7 @@ import { createTRPCRouter } from "./init"
 import { authRouter } from "./routers/auth"
 import { downloadClientsRouter } from "./routers/downloadClients"
 import { formatsRouter } from "./routers/formats"
+import { historyRouter } from "./routers/history"
 import { indexersRouter } from "./routers/indexers"
 import { mediaServersRouter } from "./routers/mediaServers"
 import { moviesRouter } from "./routers/movies"
@@ -21,6 +22,7 @@ export const trpcRouter = createTRPCRouter({
   indexers: indexersRouter,
   downloadClients: downloadClientsRouter,
   mediaServers: mediaServersRouter,
+  history: historyRouter,
   releases: releasesRouter,
   rootFolders: rootFoldersRouter,
   scheduler: schedulerRouter,

--- a/src/integrations/trpc/routers/history.ts
+++ b/src/integrations/trpc/routers/history.ts
@@ -1,0 +1,48 @@
+import type { TRPCRouterRecord } from "@trpc/server"
+import { Effect } from "effect"
+import { z } from "zod"
+
+import { SessionHistoryService } from "#/effect/services/SessionHistoryService"
+
+import { authedProcedure, runEffect } from "../init"
+
+const listInputSchema = z
+  .object({
+    cursor: z.number().int().nullish(),
+    limit: z.number().int().min(1).max(200).optional(),
+    filters: z
+      .object({
+        userId: z.string().optional(),
+        mediaType: z.enum(["movie", "episode"]).optional(),
+        mediaServerId: z.number().int().optional(),
+        start: z.date().optional(),
+        end: z.date().optional(),
+      })
+      .optional(),
+  })
+  .optional()
+
+const forMediaInputSchema = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("movie"), movieId: z.number().int() }),
+  z.object({ kind: z.literal("episode"), episodeId: z.number().int() }),
+])
+
+export const historyRouter = {
+  list: authedProcedure.input(listInputSchema).query(({ input }) =>
+    runEffect(
+      Effect.gen(function* () {
+        const svc = yield* SessionHistoryService
+        return yield* svc.listHistory(input ?? undefined)
+      }),
+    ),
+  ),
+
+  getForMedia: authedProcedure.input(forMediaInputSchema).query(({ input }) =>
+    runEffect(
+      Effect.gen(function* () {
+        const svc = yield* SessionHistoryService
+        return yield* svc.getHistoryForMedia(input)
+      }),
+    ),
+  ),
+} satisfies TRPCRouterRecord

--- a/src/routes/activity/history.tsx
+++ b/src/routes/activity/history.tsx
@@ -1,12 +1,152 @@
+import { useQuery } from "@tanstack/react-query"
 import { createFileRoute } from "@tanstack/react-router"
+import { useState } from "react"
+
+import { useTRPC } from "#/integrations/trpc/react"
 
 export const Route = createFileRoute("/activity/history")({ component: History })
 
+type MediaTypeFilter = "all" | "movie" | "episode"
+
 function History() {
+  const trpc = useTRPC()
+  const [mediaType, setMediaType] = useState<MediaTypeFilter>("all")
+  const [cursor, setCursor] = useState<number | null>(null)
+  const [stack, setStack] = useState<ReadonlyArray<number | null>>([])
+
+  const query = useQuery(
+    trpc.history.list.queryOptions({
+      cursor,
+      limit: 50,
+      filters: mediaType === "all" ? undefined : { mediaType },
+    }),
+  )
+
+  const onMediaTypeChange = (next: MediaTypeFilter) => {
+    setMediaType(next)
+    setCursor(null)
+    setStack([])
+  }
+
+  const onNext = () => {
+    if (query.data?.nextCursor === null || query.data?.nextCursor === undefined) return
+    setStack((s) => [...s, cursor])
+    setCursor(query.data.nextCursor)
+  }
+
+  const onPrev = () => {
+    if (stack.length === 0) return
+    const prev = stack[stack.length - 1] ?? null
+    setStack((s) => s.slice(0, -1))
+    setCursor(prev)
+  }
+
   return (
     <div className="p-6">
-      <h1 className="text-2xl font-bold">History</h1>
-      <p className="text-muted-foreground mt-1">Download and import history</p>
+      <header className="mb-4 flex items-end justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold">History</h1>
+          <p className="text-muted-foreground mt-1">Playback session history</p>
+        </div>
+        <div className="flex items-center gap-2 text-sm">
+          <label htmlFor="mediaType" className="text-muted-foreground">
+            Type
+          </label>
+          <select
+            id="mediaType"
+            className="bg-background rounded border px-2 py-1"
+            value={mediaType}
+            onChange={(e) => onMediaTypeChange(e.target.value as MediaTypeFilter)}
+          >
+            <option value="all">All</option>
+            <option value="movie">Movies</option>
+            <option value="episode">Episodes</option>
+          </select>
+        </div>
+      </header>
+
+      {query.isLoading && <p className="text-muted-foreground">Loading…</p>}
+      {query.error && (
+        <p className="text-destructive">Failed to load history: {query.error.message}</p>
+      )}
+
+      {query.data && query.data.items.length === 0 && (
+        <p className="text-muted-foreground">No playback history yet.</p>
+      )}
+
+      {query.data && query.data.items.length > 0 && (
+        <div className="overflow-hidden rounded-md border">
+          <table className="w-full text-sm">
+            <thead className="bg-muted/50 text-muted-foreground">
+              <tr>
+                <th className="px-3 py-2 text-left font-medium">User</th>
+                <th className="px-3 py-2 text-left font-medium">Title</th>
+                <th className="px-3 py-2 text-left font-medium">Type</th>
+                <th className="px-3 py-2 text-left font-medium">Player</th>
+                <th className="px-3 py-2 text-left font-medium">Decision</th>
+                <th className="px-3 py-2 text-right font-medium">Watched</th>
+                <th className="px-3 py-2 text-right font-medium">Stopped</th>
+                <th className="px-3 py-2 text-left font-medium">Match</th>
+              </tr>
+            </thead>
+            <tbody>
+              {query.data.items.map((row) => {
+                const watchedPct =
+                  row.duration > 0
+                    ? Math.min(100, Math.round((row.viewOffset / row.duration) * 100))
+                    : 0
+                const matched = row.movieId !== null || row.episodeId !== null
+                const display =
+                  row.mediaType === "episode" && row.grandparentTitle
+                    ? `${row.grandparentTitle} — ${row.title}`
+                    : row.title
+                return (
+                  <tr key={row.id} className="border-t">
+                    <td className="px-3 py-2">{row.plexUsername}</td>
+                    <td className="px-3 py-2">{display}</td>
+                    <td className="px-3 py-2">{row.mediaType}</td>
+                    <td className="px-3 py-2">
+                      {row.player}
+                      <span className="text-muted-foreground"> · {row.platform}</span>
+                    </td>
+                    <td className="px-3 py-2">{row.transcodeDecision}</td>
+                    <td className="px-3 py-2 text-right">{watchedPct}%</td>
+                    <td className="text-muted-foreground px-3 py-2 text-right">
+                      {new Date(row.stoppedAt).toLocaleString()}
+                    </td>
+                    <td className="px-3 py-2">
+                      {matched ? (
+                        <span className="text-xs text-green-500">linked</span>
+                      ) : (
+                        <span className="text-muted-foreground text-xs">unmonitored</span>
+                      )}
+                    </td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <div className="mt-4 flex items-center justify-between">
+        <button
+          type="button"
+          onClick={onPrev}
+          disabled={stack.length === 0}
+          className="rounded border px-3 py-1 text-sm disabled:opacity-50"
+        >
+          ← Previous
+        </button>
+        <button
+          type="button"
+          onClick={onNext}
+          disabled={!query.data?.nextCursor}
+          className="rounded border px-3 py-1 text-sm disabled:opacity-50"
+        >
+          Next →
+        </button>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- New `session_history` table + `SessionHistoryService` persisting stopped Plex sessions, FK-linked to monitored movies/episodes via tmdb/tvdb GUID match.
- `PlexSessionMonitor` now writes history on session end (best-effort; failures logged, not fatal).
- `history` tRPC router (`list`, `getForMedia`) + `/activity/history` UI page with mediaType filter and cursor pagination.

## Test plan
- [x] `bun run test` — 235/235 pass (9 new SessionHistoryService tests cover write/filter/pagination/FK matching)
- [x] `bun run typecheck` clean
- [x] `bun run lint` — 0 errors (5 pre-existing react-perf warnings on the new page; non-blocking)
- [ ] Manual: connect Plex, start playback, stop it, confirm row appears in `/activity/history` with linked badge for monitored titles.