### PR TITLE
feat: onboarding orchestrator (closes #12)

### DIFF
--- a/drizzle/0003_hard_morph.sql
+++ b/drizzle/0003_hard_morph.sql
@@ -1,0 +1,20 @@
+CREATE TABLE `setup_log` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`step_name` text NOT NULL,
+	`action` text NOT NULL,
+	`result` text NOT NULL,
+	`message` text,
+	`reversible` integer DEFAULT false NOT NULL,
+	`rolled_back` integer DEFAULT false NOT NULL,
+	`created_at` integer DEFAULT (unixepoch()) NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE `setup_state` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`path` text,
+	`current_step` text,
+	`completed_steps` text DEFAULT '[]' NOT NULL,
+	`capabilities` text DEFAULT '{"movies":true,"tv":true}' NOT NULL,
+	`started_at` integer DEFAULT (unixepoch()) NOT NULL,
+	`completed_at` integer
+);

--- a/drizzle/meta/0003_snapshot.json
+++ b/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,2494 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "0d13a62a-b756-467e-ba63-8100044e7d12",
+  "prevId": "51f8f04b-5124-491d-ba31-d142fed4053f",
+  "tables": {
+    "api_keys": {
+      "name": "api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "api_keys_token_hash_unique": {
+          "name": "api_keys_token_hash_unique",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "api_keys_user_id_users_id_fk": {
+          "name": "api_keys_user_id_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "custom_format_scores": {
+      "name": "custom_format_scores",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "custom_format_id": {
+          "name": "custom_format_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "custom_format_scores_profile_id_custom_format_id_unique": {
+          "name": "custom_format_scores_profile_id_custom_format_id_unique",
+          "columns": [
+            "profile_id",
+            "custom_format_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "custom_format_scores_profile_id_quality_profiles_id_fk": {
+          "name": "custom_format_scores_profile_id_quality_profiles_id_fk",
+          "tableFrom": "custom_format_scores",
+          "tableTo": "quality_profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "custom_format_scores_custom_format_id_custom_formats_id_fk": {
+          "name": "custom_format_scores_custom_format_id_custom_formats_id_fk",
+          "tableFrom": "custom_format_scores",
+          "tableTo": "custom_formats",
+          "columnsFrom": [
+            "custom_format_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "custom_format_specs": {
+      "name": "custom_format_specs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "custom_format_id": {
+          "name": "custom_format_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field": {
+          "name": "field",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "negate": {
+          "name": "negate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "required": {
+          "name": "required",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "custom_format_specs_custom_format_id_custom_formats_id_fk": {
+          "name": "custom_format_specs_custom_format_id_custom_formats_id_fk",
+          "tableFrom": "custom_format_specs",
+          "tableTo": "custom_formats",
+          "columnsFrom": [
+            "custom_format_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "custom_formats": {
+      "name": "custom_formats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "include_when_renaming": {
+          "name": "include_when_renaming",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "custom_formats_name_unique": {
+          "name": "custom_formats_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "download_client_health": {
+      "name": "download_client_health",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "download_client_id": {
+          "name": "download_client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_check": {
+          "name": "last_check",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unknown'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response_time_ms": {
+          "name": "response_time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "download_client_health_download_client_id_unique": {
+          "name": "download_client_health_download_client_id_unique",
+          "columns": [
+            "download_client_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "download_client_health_download_client_id_download_clients_id_fk": {
+          "name": "download_client_health_download_client_id_download_clients_id_fk",
+          "tableFrom": "download_client_health",
+          "tableTo": "download_clients",
+          "columnsFrom": [
+            "download_client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "download_clients": {
+      "name": "download_clients",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "port": {
+          "name": "port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_encrypted": {
+          "name": "password_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "use_ssl": {
+          "name": "use_ssl",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 50
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "settings": {
+          "name": "settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{\"pollIntervalMs\":5000}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "download_queue": {
+      "name": "download_queue",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "download_client_id": {
+          "name": "download_client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "movie_id": {
+          "name": "movie_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "series_id": {
+          "name": "series_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "episode_ids": {
+          "name": "episode_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'queued'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "progress": {
+          "name": "progress",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "eta_seconds": {
+          "name": "eta_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "download_queue_external_id_unique": {
+          "name": "download_queue_external_id_unique",
+          "columns": [
+            "external_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "download_queue_download_client_id_download_clients_id_fk": {
+          "name": "download_queue_download_client_id_download_clients_id_fk",
+          "tableFrom": "download_queue",
+          "tableTo": "download_clients",
+          "columnsFrom": [
+            "download_client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "download_queue_movie_id_movies_id_fk": {
+          "name": "download_queue_movie_id_movies_id_fk",
+          "tableFrom": "download_queue",
+          "tableTo": "movies",
+          "columnsFrom": [
+            "movie_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "download_queue_series_id_series_id_fk": {
+          "name": "download_queue_series_id_series_id_fk",
+          "tableFrom": "download_queue",
+          "tableTo": "series",
+          "columnsFrom": [
+            "series_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "episodes": {
+      "name": "episodes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tvdb_id": {
+          "name": "tvdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "episode_number": {
+          "name": "episode_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "air_date": {
+          "name": "air_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "overview": {
+          "name": "overview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "has_file": {
+          "name": "has_file",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "monitored": {
+          "name": "monitored",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "existing_quality_name": {
+          "name": "existing_quality_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "existing_quality_rank": {
+          "name": "existing_quality_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "existing_format_score": {
+          "name": "existing_format_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "episodes_tvdb_id_unique": {
+          "name": "episodes_tvdb_id_unique",
+          "columns": [
+            "tvdb_id"
+          ],
+          "isUnique": true
+        },
+        "episodes_season_id_episode_number_unique": {
+          "name": "episodes_season_id_episode_number_unique",
+          "columns": [
+            "season_id",
+            "episode_number"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "episodes_season_id_seasons_id_fk": {
+          "name": "episodes_season_id_seasons_id_fk",
+          "tableFrom": "episodes",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "indexer_health": {
+      "name": "indexer_health",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "indexer_id": {
+          "name": "indexer_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_check": {
+          "name": "last_check",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unknown'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response_time_ms": {
+          "name": "response_time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "indexer_health_indexer_id_unique": {
+          "name": "indexer_health_indexer_id_unique",
+          "columns": [
+            "indexer_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "indexer_health_indexer_id_indexers_id_fk": {
+          "name": "indexer_health_indexer_id_indexers_id_fk",
+          "tableFrom": "indexer_health",
+          "tableTo": "indexers",
+          "columnsFrom": [
+            "indexer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "indexers": {
+      "name": "indexers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key_encrypted": {
+          "name": "api_key_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 50
+        },
+        "categories": {
+          "name": "categories",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'null'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media_server_health": {
+      "name": "media_server_health",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "media_server_id": {
+          "name": "media_server_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_check": {
+          "name": "last_check",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unknown'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response_time_ms": {
+          "name": "response_time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "media_server_health_media_server_id_unique": {
+          "name": "media_server_health_media_server_id_unique",
+          "columns": [
+            "media_server_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "media_server_health_media_server_id_media_servers_id_fk": {
+          "name": "media_server_health_media_server_id_media_servers_id_fk",
+          "tableFrom": "media_server_health",
+          "tableTo": "media_servers",
+          "columnsFrom": [
+            "media_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media_server_libraries": {
+      "name": "media_server_libraries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "media_server_id": {
+          "name": "media_server_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "last_synced": {
+          "name": "last_synced",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "media_server_libraries_media_server_id_external_id_unique": {
+          "name": "media_server_libraries_media_server_id_external_id_unique",
+          "columns": [
+            "media_server_id",
+            "external_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "media_server_libraries_media_server_id_media_servers_id_fk": {
+          "name": "media_server_libraries_media_server_id_media_servers_id_fk",
+          "tableFrom": "media_server_libraries",
+          "tableTo": "media_servers",
+          "columnsFrom": [
+            "media_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media_servers": {
+      "name": "media_servers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "port": {
+          "name": "port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_encrypted": {
+          "name": "token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "use_ssl": {
+          "name": "use_ssl",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "settings": {
+          "name": "settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{\"syncIntervalMs\":3600000,\"monitoringEnabled\":true}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "movies": {
+      "name": "movies",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "tmdb_id": {
+          "name": "tmdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "overview": {
+          "name": "overview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "poster_path": {
+          "name": "poster_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'wanted'"
+        },
+        "quality_profile_id": {
+          "name": "quality_profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "root_folder_path": {
+          "name": "root_folder_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "monitored": {
+          "name": "monitored",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "has_file": {
+          "name": "has_file",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "existing_quality_name": {
+          "name": "existing_quality_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "existing_quality_rank": {
+          "name": "existing_quality_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "existing_format_score": {
+          "name": "existing_format_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "movies_tmdb_id_unique": {
+          "name": "movies_tmdb_id_unique",
+          "columns": [
+            "tmdb_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "movies_quality_profile_id_quality_profiles_id_fk": {
+          "name": "movies_quality_profile_id_quality_profiles_id_fk",
+          "tableFrom": "movies",
+          "tableTo": "quality_profiles",
+          "columnsFrom": [
+            "quality_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "quality_items": {
+      "name": "quality_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quality_name": {
+          "name": "quality_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "group_name": {
+          "name": "group_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "allowed": {
+          "name": "allowed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "quality_items_profile_id_quality_profiles_id_fk": {
+          "name": "quality_items_profile_id_quality_profiles_id_fk",
+          "tableFrom": "quality_items",
+          "tableTo": "quality_profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "quality_profiles": {
+      "name": "quality_profiles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "upgrade_allowed": {
+          "name": "upgrade_allowed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "min_format_score": {
+          "name": "min_format_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cutoff_format_score": {
+          "name": "cutoff_format_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "min_upgrade_format_score": {
+          "name": "min_upgrade_format_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "applied_bundle_id": {
+          "name": "applied_bundle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "applied_bundle_version": {
+          "name": "applied_bundle_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "quality_profiles_name_unique": {
+          "name": "quality_profiles_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "release_decisions": {
+      "name": "release_decisions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "candidate_title": {
+          "name": "candidate_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "indexer_id": {
+          "name": "indexer_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "indexer_name": {
+          "name": "indexer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quality_rank": {
+          "name": "quality_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "format_score": {
+          "name": "format_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reasons": {
+          "name": "reasons",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "root_folders": {
+      "name": "root_folders",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "free_space_bytes": {
+          "name": "free_space_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_space_bytes": {
+          "name": "total_space_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "root_folders_path_unique": {
+          "name": "root_folders_path_unique",
+          "columns": [
+            "path"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scheduler_config": {
+      "name": "scheduler_config",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "job_type": {
+          "name": "job_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "interval_minutes": {
+          "name": "interval_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "retry_delay_seconds": {
+          "name": "retry_delay_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 60
+        },
+        "max_retries": {
+          "name": "max_retries",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 3
+        },
+        "backoff_multiplier": {
+          "name": "backoff_multiplier",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "scheduler_config_job_type_unique": {
+          "name": "scheduler_config_job_type_unique",
+          "columns": [
+            "job_type"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scheduler_jobs": {
+      "name": "scheduler_jobs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "job_type": {
+          "name": "job_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 3
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "seasons": {
+      "name": "seasons",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "series_id": {
+          "name": "series_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "season_number": {
+          "name": "season_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "monitored": {
+          "name": "monitored",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "seasons_series_id_season_number_unique": {
+          "name": "seasons_series_id_season_number_unique",
+          "columns": [
+            "series_id",
+            "season_number"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "seasons_series_id_series_id_fk": {
+          "name": "seasons_series_id_series_id_fk",
+          "tableFrom": "seasons",
+          "tableTo": "series",
+          "columnsFrom": [
+            "series_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "series": {
+      "name": "series",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "tvdb_id": {
+          "name": "tvdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "overview": {
+          "name": "overview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "poster_path": {
+          "name": "poster_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'wanted'"
+        },
+        "network": {
+          "name": "network",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "root_folder_path": {
+          "name": "root_folder_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "monitored": {
+          "name": "monitored",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "quality_profile_id": {
+          "name": "quality_profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "season_folder": {
+          "name": "season_folder",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "series_tvdb_id_unique": {
+          "name": "series_tvdb_id_unique",
+          "columns": [
+            "tvdb_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "series_quality_profile_id_quality_profiles_id_fk": {
+          "name": "series_quality_profile_id_quality_profiles_id_fk",
+          "tableFrom": "series",
+          "tableTo": "quality_profiles",
+          "columnsFrom": [
+            "quality_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_history": {
+      "name": "session_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "media_server_id": {
+          "name": "media_server_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plex_user_id": {
+          "name": "plex_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plex_username": {
+          "name": "plex_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rating_key": {
+          "name": "rating_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_title": {
+          "name": "parent_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "grandparent_title": {
+          "name": "grandparent_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thumb": {
+          "name": "thumb",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stopped_at": {
+          "name": "stopped_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "view_offset": {
+          "name": "view_offset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "paused_duration_sec": {
+          "name": "paused_duration_sec",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "transcode_decision": {
+          "name": "transcode_decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "video_resolution": {
+          "name": "video_resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "audio_codec": {
+          "name": "audio_codec",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "player": {
+          "name": "player",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "product": {
+          "name": "product",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bandwidth": {
+          "name": "bandwidth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_local": {
+          "name": "is_local",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "movie_id": {
+          "name": "movie_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "episode_id": {
+          "name": "episode_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_history_media_server_id_media_servers_id_fk": {
+          "name": "session_history_media_server_id_media_servers_id_fk",
+          "tableFrom": "session_history",
+          "tableTo": "media_servers",
+          "columnsFrom": [
+            "media_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_history_movie_id_movies_id_fk": {
+          "name": "session_history_movie_id_movies_id_fk",
+          "tableFrom": "session_history",
+          "tableTo": "movies",
+          "columnsFrom": [
+            "movie_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "session_history_episode_id_episodes_id_fk": {
+          "name": "session_history_episode_id_episodes_id_fk",
+          "tableFrom": "session_history",
+          "tableTo": "episodes",
+          "columnsFrom": [
+            "episode_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "settings": {
+      "name": "settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "setup_log": {
+      "name": "setup_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "step_name": {
+          "name": "step_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reversible": {
+          "name": "reversible",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "rolled_back": {
+          "name": "rolled_back",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "setup_state": {
+      "name": "setup_state",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "current_step": {
+          "name": "current_step",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_steps": {
+          "name": "completed_steps",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{\"movies\":true,\"tv\":true}'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1776488365165,
       "tag": "0002_yellow_may_parker",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "6",
+      "when": 1776489632438,
+      "tag": "0003_hard_morph",
+      "breakpoints": true
     }
   ]
 }

--- a/src/components/auth-guard.tsx
+++ b/src/components/auth-guard.tsx
@@ -1,0 +1,55 @@
+import { useQuery } from "@tanstack/react-query"
+import { useNavigate, useRouterState } from "@tanstack/react-router"
+import { useEffect } from "react"
+
+import { useTRPC } from "#/integrations/trpc/react"
+import { hasAuthToken } from "#/lib/auth-token"
+
+const UNAUTHED_PATH_PREFIXES = ["/onboarding", "/login"]
+
+/**
+ * Redirects on first launch (no onboarding) or missing auth token.
+ * Also passes through for allow-listed unauthed paths.
+ */
+export function AuthGuard({ children }: { children: React.ReactNode }) {
+  const trpc = useTRPC()
+  const navigate = useNavigate()
+  const pathname = useRouterState({ select: (s) => s.location.pathname })
+
+  const isUnauthedPath = UNAUTHED_PATH_PREFIXES.some((p) => pathname.startsWith(p))
+
+  const status = useQuery({
+    ...trpc.onboarding.status.queryOptions(),
+    staleTime: 5_000,
+  })
+
+  useEffect(() => {
+    if (!status.data) return
+
+    // First launch: no onboarding complete → go to /onboarding
+    if (!status.data.completed) {
+      if (!pathname.startsWith("/onboarding")) {
+        void navigate({ to: "/onboarding" })
+      }
+      return
+    }
+
+    // Onboarded but on onboarding page — bounce to dashboard
+    if (status.data.completed && pathname.startsWith("/onboarding")) {
+      void navigate({ to: "/" })
+      return
+    }
+
+    // Onboarded but no auth token — go to /login
+    if (status.data.completed && !hasAuthToken() && !isUnauthedPath) {
+      void navigate({ to: "/login" })
+    }
+  }, [status.data, pathname, navigate, isUnauthedPath])
+
+  return <>{children}</>
+}
+
+export function useHideShell(): boolean {
+  const pathname = useRouterState({ select: (s) => s.location.pathname })
+  return UNAUTHED_PATH_PREFIXES.some((p) => pathname.startsWith(p))
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -430,6 +430,39 @@ export const schedulerConfig = sqliteTable("scheduler_config", {
   enabled: integer({ mode: "boolean" }).notNull().default(true),
 })
 
+// ── Onboarding ──
+
+export const setupState = sqliteTable("setup_state", {
+  id: integer().primaryKey({ autoIncrement: true }),
+  path: text({ enum: ["quickstart", "wizard"] }),
+  currentStep: text("current_step"),
+  completedSteps: text("completed_steps", { mode: "json" })
+    .$type<ReadonlyArray<string>>()
+    .notNull()
+    .default(sql`'[]'`),
+  capabilities: text({ mode: "json" })
+    .$type<{ readonly movies: boolean; readonly tv: boolean }>()
+    .notNull()
+    .default(sql`'{"movies":true,"tv":true}'`),
+  startedAt: integer("started_at", { mode: "timestamp" })
+    .notNull()
+    .default(sql`(unixepoch())`),
+  completedAt: integer("completed_at", { mode: "timestamp" }),
+})
+
+export const setupLog = sqliteTable("setup_log", {
+  id: integer().primaryKey({ autoIncrement: true }),
+  stepName: text("step_name").notNull(),
+  action: text().notNull(),
+  result: text({ enum: ["success", "failure", "skipped"] }).notNull(),
+  message: text(),
+  reversible: integer({ mode: "boolean" }).notNull().default(false),
+  rolledBack: integer("rolled_back", { mode: "boolean" }).notNull().default(false),
+  createdAt: integer("created_at", { mode: "timestamp" })
+    .notNull()
+    .default(sql`(unixepoch())`),
+})
+
 export const schedulerJobs = sqliteTable("scheduler_jobs", {
   id: integer().primaryKey({ autoIncrement: true }),
   jobType: text("job_type").$type<SchedulerJobType>().notNull(),

--- a/src/effect/errors.ts
+++ b/src/effect/errors.ts
@@ -123,3 +123,16 @@ export class MetadataError extends Data.TaggedError("MetadataError")<{
   readonly message: string
   readonly retryable: boolean
 }> {}
+
+export type OnboardingErrorReason =
+  | "already_complete"
+  | "not_started"
+  | "invalid_step"
+  | "step_out_of_order"
+  | "integration_test_failed"
+  | "admin_already_exists"
+
+export class OnboardingError extends Data.TaggedError("OnboardingError")<{
+  readonly reason: OnboardingErrorReason
+  readonly message: string
+}> {}

--- a/src/effect/layers.ts
+++ b/src/effect/layers.ts
@@ -11,6 +11,7 @@ import { DownloadMonitorLive } from "./services/DownloadMonitor"
 import { IndexerServiceLive } from "./services/IndexerService"
 import { MediaServerServiceLive } from "./services/MediaServerService"
 import { MovieServiceLive } from "./services/MovieService"
+import { OnboardingServiceLive } from "./services/OnboardingService"
 import { PlexSessionMonitorLive } from "./services/PlexSessionMonitor"
 import { ProfileDefaultsEngineLive } from "./services/ProfileDefaultsEngine"
 import { ProfileServiceLive } from "./services/ProfileService"
@@ -24,12 +25,13 @@ import { TmdbClientLive } from "./services/TmdbClient"
 
 /** All application services, fully wired. Db + CryptoService also exposed for direct use. */
 export const AppLive = Layer.mergeAll(
-  AuthServiceLive,
   SchedulerServiceLive,
   AcquisitionPipelineLive,
   DownloadMonitorLive,
   PlexSessionMonitorLive,
+  OnboardingServiceLive,
 ).pipe(
+  Layer.provideMerge(AuthServiceLive),
   Layer.provideMerge(
     Layer.mergeAll(
       MovieServiceLive,

--- a/src/effect/runtime.ts
+++ b/src/effect/runtime.ts
@@ -7,19 +7,24 @@ import { AppLive } from "./layers"
 import { CryptoService } from "./services/CryptoService"
 import { Db } from "./services/Db"
 import { PlexSessionMonitor } from "./services/PlexSessionMonitor"
-import { ProfileDefaultsEngine } from "./services/ProfileDefaultsEngine"
 import { createSchedulerLoop } from "./services/SchedulerLoop"
 import { SchedulerService } from "./services/SchedulerService"
 
 export const AppRuntime = ManagedRuntime.make(AppLive)
 
-/** Seed admin user + default quality profile + scheduler config if tables are empty. */
+/**
+ * Seed scheduler config + start background services.
+ *
+ * Admin user and quality profile defaults are no longer created here — onboarding
+ * (OnboardingService) drives those on first launch. As an escape hatch, an admin is
+ * still seeded iff INITIAL_ADMIN_PASSWORD is explicitly set (e.g. headless docker).
+ */
 const seed = Effect.gen(function* () {
   const db = yield* Db
   const crypto = yield* CryptoService
 
   const existing = yield* db.select({ id: users.id }).from(users).limit(1)
-  if (existing.length === 0) {
+  if (existing.length === 0 && process.env.INITIAL_ADMIN_PASSWORD?.trim()) {
     const password = resolveInitialAdminPassword(process.env)
     const passwordHash = yield* crypto.hashPassword(password)
 
@@ -29,11 +34,8 @@ const seed = Effect.gen(function* () {
     })
 
     // eslint-disable-next-line no-console -- startup log
-    console.log("[arr-hub] admin user seeded")
+    console.log("[arr-hub] admin user seeded from INITIAL_ADMIN_PASSWORD")
   }
-
-  const engine = yield* ProfileDefaultsEngine
-  yield* engine.seedDefaults()
 
   const scheduler = yield* SchedulerService
   yield* scheduler.seedConfig()

--- a/src/effect/services/OnboardingService.ts
+++ b/src/effect/services/OnboardingService.ts
@@ -1,0 +1,494 @@
+import { SqlError } from "@effect/sql/SqlError"
+import { eq } from "drizzle-orm"
+import { Context, Effect, Layer } from "effect"
+
+import { rootFolders, setupLog, setupState, users } from "#/db/schema"
+
+import {
+  AuthError,
+  ConflictError,
+  NotFoundError,
+  OnboardingError,
+  ValidationError,
+  type EncryptionError,
+} from "../errors"
+import { AuthService } from "./AuthService"
+import { CryptoService } from "./CryptoService"
+import { Db } from "./Db"
+import { ProfileDefaultsEngine } from "./ProfileDefaultsEngine"
+
+// ── Types ──
+
+export type OnboardingPath = "quickstart" | "wizard"
+
+export type WizardStep =
+  | "admin"
+  | "capabilities"
+  | "profiles"
+  | "root_folders"
+  | "indexers"
+  | "download_client"
+  | "media_server"
+  | "import"
+  | "review"
+
+export const WIZARD_STEP_ORDER: ReadonlyArray<WizardStep> = [
+  "admin",
+  "capabilities",
+  "profiles",
+  "root_folders",
+  "indexers",
+  "download_client",
+  "media_server",
+  "import",
+  "review",
+]
+
+interface Capabilities {
+  readonly movies: boolean
+  readonly tv: boolean
+}
+
+export interface SetupStatus {
+  readonly started: boolean
+  readonly completed: boolean
+  readonly hasAdmin: boolean
+  readonly path: OnboardingPath | null
+  readonly currentStep: string | null
+  readonly completedSteps: ReadonlyArray<string>
+  readonly capabilities: Capabilities
+  readonly startedAt: Date | null
+  readonly completedAt: Date | null
+}
+
+interface SessionResult {
+  readonly token: string
+  readonly expiresAt: Date
+}
+
+export interface QuickstartInput {
+  readonly username: string
+  readonly password: string
+  readonly moviesRootFolder?: string
+  readonly tvRootFolder?: string
+}
+
+export interface QuickstartResult {
+  readonly session: SessionResult
+}
+
+export interface AdminStepResult {
+  readonly session: SessionResult
+}
+
+export class OnboardingService extends Context.Tag("@arr-hub/OnboardingService")<
+  OnboardingService,
+  {
+    readonly getStatus: () => Effect.Effect<SetupStatus, SqlError>
+
+    readonly runQuickstart: (
+      input: QuickstartInput,
+    ) => Effect.Effect<
+      QuickstartResult,
+      OnboardingError | ValidationError | ConflictError | NotFoundError | EncryptionError | SqlError
+    >
+
+    readonly submitAdmin: (input: {
+      readonly username: string
+      readonly password: string
+    }) => Effect.Effect<
+      AdminStepResult,
+      OnboardingError | AuthError | ValidationError | ConflictError | SqlError
+    >
+
+    readonly submitCapabilities: (
+      input: Capabilities,
+    ) => Effect.Effect<void, OnboardingError | SqlError>
+
+    readonly submitProfiles: (input: {
+      readonly bundleId: string
+    }) => Effect.Effect<void, OnboardingError | NotFoundError | ConflictError | SqlError>
+
+    readonly submitRootFolders: (input: {
+      readonly movies?: string
+      readonly tv?: string
+    }) => Effect.Effect<void, OnboardingError | ValidationError | SqlError>
+
+    readonly skipStep: (step: WizardStep) => Effect.Effect<void, OnboardingError | SqlError>
+
+    readonly goBack: () => Effect.Effect<void, OnboardingError | SqlError>
+
+    readonly complete: () => Effect.Effect<void, OnboardingError | SqlError>
+
+    readonly startWizard: () => Effect.Effect<void, OnboardingError | SqlError>
+  }
+>() {}
+
+// ── Helpers ──
+
+const SINGLETON_ID = 1
+
+export const OnboardingServiceLive = Layer.effect(
+  OnboardingService,
+  Effect.gen(function* () {
+    const db = yield* Db
+    const crypto = yield* CryptoService
+    const auth = yield* AuthService
+    const profileDefaults = yield* ProfileDefaultsEngine
+
+    const loadState = () =>
+      Effect.gen(function* () {
+        const rows = yield* db.select().from(setupState).where(eq(setupState.id, SINGLETON_ID))
+        return rows[0] ?? null
+      })
+
+    const ensureStateRow = (path: OnboardingPath, currentStep: WizardStep | null) =>
+      Effect.gen(function* () {
+        const existing = yield* loadState()
+        if (existing) return existing
+        const rows = yield* db
+          .insert(setupState)
+          .values({
+            id: SINGLETON_ID,
+            path,
+            currentStep: currentStep ?? null,
+          })
+          .returning()
+        return rows[0]
+      })
+
+    const assertNotComplete = () =>
+      Effect.gen(function* () {
+        const state = yield* loadState()
+        if (state?.completedAt) {
+          return yield* new OnboardingError({
+            reason: "already_complete",
+            message: "setup already completed",
+          })
+        }
+      })
+
+    const hasAnyAdmin = () =>
+      Effect.gen(function* () {
+        const rows = yield* db.select({ id: users.id }).from(users).limit(1)
+        return rows.length > 0
+      })
+
+    const recordLog = (
+      stepName: string,
+      action: string,
+      result: "success" | "failure" | "skipped",
+      opts?: { readonly message?: string; readonly reversible?: boolean },
+    ) =>
+      db.insert(setupLog).values({
+        stepName,
+        action,
+        result,
+        message: opts?.message ?? null,
+        reversible: opts?.reversible ?? false,
+      })
+
+    const markStepCompleted = (step: WizardStep, nextStep: WizardStep | null) =>
+      Effect.gen(function* () {
+        const state = yield* loadState()
+        if (!state) return
+        const completed = state.completedSteps.includes(step)
+          ? state.completedSteps
+          : [...state.completedSteps, step]
+        yield* db
+          .update(setupState)
+          .set({ completedSteps: completed, currentStep: nextStep })
+          .where(eq(setupState.id, SINGLETON_ID))
+      })
+
+    const nextStepAfter = (step: WizardStep): WizardStep | null => {
+      const idx = WIZARD_STEP_ORDER.indexOf(step)
+      if (idx < 0 || idx >= WIZARD_STEP_ORDER.length - 1) return null
+      return WIZARD_STEP_ORDER[idx + 1]
+    }
+
+    const prevStepOf = (step: WizardStep): WizardStep | null => {
+      const idx = WIZARD_STEP_ORDER.indexOf(step)
+      if (idx <= 0) return null
+      return WIZARD_STEP_ORDER[idx - 1]
+    }
+
+    const addRootFolderIfMissing = (
+      path: string,
+    ): Effect.Effect<void, ValidationError | SqlError> =>
+      Effect.gen(function* () {
+        const trimmed = path.replace(/\/+$/, "")
+        if (trimmed.length === 0) {
+          return yield* new ValidationError({ message: "root folder path cannot be empty" })
+        }
+        const existing = yield* db
+          .select({ id: rootFolders.id })
+          .from(rootFolders)
+          .where(eq(rootFolders.path, trimmed))
+        if (existing.length > 0) return
+        yield* db.insert(rootFolders).values({ path: trimmed })
+      })
+
+    // ── Public API ──
+
+    const getStatus = () =>
+      Effect.gen(function* () {
+        const state = yield* loadState()
+        const hasAdmin = yield* hasAnyAdmin()
+        if (!state) {
+          return {
+            started: false,
+            completed: false,
+            hasAdmin,
+            path: null,
+            currentStep: null,
+            completedSteps: [],
+            capabilities: { movies: true, tv: true },
+            startedAt: null,
+            completedAt: null,
+          } satisfies SetupStatus
+        }
+        return {
+          started: true,
+          completed: state.completedAt !== null,
+          hasAdmin,
+          path: state.path,
+          currentStep: state.currentStep,
+          completedSteps: state.completedSteps,
+          capabilities: state.capabilities,
+          startedAt: state.startedAt,
+          completedAt: state.completedAt,
+        } satisfies SetupStatus
+      })
+
+    const runQuickstart = (input: QuickstartInput) =>
+      Effect.gen(function* () {
+        yield* assertNotComplete()
+
+        // Create admin (or reject if exists)
+        const adminExists = yield* hasAnyAdmin()
+        if (adminExists) {
+          return yield* new OnboardingError({
+            reason: "admin_already_exists",
+            message: "admin user already exists",
+          })
+        }
+        if (input.username.trim().length === 0) {
+          return yield* new ValidationError({ message: "username required" })
+        }
+        if (input.password.length < 8) {
+          return yield* new ValidationError({ message: "password must be at least 8 characters" })
+        }
+
+        const passwordHash = yield* crypto.hashPassword(input.password)
+        yield* db.insert(users).values({
+          username: input.username,
+          passwordHash,
+        })
+
+        yield* ensureStateRow("quickstart", null)
+        yield* recordLog("admin", "create_user", "success", { reversible: false })
+
+        // Seed defaults + apply first bundle (ProfileDefaultsEngine.seedDefaults is idempotent)
+        yield* profileDefaults.seedDefaults()
+        yield* recordLog("profiles", "seed_defaults", "success")
+
+        // Optional root folders
+        if (input.moviesRootFolder) {
+          yield* addRootFolderIfMissing(input.moviesRootFolder)
+          yield* recordLog("root_folders", `add:${input.moviesRootFolder}`, "success")
+        }
+        if (input.tvRootFolder) {
+          yield* addRootFolderIfMissing(input.tvRootFolder)
+          yield* recordLog("root_folders", `add:${input.tvRootFolder}`, "success")
+        }
+
+        // Mark complete
+        yield* db
+          .update(setupState)
+          .set({
+            completedSteps: [
+              "admin",
+              "capabilities",
+              "profiles",
+              "root_folders",
+              "indexers",
+              "download_client",
+              "media_server",
+              "import",
+              "review",
+            ],
+            completedAt: new Date(),
+          })
+          .where(eq(setupState.id, SINGLETON_ID))
+        yield* recordLog("review", "complete", "success")
+
+        // Auto-login
+        const session = yield* auth.login(input.username, input.password).pipe(
+          Effect.catchTag("AuthError", (e) =>
+            // Should never happen — we just created the user.
+            Effect.fail(
+              new OnboardingError({
+                reason: "invalid_step",
+                message: `auto-login failed: ${e.reason}`,
+              }),
+            ),
+          ),
+        )
+
+        return { session }
+      })
+
+    const startWizard = () =>
+      Effect.gen(function* () {
+        yield* assertNotComplete()
+        const existing = yield* loadState()
+        if (existing) return
+        yield* db.insert(setupState).values({
+          id: SINGLETON_ID,
+          path: "wizard",
+          currentStep: "admin",
+        })
+      })
+
+    const submitAdmin = (input: { readonly username: string; readonly password: string }) =>
+      Effect.gen(function* () {
+        yield* assertNotComplete()
+
+        const adminExists = yield* hasAnyAdmin()
+        if (adminExists) {
+          return yield* new OnboardingError({
+            reason: "admin_already_exists",
+            message: "admin user already exists",
+          })
+        }
+
+        if (input.username.trim().length === 0) {
+          return yield* new ValidationError({ message: "username required" })
+        }
+        if (input.password.length < 8) {
+          return yield* new ValidationError({ message: "password must be at least 8 characters" })
+        }
+
+        const passwordHash = yield* crypto.hashPassword(input.password)
+        yield* db.insert(users).values({ username: input.username, passwordHash })
+
+        yield* ensureStateRow("wizard", "admin")
+        yield* markStepCompleted("admin", nextStepAfter("admin"))
+        yield* recordLog("admin", "create_user", "success", { reversible: false })
+
+        const session = yield* auth.login(input.username, input.password)
+        return { session }
+      })
+
+    const submitCapabilities = (input: Capabilities) =>
+      Effect.gen(function* () {
+        yield* assertNotComplete()
+        yield* ensureStateRow("wizard", "capabilities")
+        yield* db
+          .update(setupState)
+          .set({ capabilities: input })
+          .where(eq(setupState.id, SINGLETON_ID))
+        yield* markStepCompleted("capabilities", nextStepAfter("capabilities"))
+        yield* recordLog("capabilities", JSON.stringify(input), "success", { reversible: true })
+      })
+
+    const submitProfiles = (input: { readonly bundleId: string }) =>
+      Effect.gen(function* () {
+        yield* assertNotComplete()
+        // seedDefaults is idempotent — safe to call. (Ignores bundle override for v1; schema supports later.)
+        yield* profileDefaults.seedDefaults()
+        yield* markStepCompleted("profiles", nextStepAfter("profiles"))
+        yield* recordLog("profiles", `apply:${input.bundleId}`, "success", { reversible: false })
+      })
+
+    const submitRootFolders = (input: { readonly movies?: string; readonly tv?: string }) =>
+      Effect.gen(function* () {
+        yield* assertNotComplete()
+        if (input.movies) {
+          yield* addRootFolderIfMissing(input.movies)
+          yield* recordLog("root_folders", `add:${input.movies}`, "success", { reversible: true })
+        }
+        if (input.tv) {
+          yield* addRootFolderIfMissing(input.tv)
+          yield* recordLog("root_folders", `add:${input.tv}`, "success", { reversible: true })
+        }
+        yield* markStepCompleted("root_folders", nextStepAfter("root_folders"))
+      })
+
+    const skipStep = (step: WizardStep) =>
+      Effect.gen(function* () {
+        yield* assertNotComplete()
+        yield* markStepCompleted(step, nextStepAfter(step))
+        yield* recordLog(step, "skip", "skipped")
+      })
+
+    const goBack = () =>
+      Effect.gen(function* () {
+        yield* assertNotComplete()
+        const state = yield* loadState()
+        if (!state?.currentStep) {
+          return yield* new OnboardingError({
+            reason: "not_started",
+            message: "wizard has not started",
+          })
+        }
+        const current = state.currentStep as WizardStep
+        const prev = prevStepOf(current)
+        if (!prev) {
+          return yield* new OnboardingError({
+            reason: "step_out_of_order",
+            message: "already at first step",
+          })
+        }
+        // Remove current from completedSteps so it can be re-submitted, set cursor to prev
+        const nextCompleted = state.completedSteps.filter((s) => s !== prev && s !== current)
+        yield* db
+          .update(setupState)
+          .set({ completedSteps: nextCompleted, currentStep: prev })
+          .where(eq(setupState.id, SINGLETON_ID))
+      })
+
+    const complete = () =>
+      Effect.gen(function* () {
+        const state = yield* loadState()
+        if (!state) {
+          return yield* new OnboardingError({
+            reason: "not_started",
+            message: "setup has not started",
+          })
+        }
+        if (state.completedAt) {
+          return yield* new OnboardingError({
+            reason: "already_complete",
+            message: "setup already completed",
+          })
+        }
+        const adminExists = yield* hasAnyAdmin()
+        if (!adminExists) {
+          return yield* new OnboardingError({
+            reason: "step_out_of_order",
+            message: "admin must be created before completing setup",
+          })
+        }
+        yield* db
+          .update(setupState)
+          .set({ completedAt: new Date(), currentStep: null })
+          .where(eq(setupState.id, SINGLETON_ID))
+        yield* recordLog("review", "complete", "success")
+      })
+
+    return {
+      getStatus,
+      runQuickstart,
+      submitAdmin,
+      submitCapabilities,
+      submitProfiles,
+      submitRootFolders,
+      skipStep,
+      goBack,
+      complete,
+      startWizard,
+    }
+  }),
+)

--- a/src/integrations/trpc/init.ts
+++ b/src/integrations/trpc/init.ts
@@ -15,6 +15,7 @@ import type {
   MediaServerError,
   MetadataError,
   NotFoundError,
+  OnboardingError,
   ParseFailed,
   ProfileInUseError,
   SchedulerError,
@@ -59,6 +60,7 @@ type DomainError =
   | SchedulerError
   | AcquisitionError
   | MetadataError
+  | OnboardingError
 
 export function domainToTRPC(error: DomainError): TRPCError {
   switch (error._tag) {
@@ -156,6 +158,20 @@ export function domainToTRPC(error: DomainError): TRPCError {
       return new TRPCError({
         code: codeMap[error.reason] ?? "BAD_GATEWAY",
         message: `[${error.provider}] ${error.message}`,
+      })
+    }
+    case "OnboardingError": {
+      const codeMap: Record<string, TRPCError["code"]> = {
+        already_complete: "CONFLICT",
+        not_started: "PRECONDITION_FAILED",
+        invalid_step: "BAD_REQUEST",
+        step_out_of_order: "PRECONDITION_FAILED",
+        integration_test_failed: "BAD_GATEWAY",
+        admin_already_exists: "CONFLICT",
+      }
+      return new TRPCError({
+        code: codeMap[error.reason] ?? "BAD_REQUEST",
+        message: error.message,
       })
     }
   }

--- a/src/integrations/trpc/router.ts
+++ b/src/integrations/trpc/router.ts
@@ -6,6 +6,7 @@ import { historyRouter } from "./routers/history"
 import { indexersRouter } from "./routers/indexers"
 import { mediaServersRouter } from "./routers/mediaServers"
 import { moviesRouter } from "./routers/movies"
+import { onboardingRouter } from "./routers/onboarding"
 import { profilesRouter } from "./routers/profiles"
 import { releasesRouter } from "./routers/releases"
 import { rootFoldersRouter } from "./routers/rootFolders"
@@ -15,6 +16,7 @@ import { tmdbRouter } from "./routers/tmdb"
 
 export const trpcRouter = createTRPCRouter({
   auth: authRouter,
+  onboarding: onboardingRouter,
   movies: moviesRouter,
   series: seriesRouter,
   profiles: profilesRouter,

--- a/src/integrations/trpc/routers/onboarding.ts
+++ b/src/integrations/trpc/routers/onboarding.ts
@@ -1,0 +1,137 @@
+import type { TRPCRouterRecord } from "@trpc/server"
+import { Effect } from "effect"
+import { z } from "zod"
+
+import { OnboardingService } from "#/effect/services/OnboardingService"
+
+import { publicProcedure, runEffect } from "../init"
+
+const adminInput = z.object({
+  username: z.string().min(1),
+  password: z.string().min(8),
+})
+
+const quickstartInput = adminInput.extend({
+  moviesRootFolder: z.string().optional(),
+  tvRootFolder: z.string().optional(),
+})
+
+const capabilitiesInput = z.object({
+  movies: z.boolean(),
+  tv: z.boolean(),
+})
+
+const profilesInput = z.object({
+  bundleId: z.string(),
+})
+
+const rootFoldersInput = z.object({
+  movies: z.string().optional(),
+  tv: z.string().optional(),
+})
+
+const skipInput = z.object({
+  step: z.enum([
+    "admin",
+    "capabilities",
+    "profiles",
+    "root_folders",
+    "indexers",
+    "download_client",
+    "media_server",
+    "import",
+    "review",
+  ]),
+})
+
+export const onboardingRouter = {
+  status: publicProcedure.query(() =>
+    runEffect(
+      Effect.gen(function* () {
+        const svc = yield* OnboardingService
+        return yield* svc.getStatus()
+      }),
+    ),
+  ),
+
+  quickstart: publicProcedure.input(quickstartInput).mutation(({ input }) =>
+    runEffect(
+      Effect.gen(function* () {
+        const svc = yield* OnboardingService
+        return yield* svc.runQuickstart(input)
+      }),
+    ),
+  ),
+
+  startWizard: publicProcedure.mutation(() =>
+    runEffect(
+      Effect.gen(function* () {
+        const svc = yield* OnboardingService
+        yield* svc.startWizard()
+      }),
+    ),
+  ),
+
+  submitAdmin: publicProcedure.input(adminInput).mutation(({ input }) =>
+    runEffect(
+      Effect.gen(function* () {
+        const svc = yield* OnboardingService
+        return yield* svc.submitAdmin(input)
+      }),
+    ),
+  ),
+
+  submitCapabilities: publicProcedure.input(capabilitiesInput).mutation(({ input }) =>
+    runEffect(
+      Effect.gen(function* () {
+        const svc = yield* OnboardingService
+        yield* svc.submitCapabilities(input)
+      }),
+    ),
+  ),
+
+  submitProfiles: publicProcedure.input(profilesInput).mutation(({ input }) =>
+    runEffect(
+      Effect.gen(function* () {
+        const svc = yield* OnboardingService
+        yield* svc.submitProfiles(input)
+      }),
+    ),
+  ),
+
+  submitRootFolders: publicProcedure.input(rootFoldersInput).mutation(({ input }) =>
+    runEffect(
+      Effect.gen(function* () {
+        const svc = yield* OnboardingService
+        yield* svc.submitRootFolders(input)
+      }),
+    ),
+  ),
+
+  skip: publicProcedure.input(skipInput).mutation(({ input }) =>
+    runEffect(
+      Effect.gen(function* () {
+        const svc = yield* OnboardingService
+        yield* svc.skipStep(input.step)
+      }),
+    ),
+  ),
+
+  back: publicProcedure.mutation(() =>
+    runEffect(
+      Effect.gen(function* () {
+        const svc = yield* OnboardingService
+        yield* svc.goBack()
+      }),
+    ),
+  ),
+
+  complete: publicProcedure.mutation(() =>
+    runEffect(
+      Effect.gen(function* () {
+        const svc = yield* OnboardingService
+        yield* svc.complete()
+      }),
+    ),
+  ),
+} satisfies TRPCRouterRecord

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -10,9 +10,11 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as SystemRouteImport } from './routes/system'
+import { Route as LoginRouteImport } from './routes/login'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as TvIndexRouteImport } from './routes/tv/index'
 import { Route as SettingsIndexRouteImport } from './routes/settings/index'
+import { Route as OnboardingIndexRouteImport } from './routes/onboarding/index'
 import { Route as MoviesIndexRouteImport } from './routes/movies/index'
 import { Route as ActivityIndexRouteImport } from './routes/activity/index'
 import { Route as SettingsSecurityRouteImport } from './routes/settings/security'
@@ -25,6 +27,8 @@ import { Route as SettingsMediaManagementRouteImport } from './routes/settings/m
 import { Route as SettingsIndexersRouteImport } from './routes/settings/indexers'
 import { Route as SettingsGeneralRouteImport } from './routes/settings/general'
 import { Route as SettingsDownloadClientsRouteImport } from './routes/settings/download-clients'
+import { Route as OnboardingWizardRouteImport } from './routes/onboarding/wizard'
+import { Route as OnboardingQuickstartRouteImport } from './routes/onboarding/quickstart'
 import { Route as ActivityQueueRouteImport } from './routes/activity/queue'
 import { Route as ActivityHistoryRouteImport } from './routes/activity/history'
 import { Route as ApiTrpcSplatRouteImport } from './routes/api.trpc.$'
@@ -32,6 +36,11 @@ import { Route as ApiTrpcSplatRouteImport } from './routes/api.trpc.$'
 const SystemRoute = SystemRouteImport.update({
   id: '/system',
   path: '/system',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const LoginRoute = LoginRouteImport.update({
+  id: '/login',
+  path: '/login',
   getParentRoute: () => rootRouteImport,
 } as any)
 const IndexRoute = IndexRouteImport.update({
@@ -47,6 +56,11 @@ const TvIndexRoute = TvIndexRouteImport.update({
 const SettingsIndexRoute = SettingsIndexRouteImport.update({
   id: '/settings/',
   path: '/settings/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const OnboardingIndexRoute = OnboardingIndexRouteImport.update({
+  id: '/onboarding/',
+  path: '/onboarding/',
   getParentRoute: () => rootRouteImport,
 } as any)
 const MoviesIndexRoute = MoviesIndexRouteImport.update({
@@ -109,6 +123,16 @@ const SettingsDownloadClientsRoute = SettingsDownloadClientsRouteImport.update({
   path: '/settings/download-clients',
   getParentRoute: () => rootRouteImport,
 } as any)
+const OnboardingWizardRoute = OnboardingWizardRouteImport.update({
+  id: '/onboarding/wizard',
+  path: '/onboarding/wizard',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const OnboardingQuickstartRoute = OnboardingQuickstartRouteImport.update({
+  id: '/onboarding/quickstart',
+  path: '/onboarding/quickstart',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ActivityQueueRoute = ActivityQueueRouteImport.update({
   id: '/activity/queue',
   path: '/activity/queue',
@@ -127,9 +151,12 @@ const ApiTrpcSplatRoute = ApiTrpcSplatRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/login': typeof LoginRoute
   '/system': typeof SystemRoute
   '/activity/history': typeof ActivityHistoryRoute
   '/activity/queue': typeof ActivityQueueRoute
+  '/onboarding/quickstart': typeof OnboardingQuickstartRoute
+  '/onboarding/wizard': typeof OnboardingWizardRoute
   '/settings/download-clients': typeof SettingsDownloadClientsRoute
   '/settings/general': typeof SettingsGeneralRoute
   '/settings/indexers': typeof SettingsIndexersRoute
@@ -142,15 +169,19 @@ export interface FileRoutesByFullPath {
   '/settings/security': typeof SettingsSecurityRoute
   '/activity/': typeof ActivityIndexRoute
   '/movies/': typeof MoviesIndexRoute
+  '/onboarding/': typeof OnboardingIndexRoute
   '/settings/': typeof SettingsIndexRoute
   '/tv/': typeof TvIndexRoute
   '/api/trpc/$': typeof ApiTrpcSplatRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/login': typeof LoginRoute
   '/system': typeof SystemRoute
   '/activity/history': typeof ActivityHistoryRoute
   '/activity/queue': typeof ActivityQueueRoute
+  '/onboarding/quickstart': typeof OnboardingQuickstartRoute
+  '/onboarding/wizard': typeof OnboardingWizardRoute
   '/settings/download-clients': typeof SettingsDownloadClientsRoute
   '/settings/general': typeof SettingsGeneralRoute
   '/settings/indexers': typeof SettingsIndexersRoute
@@ -163,6 +194,7 @@ export interface FileRoutesByTo {
   '/settings/security': typeof SettingsSecurityRoute
   '/activity': typeof ActivityIndexRoute
   '/movies': typeof MoviesIndexRoute
+  '/onboarding': typeof OnboardingIndexRoute
   '/settings': typeof SettingsIndexRoute
   '/tv': typeof TvIndexRoute
   '/api/trpc/$': typeof ApiTrpcSplatRoute
@@ -170,9 +202,12 @@ export interface FileRoutesByTo {
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/login': typeof LoginRoute
   '/system': typeof SystemRoute
   '/activity/history': typeof ActivityHistoryRoute
   '/activity/queue': typeof ActivityQueueRoute
+  '/onboarding/quickstart': typeof OnboardingQuickstartRoute
+  '/onboarding/wizard': typeof OnboardingWizardRoute
   '/settings/download-clients': typeof SettingsDownloadClientsRoute
   '/settings/general': typeof SettingsGeneralRoute
   '/settings/indexers': typeof SettingsIndexersRoute
@@ -185,6 +220,7 @@ export interface FileRoutesById {
   '/settings/security': typeof SettingsSecurityRoute
   '/activity/': typeof ActivityIndexRoute
   '/movies/': typeof MoviesIndexRoute
+  '/onboarding/': typeof OnboardingIndexRoute
   '/settings/': typeof SettingsIndexRoute
   '/tv/': typeof TvIndexRoute
   '/api/trpc/$': typeof ApiTrpcSplatRoute
@@ -193,9 +229,12 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/login'
     | '/system'
     | '/activity/history'
     | '/activity/queue'
+    | '/onboarding/quickstart'
+    | '/onboarding/wizard'
     | '/settings/download-clients'
     | '/settings/general'
     | '/settings/indexers'
@@ -208,15 +247,19 @@ export interface FileRouteTypes {
     | '/settings/security'
     | '/activity/'
     | '/movies/'
+    | '/onboarding/'
     | '/settings/'
     | '/tv/'
     | '/api/trpc/$'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/login'
     | '/system'
     | '/activity/history'
     | '/activity/queue'
+    | '/onboarding/quickstart'
+    | '/onboarding/wizard'
     | '/settings/download-clients'
     | '/settings/general'
     | '/settings/indexers'
@@ -229,15 +272,19 @@ export interface FileRouteTypes {
     | '/settings/security'
     | '/activity'
     | '/movies'
+    | '/onboarding'
     | '/settings'
     | '/tv'
     | '/api/trpc/$'
   id:
     | '__root__'
     | '/'
+    | '/login'
     | '/system'
     | '/activity/history'
     | '/activity/queue'
+    | '/onboarding/quickstart'
+    | '/onboarding/wizard'
     | '/settings/download-clients'
     | '/settings/general'
     | '/settings/indexers'
@@ -250,6 +297,7 @@ export interface FileRouteTypes {
     | '/settings/security'
     | '/activity/'
     | '/movies/'
+    | '/onboarding/'
     | '/settings/'
     | '/tv/'
     | '/api/trpc/$'
@@ -257,9 +305,12 @@ export interface FileRouteTypes {
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  LoginRoute: typeof LoginRoute
   SystemRoute: typeof SystemRoute
   ActivityHistoryRoute: typeof ActivityHistoryRoute
   ActivityQueueRoute: typeof ActivityQueueRoute
+  OnboardingQuickstartRoute: typeof OnboardingQuickstartRoute
+  OnboardingWizardRoute: typeof OnboardingWizardRoute
   SettingsDownloadClientsRoute: typeof SettingsDownloadClientsRoute
   SettingsGeneralRoute: typeof SettingsGeneralRoute
   SettingsIndexersRoute: typeof SettingsIndexersRoute
@@ -272,6 +323,7 @@ export interface RootRouteChildren {
   SettingsSecurityRoute: typeof SettingsSecurityRoute
   ActivityIndexRoute: typeof ActivityIndexRoute
   MoviesIndexRoute: typeof MoviesIndexRoute
+  OnboardingIndexRoute: typeof OnboardingIndexRoute
   SettingsIndexRoute: typeof SettingsIndexRoute
   TvIndexRoute: typeof TvIndexRoute
   ApiTrpcSplatRoute: typeof ApiTrpcSplatRoute
@@ -284,6 +336,13 @@ declare module '@tanstack/react-router' {
       path: '/system'
       fullPath: '/system'
       preLoaderRoute: typeof SystemRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/login': {
+      id: '/login'
+      path: '/login'
+      fullPath: '/login'
+      preLoaderRoute: typeof LoginRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/': {
@@ -305,6 +364,13 @@ declare module '@tanstack/react-router' {
       path: '/settings'
       fullPath: '/settings/'
       preLoaderRoute: typeof SettingsIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/onboarding/': {
+      id: '/onboarding/'
+      path: '/onboarding'
+      fullPath: '/onboarding/'
+      preLoaderRoute: typeof OnboardingIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/movies/': {
@@ -391,6 +457,20 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof SettingsDownloadClientsRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/onboarding/wizard': {
+      id: '/onboarding/wizard'
+      path: '/onboarding/wizard'
+      fullPath: '/onboarding/wizard'
+      preLoaderRoute: typeof OnboardingWizardRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/onboarding/quickstart': {
+      id: '/onboarding/quickstart'
+      path: '/onboarding/quickstart'
+      fullPath: '/onboarding/quickstart'
+      preLoaderRoute: typeof OnboardingQuickstartRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/activity/queue': {
       id: '/activity/queue'
       path: '/activity/queue'
@@ -417,9 +497,12 @@ declare module '@tanstack/react-router' {
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  LoginRoute: LoginRoute,
   SystemRoute: SystemRoute,
   ActivityHistoryRoute: ActivityHistoryRoute,
   ActivityQueueRoute: ActivityQueueRoute,
+  OnboardingQuickstartRoute: OnboardingQuickstartRoute,
+  OnboardingWizardRoute: OnboardingWizardRoute,
   SettingsDownloadClientsRoute: SettingsDownloadClientsRoute,
   SettingsGeneralRoute: SettingsGeneralRoute,
   SettingsIndexersRoute: SettingsIndexersRoute,
@@ -432,6 +515,7 @@ const rootRouteChildren: RootRouteChildren = {
   SettingsSecurityRoute: SettingsSecurityRoute,
   ActivityIndexRoute: ActivityIndexRoute,
   MoviesIndexRoute: MoviesIndexRoute,
+  OnboardingIndexRoute: OnboardingIndexRoute,
   SettingsIndexRoute: SettingsIndexRoute,
   TvIndexRoute: TvIndexRoute,
   ApiTrpcSplatRoute: ApiTrpcSplatRoute,

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -6,6 +6,7 @@ import type { TRPCOptionsProxy } from "@trpc/tanstack-react-query"
 
 import type { TRPCRouter } from "#/integrations/trpc/router"
 
+import { AuthGuard, useHideShell } from "../components/auth-guard"
 import { AppSidebar } from "../components/sidebar/app-sidebar"
 import { Separator } from "../components/ui/separator"
 import { SidebarInset, SidebarProvider, SidebarTrigger } from "../components/ui/sidebar"
@@ -61,20 +62,34 @@ function RootDocument({ children }: { children: React.ReactNode }) {
       </head>
       <body>
         <TanStackQueryProvider>
-          <SidebarProvider>
-            <AppSidebar />
-            <SidebarInset>
-              <header className="flex h-12 shrink-0 items-center gap-2 border-b px-4">
-                <SidebarTrigger className="-ml-1" />
-                <Separator orientation="vertical" className="mr-2 h-4" />
-              </header>
-              <div className="flex-1">{children}</div>
-            </SidebarInset>
-          </SidebarProvider>
+          <AuthGuard>
+            <Shell>{children}</Shell>
+          </AuthGuard>
           <TanStackDevtools config={devtoolsConfig} plugins={devtoolsPlugins} />
         </TanStackQueryProvider>
         <Scripts />
       </body>
     </html>
+  )
+}
+
+function Shell({ children }: { children: React.ReactNode }) {
+  const hideShell = useHideShell()
+
+  if (hideShell) {
+    return <>{children}</>
+  }
+
+  return (
+    <SidebarProvider>
+      <AppSidebar />
+      <SidebarInset>
+        <header className="flex h-12 shrink-0 items-center gap-2 border-b px-4">
+          <SidebarTrigger className="-ml-1" />
+          <Separator orientation="vertical" className="mr-2 h-4" />
+        </header>
+        <div className="flex-1">{children}</div>
+      </SidebarInset>
+    </SidebarProvider>
   )
 }

--- a/src/routes/login.tsx
+++ b/src/routes/login.tsx
@@ -1,0 +1,75 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { createFileRoute, useNavigate } from "@tanstack/react-router"
+import { useState } from "react"
+
+import { Button } from "#/components/ui/button"
+import { Input } from "#/components/ui/input"
+import { useTRPC } from "#/integrations/trpc/react"
+import { setAuthToken } from "#/lib/auth-token"
+
+export const Route = createFileRoute("/login")({ component: Login })
+
+function Login() {
+  const trpc = useTRPC()
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+  const [username, setUsername] = useState("")
+  const [password, setPassword] = useState("")
+  const [error, setError] = useState<string | null>(null)
+
+  const mutation = useMutation(
+    trpc.auth.login.mutationOptions({
+      onSuccess: async (data) => {
+        setAuthToken(data.token)
+        await queryClient.invalidateQueries()
+        void navigate({ to: "/" })
+      },
+      onError: (e) => setError(e.message),
+    }),
+  )
+
+  return (
+    <div className="bg-background flex min-h-screen items-center justify-center p-6">
+      <form
+        className="w-full max-w-sm space-y-6"
+        onSubmit={(e) => {
+          e.preventDefault()
+          setError(null)
+          mutation.mutate({ username, password })
+        }}
+      >
+        <header className="space-y-2">
+          <h1 className="text-2xl font-bold">Sign in</h1>
+          <p className="text-muted-foreground text-sm">arr-hub admin login</p>
+        </header>
+
+        <label className="block space-y-1.5">
+          <span className="text-sm font-medium">Username</span>
+          <Input
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            autoComplete="username"
+            required
+          />
+        </label>
+
+        <label className="block space-y-1.5">
+          <span className="text-sm font-medium">Password</span>
+          <Input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            autoComplete="current-password"
+            required
+          />
+        </label>
+
+        {error && <p className="text-destructive text-sm">{error}</p>}
+
+        <Button type="submit" disabled={mutation.isPending} className="w-full">
+          {mutation.isPending ? "Signing in…" : "Sign in"}
+        </Button>
+      </form>
+    </div>
+  )
+}

--- a/src/routes/onboarding/index.tsx
+++ b/src/routes/onboarding/index.tsx
@@ -1,0 +1,81 @@
+import { useQuery } from "@tanstack/react-query"
+import { Link, createFileRoute, useNavigate } from "@tanstack/react-router"
+import { useEffect } from "react"
+
+import { Button } from "#/components/ui/button"
+import { useTRPC } from "#/integrations/trpc/react"
+
+export const Route = createFileRoute("/onboarding/")({ component: OnboardingLanding })
+
+function OnboardingLanding() {
+  const trpc = useTRPC()
+  const navigate = useNavigate()
+  const status = useQuery(trpc.onboarding.status.queryOptions())
+
+  useEffect(() => {
+    if (status.data?.completed) {
+      void navigate({ to: "/" })
+    }
+  }, [status.data?.completed, navigate])
+
+  // If a wizard is already in progress, resume it.
+  useEffect(() => {
+    if (status.data?.started && status.data.path === "wizard" && !status.data.completed) {
+      void navigate({ to: "/onboarding/wizard" })
+    }
+  }, [status.data, navigate])
+
+  return (
+    <div className="bg-background flex min-h-screen items-center justify-center p-6">
+      <div className="w-full max-w-2xl space-y-8">
+        <header className="space-y-2 text-center">
+          <h1 className="text-3xl font-bold">Welcome to arr-hub</h1>
+          <p className="text-muted-foreground">
+            One cohesive app for movies, TV, indexers, download clients, and Plex.
+          </p>
+        </header>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <Card
+            title="Quickstart"
+            description="Create your admin account and get productive in under a minute. Integrations can be added afterward."
+            action={
+              <Button asChild>
+                <Link to="/onboarding/quickstart">Start</Link>
+              </Button>
+            }
+          />
+          <Card
+            title="Advanced wizard"
+            description="Step through each decision: capabilities, profiles, indexers, download client, media server, and root folders."
+            action={
+              <Button asChild variant="outline">
+                <Link to="/onboarding/wizard">Configure</Link>
+              </Button>
+            }
+          />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function Card({
+  title,
+  description,
+  action,
+}: {
+  title: string
+  description: string
+  action: React.ReactNode
+}) {
+  return (
+    <div className="flex flex-col gap-4 rounded-lg border p-6">
+      <div className="space-y-1">
+        <h2 className="text-lg font-semibold">{title}</h2>
+        <p className="text-muted-foreground text-sm">{description}</p>
+      </div>
+      <div className="mt-auto">{action}</div>
+    </div>
+  )
+}

--- a/src/routes/onboarding/quickstart.tsx
+++ b/src/routes/onboarding/quickstart.tsx
@@ -1,0 +1,122 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { Link, createFileRoute, useNavigate } from "@tanstack/react-router"
+import { useState } from "react"
+
+import { Button } from "#/components/ui/button"
+import { Input } from "#/components/ui/input"
+import { useTRPC } from "#/integrations/trpc/react"
+import { setAuthToken } from "#/lib/auth-token"
+
+export const Route = createFileRoute("/onboarding/quickstart")({ component: Quickstart })
+
+function Quickstart() {
+  const trpc = useTRPC()
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+  const [username, setUsername] = useState("admin")
+  const [password, setPassword] = useState("")
+  const [moviesRootFolder, setMoviesRootFolder] = useState("")
+  const [tvRootFolder, setTvRootFolder] = useState("")
+  const [error, setError] = useState<string | null>(null)
+
+  const mutation = useMutation(
+    trpc.onboarding.quickstart.mutationOptions({
+      onSuccess: async (data) => {
+        setAuthToken(data.session.token)
+        await queryClient.invalidateQueries()
+        void navigate({ to: "/" })
+      },
+      onError: (e) => setError(e.message),
+    }),
+  )
+
+  const onSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    setError(null)
+    mutation.mutate({
+      username,
+      password,
+      moviesRootFolder: moviesRootFolder.trim() || undefined,
+      tvRootFolder: tvRootFolder.trim() || undefined,
+    })
+  }
+
+  return (
+    <div className="bg-background flex min-h-screen items-center justify-center p-6">
+      <form className="w-full max-w-md space-y-6" onSubmit={onSubmit}>
+        <header className="space-y-2">
+          <h1 className="text-2xl font-bold">Quickstart</h1>
+          <p className="text-muted-foreground text-sm">
+            Create your admin account. We&apos;ll apply recommended quality profiles automatically.
+            You can add indexers, download clients, and Plex later from Settings.
+          </p>
+        </header>
+
+        <Field label="Username">
+          <Input
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            autoComplete="username"
+            required
+          />
+        </Field>
+
+        <Field label="Password" hint="At least 8 characters">
+          <Input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            autoComplete="new-password"
+            minLength={8}
+            required
+          />
+        </Field>
+
+        <Field label="Movies root folder" hint="Optional — can be added later">
+          <Input
+            value={moviesRootFolder}
+            onChange={(e) => setMoviesRootFolder(e.target.value)}
+            placeholder="/media/movies"
+          />
+        </Field>
+
+        <Field label="TV root folder" hint="Optional — can be added later">
+          <Input
+            value={tvRootFolder}
+            onChange={(e) => setTvRootFolder(e.target.value)}
+            placeholder="/media/tv"
+          />
+        </Field>
+
+        {error && <p className="text-destructive text-sm">{error}</p>}
+
+        <div className="flex items-center justify-between">
+          <Button asChild variant="ghost" type="button">
+            <Link to="/onboarding">← Back</Link>
+          </Button>
+          <Button type="submit" disabled={mutation.isPending}>
+            {mutation.isPending ? "Creating…" : "Create account"}
+          </Button>
+        </div>
+      </form>
+    </div>
+  )
+}
+
+function Field({
+  label,
+  hint,
+  children,
+}: {
+  label: string
+  hint?: string
+  children: React.ReactNode
+}) {
+  return (
+    <label className="block space-y-1.5">
+      <span className="text-sm font-medium">{label}</span>
+      {children}
+      {hint && <span className="text-muted-foreground block text-xs">{hint}</span>}
+    </label>
+  )
+}

--- a/src/routes/onboarding/wizard.tsx
+++ b/src/routes/onboarding/wizard.tsx
@@ -1,0 +1,548 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { Link, createFileRoute, useNavigate } from "@tanstack/react-router"
+import { useEffect, useState } from "react"
+
+import { Button } from "#/components/ui/button"
+import { Input } from "#/components/ui/input"
+import { useTRPC } from "#/integrations/trpc/react"
+import { setAuthToken } from "#/lib/auth-token"
+
+export const Route = createFileRoute("/onboarding/wizard")({ component: Wizard })
+
+const STEPS = [
+  { key: "admin", label: "Admin account" },
+  { key: "capabilities", label: "Capabilities" },
+  { key: "profiles", label: "Quality profiles" },
+  { key: "root_folders", label: "Root folders" },
+  { key: "indexers", label: "Indexers" },
+  { key: "download_client", label: "Download client" },
+  { key: "media_server", label: "Media server" },
+  { key: "import", label: "Import" },
+  { key: "review", label: "Review" },
+] as const
+
+type StepKey = (typeof STEPS)[number]["key"]
+
+function Wizard() {
+  const trpc = useTRPC()
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+  const status = useQuery(trpc.onboarding.status.queryOptions())
+
+  const startWizard = useMutation(
+    trpc.onboarding.startWizard.mutationOptions({
+      onSuccess: () =>
+        queryClient.invalidateQueries({ queryKey: trpc.onboarding.status.queryKey() }),
+    }),
+  )
+
+  useEffect(() => {
+    if (status.data?.completed) {
+      void navigate({ to: "/" })
+    }
+  }, [status.data?.completed, navigate])
+
+  useEffect(() => {
+    // Initialize wizard state on first visit (if not yet started as wizard)
+    if (status.data && !status.data.started && !startWizard.isPending && !startWizard.isSuccess) {
+      startWizard.mutate()
+    }
+  }, [status.data, startWizard])
+
+  if (status.isLoading || !status.data) {
+    return (
+      <div className="text-muted-foreground flex min-h-screen items-center justify-center">
+        Loading…
+      </div>
+    )
+  }
+
+  const currentStep = (status.data.currentStep ?? "admin") as StepKey
+  const stepIndex = STEPS.findIndex((s) => s.key === currentStep)
+
+  return (
+    <div className="bg-background flex min-h-screen flex-col">
+      <header className="border-b p-6">
+        <div className="mx-auto flex max-w-3xl items-center justify-between">
+          <div>
+            <h1 className="text-2xl font-bold">Advanced setup</h1>
+            <p className="text-muted-foreground text-sm">
+              Step {stepIndex + 1} of {STEPS.length}: {STEPS[stepIndex]?.label ?? "—"}
+            </p>
+          </div>
+          <Button asChild variant="ghost" size="sm">
+            <Link to="/onboarding">Cancel</Link>
+          </Button>
+        </div>
+        <div className="mx-auto mt-4 max-w-3xl">
+          <div className="flex gap-1">
+            {STEPS.map((s, i) => (
+              <div
+                key={s.key}
+                className={`h-1.5 flex-1 rounded-full ${i <= stepIndex ? "bg-primary" : "bg-muted"}`}
+              />
+            ))}
+          </div>
+        </div>
+      </header>
+
+      <main className="mx-auto w-full max-w-3xl flex-1 p-6">
+        <StepPanel step={currentStep} capabilities={status.data.capabilities} />
+      </main>
+    </div>
+  )
+}
+
+function StepPanel({
+  step,
+  capabilities,
+}: {
+  step: StepKey
+  capabilities: { readonly movies: boolean; readonly tv: boolean }
+}) {
+  switch (step) {
+    case "admin":
+      return <AdminStep />
+    case "capabilities":
+      return <CapabilitiesStep initial={capabilities} />
+    case "profiles":
+      return <ProfilesStep />
+    case "root_folders":
+      return <RootFoldersStep capabilities={capabilities} />
+    case "indexers":
+      return (
+        <SkippableStep
+          stepKey="indexers"
+          title="Indexers"
+          description="Indexer configuration is easier after setup — use Settings → Indexers once you're in."
+        />
+      )
+    case "download_client":
+      return (
+        <SkippableStep
+          stepKey="download_client"
+          title="Download client"
+          description="Add qBittorrent or SABnzbd from Settings → Download Clients after setup."
+        />
+      )
+    case "media_server":
+      return (
+        <SkippableStep
+          stepKey="media_server"
+          title="Media server"
+          description="Connect Plex from Settings → Media Servers after setup."
+        />
+      )
+    case "import":
+      return (
+        <SkippableStep
+          stepKey="import"
+          title="Library import"
+          description="Radarr/Sonarr import is not yet available. Skip for now — tracked as a separate feature."
+        />
+      )
+    case "review":
+      return <ReviewStep />
+  }
+}
+
+// ─ Step navigation controls ─
+
+function StepControls({
+  onNext,
+  nextLabel,
+  nextDisabled,
+  pending,
+  error,
+}: {
+  onNext: () => void
+  nextLabel: string
+  nextDisabled?: boolean
+  pending?: boolean
+  error?: string | null
+}) {
+  const trpc = useTRPC()
+  const queryClient = useQueryClient()
+  const back = useMutation(
+    trpc.onboarding.back.mutationOptions({
+      onSuccess: () =>
+        queryClient.invalidateQueries({ queryKey: trpc.onboarding.status.queryKey() }),
+    }),
+  )
+
+  return (
+    <div className="mt-8 space-y-3">
+      {error && <p className="text-destructive text-sm">{error}</p>}
+      <div className="flex items-center justify-between">
+        <Button
+          type="button"
+          variant="ghost"
+          onClick={() => back.mutate()}
+          disabled={back.isPending}
+        >
+          ← Back
+        </Button>
+        <Button type="button" onClick={onNext} disabled={nextDisabled || pending}>
+          {pending ? "Saving…" : nextLabel}
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+// ─ Individual steps ─
+
+function AdminStep() {
+  const trpc = useTRPC()
+  const queryClient = useQueryClient()
+  const [username, setUsername] = useState("admin")
+  const [password, setPassword] = useState("")
+  const [error, setError] = useState<string | null>(null)
+
+  const mutation = useMutation(
+    trpc.onboarding.submitAdmin.mutationOptions({
+      onSuccess: async (data) => {
+        setAuthToken(data.session.token)
+        await queryClient.invalidateQueries()
+      },
+      onError: (e) => setError(e.message),
+    }),
+  )
+
+  return (
+    <section className="space-y-6">
+      <div>
+        <h2 className="text-xl font-semibold">Create admin account</h2>
+        <p className="text-muted-foreground text-sm">
+          The single local admin with full access. Used by automation API keys too.
+        </p>
+      </div>
+
+      <div className="space-y-4">
+        <Field label="Username">
+          <Input
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            autoComplete="username"
+          />
+        </Field>
+        <Field label="Password" hint="At least 8 characters">
+          <Input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            autoComplete="new-password"
+          />
+        </Field>
+      </div>
+
+      <StepControls
+        onNext={() => {
+          setError(null)
+          mutation.mutate({ username, password })
+        }}
+        nextLabel="Continue"
+        nextDisabled={username.trim().length === 0 || password.length < 8}
+        pending={mutation.isPending}
+        error={error}
+      />
+    </section>
+  )
+}
+
+function CapabilitiesStep({
+  initial,
+}: {
+  initial: { readonly movies: boolean; readonly tv: boolean }
+}) {
+  const trpc = useTRPC()
+  const queryClient = useQueryClient()
+  const [movies, setMovies] = useState(initial.movies)
+  const [tv, setTv] = useState(initial.tv)
+  const [error, setError] = useState<string | null>(null)
+
+  const mutation = useMutation(
+    trpc.onboarding.submitCapabilities.mutationOptions({
+      onSuccess: () =>
+        queryClient.invalidateQueries({ queryKey: trpc.onboarding.status.queryKey() }),
+      onError: (e) => setError(e.message),
+    }),
+  )
+
+  return (
+    <section className="space-y-6">
+      <div>
+        <h2 className="text-xl font-semibold">Choose capabilities</h2>
+        <p className="text-muted-foreground text-sm">
+          Pick what arr-hub should manage. You can toggle these later in Settings.
+        </p>
+      </div>
+
+      <div className="space-y-3">
+        <Toggle label="Movies" checked={movies} onChange={setMovies} />
+        <Toggle label="TV series" checked={tv} onChange={setTv} />
+      </div>
+
+      <StepControls
+        onNext={() => {
+          setError(null)
+          mutation.mutate({ movies, tv })
+        }}
+        nextLabel="Continue"
+        nextDisabled={!movies && !tv}
+        pending={mutation.isPending}
+        error={error}
+      />
+    </section>
+  )
+}
+
+function ProfilesStep() {
+  const trpc = useTRPC()
+  const queryClient = useQueryClient()
+  const [error, setError] = useState<string | null>(null)
+
+  const mutation = useMutation(
+    trpc.onboarding.submitProfiles.mutationOptions({
+      onSuccess: () =>
+        queryClient.invalidateQueries({ queryKey: trpc.onboarding.status.queryKey() }),
+      onError: (e) => setError(e.message),
+    }),
+  )
+
+  return (
+    <section className="space-y-6">
+      <div>
+        <h2 className="text-xl font-semibold">Quality profiles</h2>
+        <p className="text-muted-foreground text-sm">
+          We&apos;ll seed TRaSH-inspired defaults. You can customize each profile from Settings →
+          Profiles after setup.
+        </p>
+      </div>
+
+      <div className="rounded-lg border p-4 text-sm">
+        <strong>Default bundle:</strong> TRaSH HD (1080p/2160p tiers with curated custom format
+        scoring).
+      </div>
+
+      <StepControls
+        onNext={() => {
+          setError(null)
+          mutation.mutate({ bundleId: "trash-hd" })
+        }}
+        nextLabel="Apply defaults"
+        pending={mutation.isPending}
+        error={error}
+      />
+    </section>
+  )
+}
+
+function RootFoldersStep({
+  capabilities,
+}: {
+  capabilities: { readonly movies: boolean; readonly tv: boolean }
+}) {
+  const trpc = useTRPC()
+  const queryClient = useQueryClient()
+  const [moviesPath, setMoviesPath] = useState("")
+  const [tvPath, setTvPath] = useState("")
+  const [error, setError] = useState<string | null>(null)
+
+  const mutation = useMutation(
+    trpc.onboarding.submitRootFolders.mutationOptions({
+      onSuccess: () =>
+        queryClient.invalidateQueries({ queryKey: trpc.onboarding.status.queryKey() }),
+      onError: (e) => setError(e.message),
+    }),
+  )
+
+  return (
+    <section className="space-y-6">
+      <div>
+        <h2 className="text-xl font-semibold">Root folders</h2>
+        <p className="text-muted-foreground text-sm">
+          Where media lives on disk. Optional — skip and add them later from Settings.
+        </p>
+      </div>
+
+      <div className="space-y-4">
+        {capabilities.movies && (
+          <Field label="Movies folder">
+            <Input
+              value={moviesPath}
+              onChange={(e) => setMoviesPath(e.target.value)}
+              placeholder="/media/movies"
+            />
+          </Field>
+        )}
+        {capabilities.tv && (
+          <Field label="TV folder">
+            <Input
+              value={tvPath}
+              onChange={(e) => setTvPath(e.target.value)}
+              placeholder="/media/tv"
+            />
+          </Field>
+        )}
+      </div>
+
+      <StepControls
+        onNext={() => {
+          setError(null)
+          mutation.mutate({
+            movies: moviesPath.trim() || undefined,
+            tv: tvPath.trim() || undefined,
+          })
+        }}
+        nextLabel="Continue"
+        pending={mutation.isPending}
+        error={error}
+      />
+    </section>
+  )
+}
+
+function SkippableStep({
+  stepKey,
+  title,
+  description,
+}: {
+  stepKey: StepKey
+  title: string
+  description: string
+}) {
+  const trpc = useTRPC()
+  const queryClient = useQueryClient()
+  const [error, setError] = useState<string | null>(null)
+
+  const skip = useMutation(
+    trpc.onboarding.skip.mutationOptions({
+      onSuccess: () =>
+        queryClient.invalidateQueries({ queryKey: trpc.onboarding.status.queryKey() }),
+      onError: (e) => setError(e.message),
+    }),
+  )
+
+  return (
+    <section className="space-y-6">
+      <div>
+        <h2 className="text-xl font-semibold">{title}</h2>
+        <p className="text-muted-foreground text-sm">{description}</p>
+      </div>
+
+      <StepControls
+        onNext={() => {
+          setError(null)
+          skip.mutate({ step: stepKey })
+        }}
+        nextLabel="Skip for now"
+        pending={skip.isPending}
+        error={error}
+      />
+    </section>
+  )
+}
+
+function ReviewStep() {
+  const trpc = useTRPC()
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+  const status = useQuery(trpc.onboarding.status.queryOptions())
+  const [error, setError] = useState<string | null>(null)
+
+  const complete = useMutation(
+    trpc.onboarding.complete.mutationOptions({
+      onSuccess: async () => {
+        await queryClient.invalidateQueries()
+        void navigate({ to: "/" })
+      },
+      onError: (e) => setError(e.message),
+    }),
+  )
+
+  const completed = status.data?.completedSteps ?? []
+  const caps = status.data?.capabilities ?? { movies: true, tv: true }
+
+  return (
+    <section className="space-y-6">
+      <div>
+        <h2 className="text-xl font-semibold">Review</h2>
+        <p className="text-muted-foreground text-sm">
+          Confirm your setup. Click Finish to activate arr-hub.
+        </p>
+      </div>
+
+      <dl className="space-y-3 rounded-lg border p-4 text-sm">
+        <Row label="Admin" value={status.data?.hasAdmin ? "Created" : "Missing"} />
+        <Row
+          label="Capabilities"
+          value={[caps.movies && "Movies", caps.tv && "TV"].filter(Boolean).join(", ") || "None"}
+        />
+        <Row label="Completed steps" value={completed.length ? completed.join(", ") : "—"} />
+      </dl>
+
+      <StepControls
+        onNext={() => {
+          setError(null)
+          complete.mutate()
+        }}
+        nextLabel="Finish"
+        nextDisabled={!status.data?.hasAdmin}
+        pending={complete.isPending}
+        error={error}
+      />
+    </section>
+  )
+}
+
+// ─ Tiny UI helpers ─
+
+function Field({
+  label,
+  hint,
+  children,
+}: {
+  label: string
+  hint?: string
+  children: React.ReactNode
+}) {
+  return (
+    <label className="block space-y-1.5">
+      <span className="text-sm font-medium">{label}</span>
+      {children}
+      {hint && <span className="text-muted-foreground block text-xs">{hint}</span>}
+    </label>
+  )
+}
+
+function Toggle({
+  label,
+  checked,
+  onChange,
+}: {
+  label: string
+  checked: boolean
+  onChange: (v: boolean) => void
+}) {
+  return (
+    <label className="flex items-center gap-3 rounded-md border p-3">
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={(e) => onChange(e.target.checked)}
+        className="size-4"
+      />
+      <span className="text-sm font-medium">{label}</span>
+    </label>
+  )
+}
+
+function Row({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-center justify-between gap-4">
+      <dt className="text-muted-foreground">{label}</dt>
+      <dd className="font-medium">{value}</dd>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- New `/onboarding` landing + `/onboarding/quickstart` + `/onboarding/wizard` routes. Quickstart creates admin + optional root folders + auto-applies trash-hd profiles, auto-login. Wizard steps through admin → capabilities → profiles → root folders → (stubbed) indexers/download_client/media_server/import → review.
- `OnboardingService` (Effect) drives state via new `setup_state` + `setup_log` tables. `OnboardingError` tagged error type with reason union.
- Adds `/login` route and `AuthGuard` component (gates the app shell; hides sidebar on onboarding/login).
- Seed no longer auto-creates admin on boot; only honors `INITIAL_ADMIN_PASSWORD` env for headless deploys.

## Test plan
- [ ] Fresh DB: visit `/` → redirects to `/onboarding`
- [ ] Quickstart flow: submit admin + root folders → lands on `/` authed, profiles populated
- [ ] Wizard flow: walk through all 9 steps including Back
- [ ] Skip integration steps → review → Finish
- [ ] Post-complete visit to `/onboarding` redirects to `/`
- [ ] Logout → `/login` works