### PR TITLE
feat: Radarr/Sonarr library import (closes #15)

### DIFF
--- a/src/effect/errors.ts
+++ b/src/effect/errors.ts
@@ -136,3 +136,15 @@ export class OnboardingError extends Data.TaggedError("OnboardingError")<{
   readonly reason: OnboardingErrorReason
   readonly message: string
 }> {}
+
+export type ImportErrorReason =
+  | "connection_failed"
+  | "invalid_response"
+  | "transaction_failed"
+  | "setup_not_active"
+
+export class ImportError extends Data.TaggedError("ImportError")<{
+  readonly source: "radarr" | "sonarr"
+  readonly reason: ImportErrorReason
+  readonly message: string
+}> {}

--- a/src/effect/layers.ts
+++ b/src/effect/layers.ts
@@ -8,6 +8,7 @@ import { CryptoServiceLive } from "./services/CryptoService"
 import { DbLive } from "./services/Db"
 import { DownloadClientServiceLive } from "./services/DownloadClientService"
 import { DownloadMonitorLive } from "./services/DownloadMonitor"
+import { ImportServiceLive } from "./services/ImportService"
 import { IndexerServiceLive } from "./services/IndexerService"
 import { MediaServerServiceLive } from "./services/MediaServerService"
 import { MovieServiceLive } from "./services/MovieService"
@@ -29,8 +30,9 @@ export const AppLive = Layer.mergeAll(
   AcquisitionPipelineLive,
   DownloadMonitorLive,
   PlexSessionMonitorLive,
-  OnboardingServiceLive,
+  ImportServiceLive,
 ).pipe(
+  Layer.provideMerge(OnboardingServiceLive),
   Layer.provideMerge(AuthServiceLive),
   Layer.provideMerge(
     Layer.mergeAll(

--- a/src/effect/services/ImportService.ts
+++ b/src/effect/services/ImportService.ts
@@ -1,0 +1,255 @@
+import { SqlClient } from "@effect/sql"
+import { SqlError } from "@effect/sql/SqlError"
+import { eq } from "drizzle-orm"
+import { Context, Effect, Layer } from "effect"
+import { z } from "zod"
+
+import { qualityProfiles, movies, series, seasons } from "#/db/schema"
+
+import * as radarr from "../../lib/import/radarr-client"
+import { posterOf, type RadarrMovie, type SonarrSeries } from "../../lib/import/schemas"
+import * as sonarr from "../../lib/import/sonarr-client"
+import { ImportError } from "../errors"
+import { Db } from "./Db"
+import { OnboardingService } from "./OnboardingService"
+
+// ── Types ──
+
+export interface ImportResult {
+  readonly imported: number
+  readonly skipped: number
+}
+
+export interface ConnectionTestResult {
+  readonly version: string
+}
+
+export interface ImportCredentials {
+  readonly url: string
+  readonly apiKey: string
+}
+
+// ── Service ──
+
+export class ImportService extends Context.Tag("@arr-hub/ImportService")<
+  ImportService,
+  {
+    readonly testRadarr: (
+      input: ImportCredentials,
+    ) => Effect.Effect<ConnectionTestResult, ImportError>
+    readonly testSonarr: (
+      input: ImportCredentials,
+    ) => Effect.Effect<ConnectionTestResult, ImportError>
+    readonly importFromRadarr: (
+      input: ImportCredentials,
+    ) => Effect.Effect<ImportResult, ImportError | SqlError>
+    readonly importFromSonarr: (
+      input: ImportCredentials,
+    ) => Effect.Effect<ImportResult, ImportError | SqlError>
+  }
+>() {}
+
+// ── Helpers ──
+
+function toImportError(source: "radarr" | "sonarr", e: unknown): ImportError {
+  if (e instanceof z.ZodError) {
+    return new ImportError({
+      source,
+      reason: "invalid_response",
+      message: `schema validation failed: ${e.issues.map((i) => i.message).join(", ")}`,
+    })
+  }
+  if (e instanceof Error && e.name === "AbortError") {
+    return new ImportError({
+      source,
+      reason: "connection_failed",
+      message: "request timed out",
+    })
+  }
+  const msg = e instanceof Error ? e.message : "unknown error"
+  const isConnection = /HTTP \d{3}|fetch|network|ECONN|ENOTFOUND/i.test(msg)
+  return new ImportError({
+    source,
+    reason: isConnection ? "connection_failed" : "invalid_response",
+    message: msg,
+  })
+}
+
+function mapSonarrStatus(status: string): "continuing" | "ended" | "wanted" | "available" {
+  if (status === "continuing") return "continuing"
+  if (status === "ended") return "ended"
+  return "wanted"
+}
+
+// ── Live implementation ──
+
+export const ImportServiceLive = Layer.effect(
+  ImportService,
+  Effect.gen(function* () {
+    const db = yield* Db
+    const sql = yield* SqlClient.SqlClient
+    const onboarding = yield* OnboardingService
+
+    const assertSetupActive = (): Effect.Effect<void, ImportError | SqlError> =>
+      Effect.gen(function* () {
+        const status = yield* onboarding.getStatus()
+        if (status.completed) {
+          return yield* new ImportError({
+            source: "radarr",
+            reason: "setup_not_active",
+            message: "library import is only available during setup",
+          })
+        }
+      })
+
+    const loadDefaultProfileId = (): Effect.Effect<number | null, SqlError> =>
+      Effect.gen(function* () {
+        const rows = yield* db
+          .select({ id: qualityProfiles.id })
+          .from(qualityProfiles)
+          .where(eq(qualityProfiles.isDefault, true))
+          .limit(1)
+        return rows[0]?.id ?? null
+      })
+
+    const testRadarr = (input: ImportCredentials) =>
+      Effect.tryPromise({
+        try: () => radarr.testConnection(input.url, input.apiKey),
+        catch: (e) => toImportError("radarr", e),
+      })
+
+    const testSonarr = (input: ImportCredentials) =>
+      Effect.tryPromise({
+        try: () => sonarr.testConnection(input.url, input.apiKey),
+        catch: (e) => toImportError("sonarr", e),
+      })
+
+    const insertRadarrMovie = (m: RadarrMovie, defaultProfileId: number | null) =>
+      Effect.gen(function* () {
+        const existing = yield* db
+          .select({ id: movies.id })
+          .from(movies)
+          .where(eq(movies.tmdbId, m.tmdbId))
+          .limit(1)
+        if (existing.length > 0) return "skipped" as const
+        yield* db.insert(movies).values({
+          tmdbId: m.tmdbId,
+          title: m.title,
+          year: m.year ?? null,
+          overview: m.overview ?? null,
+          posterPath: posterOf(m.images),
+          status: m.hasFile ? "available" : "wanted",
+          qualityProfileId: defaultProfileId,
+          rootFolderPath: m.path ?? null,
+          monitored: m.monitored,
+          hasFile: m.hasFile,
+        })
+        return "imported" as const
+      })
+
+    const insertSonarrSeries = (s: SonarrSeries, defaultProfileId: number | null) =>
+      Effect.gen(function* () {
+        const existing = yield* db
+          .select({ id: series.id })
+          .from(series)
+          .where(eq(series.tvdbId, s.tvdbId))
+          .limit(1)
+        if (existing.length > 0) return "skipped" as const
+        const [row] = yield* db
+          .insert(series)
+          .values({
+            tvdbId: s.tvdbId,
+            title: s.title,
+            year: s.year ?? null,
+            overview: s.overview ?? null,
+            posterPath: posterOf(s.images),
+            status: mapSonarrStatus(s.status),
+            network: s.network ?? null,
+            rootFolderPath: s.path ?? null,
+            monitored: s.monitored,
+            qualityProfileId: defaultProfileId,
+            seasonFolder: s.seasonFolder ?? true,
+          })
+          .returning({ id: series.id })
+        for (const season of s.seasons) {
+          yield* db.insert(seasons).values({
+            seriesId: row.id,
+            seasonNumber: season.seasonNumber,
+            monitored: season.monitored,
+          })
+        }
+        return "imported" as const
+      })
+
+    const importFromRadarr = (input: ImportCredentials) =>
+      Effect.gen(function* () {
+        yield* assertSetupActive()
+        const list = yield* Effect.tryPromise({
+          try: () => radarr.fetchMovies(input.url, input.apiKey),
+          catch: (e) => toImportError("radarr", e),
+        })
+        const defaultProfileId = yield* loadDefaultProfileId()
+
+        const run = Effect.gen(function* () {
+          let imported = 0
+          let skipped = 0
+          for (const movie of list) {
+            const result = yield* insertRadarrMovie(movie, defaultProfileId)
+            if (result === "imported") imported++
+            else skipped++
+          }
+          return { imported, skipped } satisfies ImportResult
+        })
+
+        return yield* sql.withTransaction(run).pipe(
+          Effect.mapError(
+            (e) =>
+              new ImportError({
+                source: "radarr",
+                reason: "transaction_failed",
+                message: e.message,
+              }),
+          ),
+        )
+      })
+
+    const importFromSonarr = (input: ImportCredentials) =>
+      Effect.gen(function* () {
+        yield* assertSetupActive()
+        const list = yield* Effect.tryPromise({
+          try: () => sonarr.fetchSeries(input.url, input.apiKey),
+          catch: (e) => toImportError("sonarr", e),
+        })
+        const defaultProfileId = yield* loadDefaultProfileId()
+
+        const run = Effect.gen(function* () {
+          let imported = 0
+          let skipped = 0
+          for (const s of list) {
+            const result = yield* insertSonarrSeries(s, defaultProfileId)
+            if (result === "imported") imported++
+            else skipped++
+          }
+          return { imported, skipped } satisfies ImportResult
+        })
+
+        return yield* sql.withTransaction(run).pipe(
+          Effect.mapError(
+            (e) =>
+              new ImportError({
+                source: "sonarr",
+                reason: "transaction_failed",
+                message: e.message,
+              }),
+          ),
+        )
+      })
+
+    return {
+      testRadarr,
+      testSonarr,
+      importFromRadarr,
+      importFromSonarr,
+    }
+  }),
+)

--- a/src/integrations/trpc/init.ts
+++ b/src/integrations/trpc/init.ts
@@ -11,6 +11,7 @@ import type {
   ConflictError,
   DownloadClientError,
   EncryptionError,
+  ImportError,
   IndexerError,
   MediaServerError,
   MetadataError,
@@ -61,6 +62,7 @@ type DomainError =
   | AcquisitionError
   | MetadataError
   | OnboardingError
+  | ImportError
 
 export function domainToTRPC(error: DomainError): TRPCError {
   switch (error._tag) {
@@ -172,6 +174,18 @@ export function domainToTRPC(error: DomainError): TRPCError {
       return new TRPCError({
         code: codeMap[error.reason] ?? "BAD_REQUEST",
         message: error.message,
+      })
+    }
+    case "ImportError": {
+      const codeMap: Record<string, TRPCError["code"]> = {
+        connection_failed: "BAD_GATEWAY",
+        invalid_response: "BAD_GATEWAY",
+        transaction_failed: "INTERNAL_SERVER_ERROR",
+        setup_not_active: "PRECONDITION_FAILED",
+      }
+      return new TRPCError({
+        code: codeMap[error.reason] ?? "BAD_REQUEST",
+        message: `[${error.source}] ${error.message}`,
       })
     }
   }

--- a/src/integrations/trpc/router.ts
+++ b/src/integrations/trpc/router.ts
@@ -3,6 +3,7 @@ import { authRouter } from "./routers/auth"
 import { downloadClientsRouter } from "./routers/downloadClients"
 import { formatsRouter } from "./routers/formats"
 import { historyRouter } from "./routers/history"
+import { importRouter } from "./routers/import"
 import { indexersRouter } from "./routers/indexers"
 import { mediaServersRouter } from "./routers/mediaServers"
 import { moviesRouter } from "./routers/movies"
@@ -25,6 +26,7 @@ export const trpcRouter = createTRPCRouter({
   downloadClients: downloadClientsRouter,
   mediaServers: mediaServersRouter,
   history: historyRouter,
+  import: importRouter,
   releases: releasesRouter,
   rootFolders: rootFoldersRouter,
   scheduler: schedulerRouter,

--- a/src/integrations/trpc/routers/import.ts
+++ b/src/integrations/trpc/routers/import.ts
@@ -1,0 +1,50 @@
+import type { TRPCRouterRecord } from "@trpc/server"
+import { Effect } from "effect"
+import { z } from "zod"
+
+import { ImportService } from "#/effect/services/ImportService"
+
+import { publicProcedure, runEffect } from "../init"
+
+const credentialsInput = z.object({
+  url: z.string().url(),
+  apiKey: z.string().min(1),
+})
+
+export const importRouter = {
+  testRadarr: publicProcedure.input(credentialsInput).mutation(({ input }) =>
+    runEffect(
+      Effect.gen(function* () {
+        const svc = yield* ImportService
+        return yield* svc.testRadarr(input)
+      }),
+    ),
+  ),
+
+  testSonarr: publicProcedure.input(credentialsInput).mutation(({ input }) =>
+    runEffect(
+      Effect.gen(function* () {
+        const svc = yield* ImportService
+        return yield* svc.testSonarr(input)
+      }),
+    ),
+  ),
+
+  executeRadarr: publicProcedure.input(credentialsInput).mutation(({ input }) =>
+    runEffect(
+      Effect.gen(function* () {
+        const svc = yield* ImportService
+        return yield* svc.importFromRadarr(input)
+      }),
+    ),
+  ),
+
+  executeSonarr: publicProcedure.input(credentialsInput).mutation(({ input }) =>
+    runEffect(
+      Effect.gen(function* () {
+        const svc = yield* ImportService
+        return yield* svc.importFromSonarr(input)
+      }),
+    ),
+  ),
+} satisfies TRPCRouterRecord

--- a/src/lib/import/radarr-client.ts
+++ b/src/lib/import/radarr-client.ts
@@ -1,0 +1,37 @@
+import { RadarrMovieListSchema, RootFolderListSchema, SystemStatusSchema } from "./schemas"
+
+const TIMEOUT_MS = 30_000
+
+async function fetchJson(url: string): Promise<unknown> {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS)
+  try {
+    const res = await fetch(url, { signal: controller.signal })
+    if (!res.ok) throw new Error(`HTTP ${res.status}`)
+    return (await res.json()) as unknown
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+function buildUrl(baseUrl: string, path: string, apiKey: string): string {
+  const trimmed = baseUrl.replace(/\/+$/, "")
+  const url = new URL(`${trimmed}${path}`)
+  url.searchParams.set("apikey", apiKey)
+  return url.toString()
+}
+
+export async function testConnection(baseUrl: string, apiKey: string) {
+  const raw = await fetchJson(buildUrl(baseUrl, "/api/v3/system/status", apiKey))
+  return SystemStatusSchema.parse(raw)
+}
+
+export async function fetchMovies(baseUrl: string, apiKey: string) {
+  const raw = await fetchJson(buildUrl(baseUrl, "/api/v3/movie", apiKey))
+  return RadarrMovieListSchema.parse(raw)
+}
+
+export async function fetchRootFolders(baseUrl: string, apiKey: string) {
+  const raw = await fetchJson(buildUrl(baseUrl, "/api/v3/rootfolder", apiKey))
+  return RootFolderListSchema.parse(raw)
+}

--- a/src/lib/import/schemas.ts
+++ b/src/lib/import/schemas.ts
@@ -1,0 +1,76 @@
+import { z } from "zod"
+
+export const SystemStatusSchema = z.object({
+  version: z.string(),
+})
+
+export type SystemStatus = z.infer<typeof SystemStatusSchema>
+
+const ImageSchema = z.object({
+  coverType: z.string(),
+  remoteUrl: z.string().optional(),
+  url: z.string().optional(),
+})
+
+const RootFolderSchema = z.object({
+  id: z.number(),
+  path: z.string(),
+  accessible: z.boolean().optional(),
+  freeSpace: z.number().optional(),
+})
+
+export const RootFolderListSchema = z.array(RootFolderSchema)
+
+export const RadarrMovieSchema = z.object({
+  id: z.number(),
+  tmdbId: z.number(),
+  title: z.string(),
+  year: z.number().optional(),
+  overview: z.string().optional(),
+  monitored: z.boolean(),
+  hasFile: z.boolean(),
+  path: z.string().optional(),
+  images: z.array(ImageSchema).optional(),
+})
+
+export type RadarrMovie = z.infer<typeof RadarrMovieSchema>
+
+export const RadarrMovieListSchema = z.array(RadarrMovieSchema)
+
+const SonarrSeasonStatisticsSchema = z.object({
+  totalEpisodeCount: z.number().optional(),
+  episodeFileCount: z.number().optional(),
+})
+
+const SonarrSeasonSchema = z.object({
+  seasonNumber: z.number(),
+  monitored: z.boolean(),
+  statistics: SonarrSeasonStatisticsSchema.optional(),
+})
+
+export const SonarrSeriesSchema = z.object({
+  id: z.number(),
+  tvdbId: z.number(),
+  title: z.string(),
+  year: z.number().optional(),
+  overview: z.string().optional(),
+  monitored: z.boolean(),
+  status: z.string(),
+  network: z.string().optional(),
+  path: z.string().optional(),
+  seasonFolder: z.boolean().optional(),
+  seasons: z.array(SonarrSeasonSchema),
+  images: z.array(ImageSchema).optional(),
+})
+
+export type SonarrSeries = z.infer<typeof SonarrSeriesSchema>
+
+export const SonarrSeriesListSchema = z.array(SonarrSeriesSchema)
+
+export function posterOf(
+  images: ReadonlyArray<{ coverType: string; remoteUrl?: string; url?: string }> | undefined,
+): string | null {
+  if (!images) return null
+  const poster = images.find((i) => i.coverType === "poster")
+  return poster?.remoteUrl ?? poster?.url ?? null
+}

--- a/src/lib/import/sonarr-client.ts
+++ b/src/lib/import/sonarr-client.ts
@@ -1,0 +1,37 @@
+import { RootFolderListSchema, SonarrSeriesListSchema, SystemStatusSchema } from "./schemas"
+
+const TIMEOUT_MS = 30_000
+
+async function fetchJson(url: string): Promise<unknown> {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS)
+  try {
+    const res = await fetch(url, { signal: controller.signal })
+    if (!res.ok) throw new Error(`HTTP ${res.status}`)
+    return (await res.json()) as unknown
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+function buildUrl(baseUrl: string, path: string, apiKey: string): string {
+  const trimmed = baseUrl.replace(/\/+$/, "")
+  const url = new URL(`${trimmed}${path}`)
+  url.searchParams.set("apikey", apiKey)
+  return url.toString()
+}
+
+export async function testConnection(baseUrl: string, apiKey: string) {
+  const raw = await fetchJson(buildUrl(baseUrl, "/api/v3/system/status", apiKey))
+  return SystemStatusSchema.parse(raw)
+}
+
+export async function fetchSeries(baseUrl: string, apiKey: string) {
+  const raw = await fetchJson(buildUrl(baseUrl, "/api/v3/series", apiKey))
+  return SonarrSeriesListSchema.parse(raw)
+}
+
+export async function fetchRootFolders(baseUrl: string, apiKey: string) {
+  const raw = await fetchJson(buildUrl(baseUrl, "/api/v3/rootfolder", apiKey))
+  return RootFolderListSchema.parse(raw)
+}

--- a/src/routes/onboarding/wizard.tsx
+++ b/src/routes/onboarding/wizard.tsx
@@ -134,13 +134,8 @@ function StepPanel({
         />
       )
     case "import":
-      return (
-        <SkippableStep
-          stepKey="import"
-          title="Library import"
-          description="Radarr/Sonarr import is not yet available. Skip for now — tracked as a separate feature."
-        />
-      )
+      return <ImportStep capabilities={capabilities} />
+
     case "review":
       return <ReviewStep />
   }
@@ -441,6 +436,149 @@ function SkippableStep({
         error={error}
       />
     </section>
+  )
+}
+
+function ImportStep({
+  capabilities,
+}: {
+  capabilities: { readonly movies: boolean; readonly tv: boolean }
+}) {
+  const trpc = useTRPC()
+  const queryClient = useQueryClient()
+  const [error, setError] = useState<string | null>(null)
+
+  const skip = useMutation(
+    trpc.onboarding.skip.mutationOptions({
+      onSuccess: () =>
+        queryClient.invalidateQueries({ queryKey: trpc.onboarding.status.queryKey() }),
+      onError: (e) => setError(e.message),
+    }),
+  )
+
+  const onContinue = () => {
+    setError(null)
+    skip.mutate({ step: "import" })
+  }
+
+  return (
+    <section className="space-y-6">
+      <div>
+        <h2 className="text-xl font-semibold">Import from Radarr / Sonarr</h2>
+        <p className="text-muted-foreground text-sm">
+          Optional — pull your existing library. Credentials are only used for this import and never
+          stored.
+        </p>
+      </div>
+
+      {capabilities.movies && <ImportCard source="radarr" title="Radarr (Movies)" />}
+      {capabilities.tv && <ImportCard source="sonarr" title="Sonarr (TV)" />}
+
+      <StepControls
+        onNext={onContinue}
+        nextLabel="Continue"
+        pending={skip.isPending}
+        error={error}
+      />
+    </section>
+  )
+}
+
+function ImportCard({ source, title }: { source: "radarr" | "sonarr"; title: string }) {
+  const trpc = useTRPC()
+  const [url, setUrl] = useState("")
+  const [apiKey, setApiKey] = useState("")
+  const [testResult, setTestResult] = useState<
+    { ok: true; version: string } | { ok: false; message: string } | null
+  >(null)
+  const [importResult, setImportResult] = useState<{ imported: number; skipped: number } | null>(
+    null,
+  )
+
+  const testMutation = useMutation(
+    source === "radarr"
+      ? trpc.import.testRadarr.mutationOptions({
+          onSuccess: (data) => setTestResult({ ok: true, version: data.version }),
+          onError: (e) => setTestResult({ ok: false, message: e.message }),
+        })
+      : trpc.import.testSonarr.mutationOptions({
+          onSuccess: (data) => setTestResult({ ok: true, version: data.version }),
+          onError: (e) => setTestResult({ ok: false, message: e.message }),
+        }),
+  )
+
+  const importMutation = useMutation(
+    source === "radarr"
+      ? trpc.import.executeRadarr.mutationOptions({
+          onSuccess: (data) => setImportResult(data),
+          onError: (e) => setTestResult({ ok: false, message: e.message }),
+        })
+      : trpc.import.executeSonarr.mutationOptions({
+          onSuccess: (data) => setImportResult(data),
+          onError: (e) => setTestResult({ ok: false, message: e.message }),
+        }),
+  )
+
+  const canTest = url.trim().length > 0 && apiKey.trim().length > 0
+  const canImport = testResult?.ok === true && !importMutation.isPending && importResult === null
+
+  return (
+    <div className="space-y-3 rounded-lg border p-4">
+      <div className="font-medium">{title}</div>
+      <Field label="URL">
+        <Input
+          value={url}
+          onChange={(e) => setUrl(e.target.value)}
+          placeholder="http://localhost:7878"
+          autoComplete="off"
+        />
+      </Field>
+      <Field label="API key">
+        <Input
+          type="password"
+          value={apiKey}
+          onChange={(e) => setApiKey(e.target.value)}
+          autoComplete="off"
+        />
+      </Field>
+
+      <div className="flex items-center gap-3">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => {
+            setTestResult(null)
+            setImportResult(null)
+            testMutation.mutate({ url: url.trim(), apiKey: apiKey.trim() })
+          }}
+          disabled={!canTest || testMutation.isPending}
+        >
+          {testMutation.isPending ? "Testing…" : "Test connection"}
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          onClick={() => {
+            setImportResult(null)
+            importMutation.mutate({ url: url.trim(), apiKey: apiKey.trim() })
+          }}
+          disabled={!canImport}
+        >
+          {importMutation.isPending ? "Importing…" : "Import now"}
+        </Button>
+      </div>
+
+      {testResult?.ok === true && importResult === null && (
+        <p className="text-sm text-green-600">Connected — v{testResult.version}</p>
+      )}
+      {testResult?.ok === false && <p className="text-destructive text-sm">{testResult.message}</p>}
+      {importResult && (
+        <p className="text-sm text-green-600">
+          Imported {importResult.imported} · Skipped {importResult.skipped}
+        </p>
+      )}
+    </div>
   )
 }
 


### PR DESCRIPTION
## Summary
- `ImportService` (Effect) with `testRadarr/testSonarr/importFromRadarr/importFromSonarr`. Uses `SqlClient.withTransaction` for atomic batch insert; skips duplicates by tmdb_id/tvdb_id.
- Lightweight `fetch` + Zod clients in `src/lib/import/{radarr,sonarr}-client.ts` + `schemas.ts`. `?apikey=` query param, 30s timeout. No credential persistence.
- `import` tRPC sub-router (test + execute for both sources). `ImportError` tagged error mapped to TRPC codes.
- Guarded to active setup — `setup_not_active` if onboarding is already complete.
- Wizard `import` step now real UI: URL + API key + Test Connection + Import now per enabled capability. Credentials only in React state.

## Test plan
- [ ] Fresh setup → wizard → import step → enter bad URL → Test Connection shows clear error
- [ ] Enter valid Radarr URL+key → Test shows version → Import → counts imported/skipped
- [ ] Re-import same source → all skipped
- [ ] Sonarr same flow (series + seasons persisted)
- [ ] Skip import → Continue works
- [ ] After setup completes, calling `import.executeRadarr` returns 412 PRECONDITION_FAILED