### PR TITLE
feat: Plex user sync + per-user stats (closes #24)

### DIFF
--- a/drizzle/0004_stale_agent_zero.sql
+++ b/drizzle/0004_stale_agent_zero.sql
@@ -1,0 +1,19 @@
+CREATE TABLE `plex_users` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`media_server_id` integer NOT NULL,
+	`plex_user_id` text NOT NULL,
+	`username` text NOT NULL,
+	`friendly_name` text NOT NULL,
+	`email` text,
+	`thumb` text,
+	`is_admin` integer DEFAULT false NOT NULL,
+	`is_active` integer DEFAULT true NOT NULL,
+	`last_seen_at` integer,
+	`total_play_count` integer DEFAULT 0 NOT NULL,
+	`total_watch_time_sec` integer DEFAULT 0 NOT NULL,
+	`synced_at` integer DEFAULT (unixepoch()) NOT NULL,
+	`created_at` integer DEFAULT (unixepoch()) NOT NULL,
+	FOREIGN KEY (`media_server_id`) REFERENCES `media_servers`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `plex_users_media_server_id_plex_user_id_unique` ON `plex_users` (`media_server_id`,`plex_user_id`);

--- a/drizzle/meta/0004_snapshot.json
+++ b/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,2631 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "91624a2b-c185-43ed-881a-faf02c94e6f9",
+  "prevId": "0d13a62a-b756-467e-ba63-8100044e7d12",
+  "tables": {
+    "api_keys": {
+      "name": "api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "api_keys_token_hash_unique": {
+          "name": "api_keys_token_hash_unique",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "api_keys_user_id_users_id_fk": {
+          "name": "api_keys_user_id_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "custom_format_scores": {
+      "name": "custom_format_scores",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "custom_format_id": {
+          "name": "custom_format_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "custom_format_scores_profile_id_custom_format_id_unique": {
+          "name": "custom_format_scores_profile_id_custom_format_id_unique",
+          "columns": [
+            "profile_id",
+            "custom_format_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "custom_format_scores_profile_id_quality_profiles_id_fk": {
+          "name": "custom_format_scores_profile_id_quality_profiles_id_fk",
+          "tableFrom": "custom_format_scores",
+          "tableTo": "quality_profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "custom_format_scores_custom_format_id_custom_formats_id_fk": {
+          "name": "custom_format_scores_custom_format_id_custom_formats_id_fk",
+          "tableFrom": "custom_format_scores",
+          "tableTo": "custom_formats",
+          "columnsFrom": [
+            "custom_format_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "custom_format_specs": {
+      "name": "custom_format_specs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "custom_format_id": {
+          "name": "custom_format_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field": {
+          "name": "field",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "negate": {
+          "name": "negate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "required": {
+          "name": "required",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "custom_format_specs_custom_format_id_custom_formats_id_fk": {
+          "name": "custom_format_specs_custom_format_id_custom_formats_id_fk",
+          "tableFrom": "custom_format_specs",
+          "tableTo": "custom_formats",
+          "columnsFrom": [
+            "custom_format_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "custom_formats": {
+      "name": "custom_formats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "include_when_renaming": {
+          "name": "include_when_renaming",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "custom_formats_name_unique": {
+          "name": "custom_formats_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "download_client_health": {
+      "name": "download_client_health",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "download_client_id": {
+          "name": "download_client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_check": {
+          "name": "last_check",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unknown'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response_time_ms": {
+          "name": "response_time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "download_client_health_download_client_id_unique": {
+          "name": "download_client_health_download_client_id_unique",
+          "columns": [
+            "download_client_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "download_client_health_download_client_id_download_clients_id_fk": {
+          "name": "download_client_health_download_client_id_download_clients_id_fk",
+          "tableFrom": "download_client_health",
+          "tableTo": "download_clients",
+          "columnsFrom": [
+            "download_client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "download_clients": {
+      "name": "download_clients",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "port": {
+          "name": "port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_encrypted": {
+          "name": "password_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "use_ssl": {
+          "name": "use_ssl",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 50
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "settings": {
+          "name": "settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{\"pollIntervalMs\":5000}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "download_queue": {
+      "name": "download_queue",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "download_client_id": {
+          "name": "download_client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "movie_id": {
+          "name": "movie_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "series_id": {
+          "name": "series_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "episode_ids": {
+          "name": "episode_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'queued'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "progress": {
+          "name": "progress",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "eta_seconds": {
+          "name": "eta_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "download_queue_external_id_unique": {
+          "name": "download_queue_external_id_unique",
+          "columns": [
+            "external_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "download_queue_download_client_id_download_clients_id_fk": {
+          "name": "download_queue_download_client_id_download_clients_id_fk",
+          "tableFrom": "download_queue",
+          "tableTo": "download_clients",
+          "columnsFrom": [
+            "download_client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "download_queue_movie_id_movies_id_fk": {
+          "name": "download_queue_movie_id_movies_id_fk",
+          "tableFrom": "download_queue",
+          "tableTo": "movies",
+          "columnsFrom": [
+            "movie_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "download_queue_series_id_series_id_fk": {
+          "name": "download_queue_series_id_series_id_fk",
+          "tableFrom": "download_queue",
+          "tableTo": "series",
+          "columnsFrom": [
+            "series_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "episodes": {
+      "name": "episodes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tvdb_id": {
+          "name": "tvdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "episode_number": {
+          "name": "episode_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "air_date": {
+          "name": "air_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "overview": {
+          "name": "overview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "has_file": {
+          "name": "has_file",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "monitored": {
+          "name": "monitored",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "existing_quality_name": {
+          "name": "existing_quality_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "existing_quality_rank": {
+          "name": "existing_quality_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "existing_format_score": {
+          "name": "existing_format_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "episodes_tvdb_id_unique": {
+          "name": "episodes_tvdb_id_unique",
+          "columns": [
+            "tvdb_id"
+          ],
+          "isUnique": true
+        },
+        "episodes_season_id_episode_number_unique": {
+          "name": "episodes_season_id_episode_number_unique",
+          "columns": [
+            "season_id",
+            "episode_number"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "episodes_season_id_seasons_id_fk": {
+          "name": "episodes_season_id_seasons_id_fk",
+          "tableFrom": "episodes",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "indexer_health": {
+      "name": "indexer_health",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "indexer_id": {
+          "name": "indexer_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_check": {
+          "name": "last_check",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unknown'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response_time_ms": {
+          "name": "response_time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "indexer_health_indexer_id_unique": {
+          "name": "indexer_health_indexer_id_unique",
+          "columns": [
+            "indexer_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "indexer_health_indexer_id_indexers_id_fk": {
+          "name": "indexer_health_indexer_id_indexers_id_fk",
+          "tableFrom": "indexer_health",
+          "tableTo": "indexers",
+          "columnsFrom": [
+            "indexer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "indexers": {
+      "name": "indexers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key_encrypted": {
+          "name": "api_key_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 50
+        },
+        "categories": {
+          "name": "categories",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'null'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media_server_health": {
+      "name": "media_server_health",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "media_server_id": {
+          "name": "media_server_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_check": {
+          "name": "last_check",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unknown'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response_time_ms": {
+          "name": "response_time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "media_server_health_media_server_id_unique": {
+          "name": "media_server_health_media_server_id_unique",
+          "columns": [
+            "media_server_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "media_server_health_media_server_id_media_servers_id_fk": {
+          "name": "media_server_health_media_server_id_media_servers_id_fk",
+          "tableFrom": "media_server_health",
+          "tableTo": "media_servers",
+          "columnsFrom": [
+            "media_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media_server_libraries": {
+      "name": "media_server_libraries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "media_server_id": {
+          "name": "media_server_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "last_synced": {
+          "name": "last_synced",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "media_server_libraries_media_server_id_external_id_unique": {
+          "name": "media_server_libraries_media_server_id_external_id_unique",
+          "columns": [
+            "media_server_id",
+            "external_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "media_server_libraries_media_server_id_media_servers_id_fk": {
+          "name": "media_server_libraries_media_server_id_media_servers_id_fk",
+          "tableFrom": "media_server_libraries",
+          "tableTo": "media_servers",
+          "columnsFrom": [
+            "media_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media_servers": {
+      "name": "media_servers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "port": {
+          "name": "port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_encrypted": {
+          "name": "token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "use_ssl": {
+          "name": "use_ssl",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "settings": {
+          "name": "settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{\"syncIntervalMs\":3600000,\"monitoringEnabled\":true}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "movies": {
+      "name": "movies",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "tmdb_id": {
+          "name": "tmdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "overview": {
+          "name": "overview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "poster_path": {
+          "name": "poster_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'wanted'"
+        },
+        "quality_profile_id": {
+          "name": "quality_profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "root_folder_path": {
+          "name": "root_folder_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "monitored": {
+          "name": "monitored",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "has_file": {
+          "name": "has_file",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "existing_quality_name": {
+          "name": "existing_quality_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "existing_quality_rank": {
+          "name": "existing_quality_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "existing_format_score": {
+          "name": "existing_format_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "movies_tmdb_id_unique": {
+          "name": "movies_tmdb_id_unique",
+          "columns": [
+            "tmdb_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "movies_quality_profile_id_quality_profiles_id_fk": {
+          "name": "movies_quality_profile_id_quality_profiles_id_fk",
+          "tableFrom": "movies",
+          "tableTo": "quality_profiles",
+          "columnsFrom": [
+            "quality_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "plex_users": {
+      "name": "plex_users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "media_server_id": {
+          "name": "media_server_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plex_user_id": {
+          "name": "plex_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "friendly_name": {
+          "name": "friendly_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thumb": {
+          "name": "thumb",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_play_count": {
+          "name": "total_play_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_watch_time_sec": {
+          "name": "total_watch_time_sec",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "plex_users_media_server_id_plex_user_id_unique": {
+          "name": "plex_users_media_server_id_plex_user_id_unique",
+          "columns": [
+            "media_server_id",
+            "plex_user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "plex_users_media_server_id_media_servers_id_fk": {
+          "name": "plex_users_media_server_id_media_servers_id_fk",
+          "tableFrom": "plex_users",
+          "tableTo": "media_servers",
+          "columnsFrom": [
+            "media_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "quality_items": {
+      "name": "quality_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quality_name": {
+          "name": "quality_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "group_name": {
+          "name": "group_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "allowed": {
+          "name": "allowed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "quality_items_profile_id_quality_profiles_id_fk": {
+          "name": "quality_items_profile_id_quality_profiles_id_fk",
+          "tableFrom": "quality_items",
+          "tableTo": "quality_profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "quality_profiles": {
+      "name": "quality_profiles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "upgrade_allowed": {
+          "name": "upgrade_allowed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "min_format_score": {
+          "name": "min_format_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cutoff_format_score": {
+          "name": "cutoff_format_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "min_upgrade_format_score": {
+          "name": "min_upgrade_format_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "applied_bundle_id": {
+          "name": "applied_bundle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "applied_bundle_version": {
+          "name": "applied_bundle_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "quality_profiles_name_unique": {
+          "name": "quality_profiles_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "release_decisions": {
+      "name": "release_decisions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "candidate_title": {
+          "name": "candidate_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "indexer_id": {
+          "name": "indexer_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "indexer_name": {
+          "name": "indexer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quality_rank": {
+          "name": "quality_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "format_score": {
+          "name": "format_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reasons": {
+          "name": "reasons",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "root_folders": {
+      "name": "root_folders",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "free_space_bytes": {
+          "name": "free_space_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_space_bytes": {
+          "name": "total_space_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "root_folders_path_unique": {
+          "name": "root_folders_path_unique",
+          "columns": [
+            "path"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scheduler_config": {
+      "name": "scheduler_config",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "job_type": {
+          "name": "job_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "interval_minutes": {
+          "name": "interval_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "retry_delay_seconds": {
+          "name": "retry_delay_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 60
+        },
+        "max_retries": {
+          "name": "max_retries",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 3
+        },
+        "backoff_multiplier": {
+          "name": "backoff_multiplier",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "scheduler_config_job_type_unique": {
+          "name": "scheduler_config_job_type_unique",
+          "columns": [
+            "job_type"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scheduler_jobs": {
+      "name": "scheduler_jobs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "job_type": {
+          "name": "job_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 3
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "seasons": {
+      "name": "seasons",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "series_id": {
+          "name": "series_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "season_number": {
+          "name": "season_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "monitored": {
+          "name": "monitored",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "seasons_series_id_season_number_unique": {
+          "name": "seasons_series_id_season_number_unique",
+          "columns": [
+            "series_id",
+            "season_number"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "seasons_series_id_series_id_fk": {
+          "name": "seasons_series_id_series_id_fk",
+          "tableFrom": "seasons",
+          "tableTo": "series",
+          "columnsFrom": [
+            "series_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "series": {
+      "name": "series",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "tvdb_id": {
+          "name": "tvdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "overview": {
+          "name": "overview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "poster_path": {
+          "name": "poster_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'wanted'"
+        },
+        "network": {
+          "name": "network",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "root_folder_path": {
+          "name": "root_folder_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "monitored": {
+          "name": "monitored",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "quality_profile_id": {
+          "name": "quality_profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "season_folder": {
+          "name": "season_folder",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "series_tvdb_id_unique": {
+          "name": "series_tvdb_id_unique",
+          "columns": [
+            "tvdb_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "series_quality_profile_id_quality_profiles_id_fk": {
+          "name": "series_quality_profile_id_quality_profiles_id_fk",
+          "tableFrom": "series",
+          "tableTo": "quality_profiles",
+          "columnsFrom": [
+            "quality_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_history": {
+      "name": "session_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "media_server_id": {
+          "name": "media_server_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plex_user_id": {
+          "name": "plex_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plex_username": {
+          "name": "plex_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rating_key": {
+          "name": "rating_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_title": {
+          "name": "parent_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "grandparent_title": {
+          "name": "grandparent_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thumb": {
+          "name": "thumb",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stopped_at": {
+          "name": "stopped_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "view_offset": {
+          "name": "view_offset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "paused_duration_sec": {
+          "name": "paused_duration_sec",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "transcode_decision": {
+          "name": "transcode_decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "video_resolution": {
+          "name": "video_resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "audio_codec": {
+          "name": "audio_codec",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "player": {
+          "name": "player",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "product": {
+          "name": "product",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bandwidth": {
+          "name": "bandwidth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_local": {
+          "name": "is_local",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "movie_id": {
+          "name": "movie_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "episode_id": {
+          "name": "episode_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_history_media_server_id_media_servers_id_fk": {
+          "name": "session_history_media_server_id_media_servers_id_fk",
+          "tableFrom": "session_history",
+          "tableTo": "media_servers",
+          "columnsFrom": [
+            "media_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_history_movie_id_movies_id_fk": {
+          "name": "session_history_movie_id_movies_id_fk",
+          "tableFrom": "session_history",
+          "tableTo": "movies",
+          "columnsFrom": [
+            "movie_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "session_history_episode_id_episodes_id_fk": {
+          "name": "session_history_episode_id_episodes_id_fk",
+          "tableFrom": "session_history",
+          "tableTo": "episodes",
+          "columnsFrom": [
+            "episode_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "settings": {
+      "name": "settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "setup_log": {
+      "name": "setup_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "step_name": {
+          "name": "step_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reversible": {
+          "name": "reversible",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "rolled_back": {
+          "name": "rolled_back",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "setup_state": {
+      "name": "setup_state",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "current_step": {
+          "name": "current_step",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_steps": {
+          "name": "completed_steps",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{\"movies\":true,\"tv\":true}'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/src/components/sidebar/nav-data.ts
+++ b/src/components/sidebar/nav-data.ts
@@ -17,6 +17,7 @@ import {
   Server,
   Settings,
   Tv,
+  Users,
 } from "lucide-react"
 
 import type { FileRoutesByTo } from "@/routeTree.gen"
@@ -52,6 +53,7 @@ const collapsibleGroups = [
     items: [
       { title: "Queue", to: "/activity/queue", icon: ListOrdered },
       { title: "History", to: "/activity/history", icon: History },
+      { title: "Users", to: "/activity/users", icon: Users },
     ],
   },
   {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -363,6 +363,33 @@ export const mediaServerLibraries = sqliteTable(
   (t) => [unique().on(t.mediaServerId, t.externalId)],
 )
 
+export const plexUsers = sqliteTable(
+  "plex_users",
+  {
+    id: integer().primaryKey({ autoIncrement: true }),
+    mediaServerId: integer("media_server_id")
+      .notNull()
+      .references(() => mediaServers.id, { onDelete: "cascade" }),
+    plexUserId: text("plex_user_id").notNull(),
+    username: text().notNull(),
+    friendlyName: text("friendly_name").notNull(),
+    email: text(),
+    thumb: text(),
+    isAdmin: integer("is_admin", { mode: "boolean" }).notNull().default(false),
+    isActive: integer("is_active", { mode: "boolean" }).notNull().default(true),
+    lastSeenAt: integer("last_seen_at", { mode: "timestamp" }),
+    totalPlayCount: integer("total_play_count").notNull().default(0),
+    totalWatchTimeSec: integer("total_watch_time_sec").notNull().default(0),
+    syncedAt: integer("synced_at", { mode: "timestamp" })
+      .notNull()
+      .default(sql`(unixepoch())`),
+    createdAt: integer("created_at", { mode: "timestamp" })
+      .notNull()
+      .default(sql`(unixepoch())`),
+  },
+  (t) => [unique().on(t.mediaServerId, t.plexUserId)],
+)
+
 export const sessionHistory = sqliteTable("session_history", {
   id: integer().primaryKey({ autoIncrement: true }),
   mediaServerId: integer("media_server_id")

--- a/src/effect/domain/mediaServer.ts
+++ b/src/effect/domain/mediaServer.ts
@@ -147,6 +147,17 @@ export interface MediaServerSession {
   readonly tvdbId: number | null
 }
 
+// ── Shared users (Plex /accounts; Jellyfin returns []) ──
+
+export interface MediaServerSharedUser {
+  readonly plexUserId: string
+  readonly username: string
+  readonly friendlyName: string
+  readonly email: string | null
+  readonly thumb: string | null
+  readonly isAdmin: boolean
+}
+
 export interface MediaServerLibraryWithSync {
   readonly id: number
   readonly mediaServerId: number

--- a/src/effect/layers.ts
+++ b/src/effect/layers.ts
@@ -14,6 +14,7 @@ import { MediaServerServiceLive } from "./services/MediaServerService"
 import { MovieServiceLive } from "./services/MovieService"
 import { OnboardingServiceLive } from "./services/OnboardingService"
 import { PlexSessionMonitorLive } from "./services/PlexSessionMonitor"
+import { PlexUserServiceLive } from "./services/PlexUserService"
 import { ProfileDefaultsEngineLive } from "./services/ProfileDefaultsEngine"
 import { ProfileServiceLive } from "./services/ProfileService"
 import { ReleasePolicyEngineLive } from "./services/ReleasePolicyEngine"
@@ -43,6 +44,7 @@ export const AppLive = Layer.mergeAll(
       MediaServerServiceLive,
       ReleasePolicyEngineLive,
       SessionHistoryServiceLive,
+      PlexUserServiceLive,
     ),
   ),
   Layer.provideMerge(TitleParserServiceLive),

--- a/src/effect/services/JellyfinAdapter.ts
+++ b/src/effect/services/JellyfinAdapter.ts
@@ -274,6 +274,8 @@ export function createJellyfinAdapter(config: MediaServerConfig): MediaServerAda
     getActiveSessions: (): Effect.Effect<ReadonlyArray<MediaServerSession>, MediaServerError> =>
       Effect.succeed([]),
 
+    getSharedUsers: () => Effect.succeed([]),
+
     getHealth: (): Effect.Effect<MediaServerHealth, MediaServerError> =>
       Effect.gen(function* () {
         const infoResult = yield* jellyfinJson<JellyfinSystemInfo>("/System/Info").pipe(

--- a/src/effect/services/MediaServerAdapter.ts
+++ b/src/effect/services/MediaServerAdapter.ts
@@ -5,6 +5,7 @@ import type {
   MediaServerHealth,
   MediaServerLibrary,
   MediaServerSession,
+  MediaServerSharedUser,
   ParsedGuid,
   SyncedItem,
 } from "../domain/mediaServer"
@@ -26,6 +27,11 @@ export interface MediaServerAdapter {
   /** Snapshot of currently-active streams. Adapters without monitoring support return []. */
   readonly getActiveSessions: () => Effect.Effect<
     ReadonlyArray<MediaServerSession>,
+    MediaServerError
+  >
+  /** Users that have access to this server. Adapters without user enumeration return []. */
+  readonly getSharedUsers: () => Effect.Effect<
+    ReadonlyArray<MediaServerSharedUser>,
     MediaServerError
   >
 }

--- a/src/effect/services/PlexAdapter.ts
+++ b/src/effect/services/PlexAdapter.ts
@@ -8,6 +8,7 @@ import type {
   MediaServerLibrary,
   MediaServerLibraryType,
   MediaServerSession,
+  MediaServerSharedUser,
   SessionMediaType,
   SessionState,
   SyncedItem,
@@ -165,6 +166,25 @@ interface PlexSessionMetadata {
 interface PlexStatusSessions {
   readonly MediaContainer: {
     readonly Metadata?: ReadonlyArray<PlexSessionMetadata>
+  }
+}
+
+// ── /accounts ──
+
+interface PlexAccount {
+  readonly id: number
+  readonly key?: string
+  readonly name?: string
+  readonly defaultAudioLanguage?: string
+  readonly autoSelectAudio?: boolean
+  readonly defaultSubtitleLanguage?: string
+  readonly subtitleMode?: number
+  readonly thumb?: string
+}
+
+interface PlexAccounts {
+  readonly MediaContainer: {
+    readonly Account?: ReadonlyArray<PlexAccount>
   }
 }
 
@@ -408,6 +428,28 @@ export function createPlexAdapter(config: MediaServerConfig): MediaServerAdapter
         return metadata.flatMap((m): ReadonlyArray<MediaServerSession> => {
           const mapped = mapPlexSession(config.id, m, now)
           return mapped ? [mapped] : []
+        })
+      }),
+
+    getSharedUsers: (): Effect.Effect<ReadonlyArray<MediaServerSharedUser>, MediaServerError> =>
+      Effect.gen(function* () {
+        const accounts = yield* plexJson<PlexAccounts>("/accounts")
+        const list = accounts.MediaContainer.Account ?? []
+        return list.flatMap((a): ReadonlyArray<MediaServerSharedUser> => {
+          // id=0 is the "Local" anonymous pseudo-account — skip.
+          if (a.id === 0) return []
+          const name = a.name ?? `user-${a.id}`
+          return [
+            {
+              plexUserId: String(a.id),
+              username: name,
+              friendlyName: name,
+              email: null,
+              thumb: a.thumb ?? null,
+              // id=1 is the server owner in Plex.
+              isAdmin: a.id === 1,
+            },
+          ]
         })
       }),
 

--- a/src/effect/services/PlexUserService.test.ts
+++ b/src/effect/services/PlexUserService.test.ts
@@ -1,0 +1,265 @@
+import { SqlClient } from "@effect/sql"
+import { describe, expect, it } from "@effect/vitest"
+import { Effect, Layer, Ref } from "effect"
+
+import type {
+  MediaServerAdapterMetadata,
+  MediaServerSession,
+  MediaServerSharedUser,
+} from "#/effect/domain/mediaServer"
+import { AdapterRegistry, AdapterRegistryLive } from "#/effect/services/AdapterRegistry"
+import { CryptoService, CryptoServiceLive } from "#/effect/services/CryptoService"
+import type { MediaServerAdapter } from "#/effect/services/MediaServerAdapter"
+import {
+  SessionHistoryService,
+  SessionHistoryServiceLive,
+} from "#/effect/services/SessionHistoryService"
+import { TestDbLive } from "#/effect/test/TestDb"
+
+import { PlexUserService, PlexUserServiceLive } from "./PlexUserService"
+
+const TestLayer = PlexUserServiceLive.pipe(
+  Layer.provideMerge(SessionHistoryServiceLive),
+  Layer.provideMerge(CryptoServiceLive),
+  Layer.provideMerge(AdapterRegistryLive),
+  Layer.provideMerge(TestDbLive),
+)
+
+const seedMediaServer = Effect.gen(function* () {
+  const crypto = yield* CryptoService
+  const token = yield* crypto.encrypt("tok")
+  const sql = yield* SqlClient.SqlClient
+  yield* sql`INSERT INTO media_servers (name, type, host, port, token_encrypted) VALUES ('mock', 'mock-plex', '127.0.0.1', 32400, ${token})`
+  return 1
+})
+
+const mockMetadata: MediaServerAdapterMetadata = {
+  displayName: "Mock",
+  defaultPort: 32400,
+  authModel: "token",
+}
+
+const mockAdapter = (
+  usersRef: Ref.Ref<ReadonlyArray<MediaServerSharedUser>>,
+): MediaServerAdapter => ({
+  testConnection: () => Effect.die("not used"),
+  getLibraries: () => Effect.succeed([]),
+  syncLibrary: () => Effect.succeed([]),
+  refreshLibrary: () => Effect.void,
+  getHealth: () => Effect.die("not used"),
+  getActiveSessions: () => Effect.succeed([]),
+  getSharedUsers: () => Ref.get(usersRef),
+})
+
+const registerMock = (usersRef: Ref.Ref<ReadonlyArray<MediaServerSharedUser>>) =>
+  Effect.gen(function* () {
+    const registry = yield* AdapterRegistry
+    registry.registerMediaServer("mock-plex", mockMetadata, () => mockAdapter(usersRef))
+  })
+
+const baseSession = (overrides: Partial<MediaServerSession> = {}): MediaServerSession => ({
+  mediaServerId: 1,
+  sessionKey: "sk-1",
+  ratingKey: "rk-1",
+  userId: "42",
+  username: "alice",
+  userThumb: null,
+  state: "playing",
+  mediaType: "movie",
+  title: "The Movie",
+  parentTitle: null,
+  grandparentTitle: null,
+  year: 2024,
+  thumb: null,
+  viewOffset: 120_000,
+  duration: 200_000,
+  progressPercent: 60,
+  transcodeDecision: "direct_play",
+  videoResolution: "1080",
+  audioCodec: "aac",
+  player: "PlexWeb",
+  platform: "Chrome",
+  product: "Plex Web",
+  ipAddress: "10.0.0.1",
+  bandwidth: 5000,
+  isLocal: true,
+  startedAt: new Date(1_700_000_000_000),
+  updatedAt: new Date(1_700_000_060_000),
+  tmdbId: null,
+  tvdbId: null,
+  ...overrides,
+})
+
+describe("PlexUserService", () => {
+  it.effect("syncUsers inserts new users and marks missing ones inactive", () =>
+    Effect.gen(function* () {
+      yield* seedMediaServer
+      const usersRef = yield* Ref.make<ReadonlyArray<MediaServerSharedUser>>([
+        {
+          plexUserId: "1",
+          username: "owner",
+          friendlyName: "owner",
+          email: null,
+          thumb: null,
+          isAdmin: true,
+        },
+        {
+          plexUserId: "42",
+          username: "alice",
+          friendlyName: "alice",
+          email: null,
+          thumb: null,
+          isAdmin: false,
+        },
+      ])
+      yield* registerMock(usersRef)
+      const svc = yield* PlexUserService
+
+      const first = yield* svc.syncUsers(1)
+      expect(first.added).toBe(2)
+      expect(first.updated).toBe(0)
+      expect(first.deactivated).toBe(0)
+
+      const listed = yield* svc.listUsers(1)
+      expect(listed).toHaveLength(2)
+      expect(listed.find((u) => u.plexUserId === "1")?.isAdmin).toBe(true)
+
+      // Second sync — same users, different friendly names + alice removed
+      yield* Ref.set(usersRef, [
+        {
+          plexUserId: "1",
+          username: "owner",
+          friendlyName: "Owner Renamed",
+          email: "o@example.com",
+          thumb: "http://thumb",
+          isAdmin: true,
+        },
+      ])
+      const second = yield* svc.syncUsers(1)
+      expect(second.added).toBe(0)
+      expect(second.updated).toBe(1)
+      expect(second.deactivated).toBe(1)
+
+      const afterSecond = yield* svc.listUsers(1)
+      const alice = afterSecond.find((u) => u.plexUserId === "42")
+      expect(alice?.isActive).toBe(false)
+      const owner = afterSecond.find((u) => u.plexUserId === "1")
+      expect(owner?.friendlyName).toBe("Owner Renamed")
+      expect(owner?.email).toBe("o@example.com")
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.effect("getUserStats aggregates from session_history", () =>
+    Effect.gen(function* () {
+      yield* seedMediaServer
+      const usersRef = yield* Ref.make<ReadonlyArray<MediaServerSharedUser>>([
+        {
+          plexUserId: "42",
+          username: "alice",
+          friendlyName: "alice",
+          email: null,
+          thumb: null,
+          isAdmin: false,
+        },
+      ])
+      yield* registerMock(usersRef)
+      const svc = yield* PlexUserService
+      yield* svc.syncUsers(1)
+
+      const history = yield* SessionHistoryService
+      yield* history.writeHistory([
+        baseSession({
+          sessionKey: "a",
+          title: "Movie A",
+          viewOffset: 60_000,
+          duration: 100_000,
+        }),
+        baseSession({
+          sessionKey: "b",
+          title: "Movie B",
+          viewOffset: 30_000,
+          duration: 100_000,
+        }),
+        baseSession({
+          sessionKey: "c",
+          mediaType: "episode",
+          title: "S01E01",
+          grandparentTitle: "Show X",
+          viewOffset: 45_000,
+          duration: 100_000,
+        }),
+        baseSession({
+          sessionKey: "d",
+          mediaType: "episode",
+          title: "S01E02",
+          grandparentTitle: "Show X",
+          viewOffset: 45_000,
+          duration: 100_000,
+        }),
+      ])
+
+      const stats = yield* svc.getUserStats({ serverId: 1, plexUserId: "42" })
+      expect(stats.totalPlayCount).toBe(4)
+      // 60 + 30 + 45 + 45 = 180 seconds
+      expect(stats.totalWatchTimeSec).toBe(180)
+      expect(stats.lastSeenAt).not.toBeNull()
+      // Top media: "Show X" has 2 plays, Movie A has 1, Movie B has 1
+      expect(stats.topMedia[0].title).toBe("Show X")
+      expect(stats.topMedia[0].playCount).toBe(2)
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.effect("session write bumps cached plex_users counters + lastSeenAt", () =>
+    Effect.gen(function* () {
+      yield* seedMediaServer
+      const usersRef = yield* Ref.make<ReadonlyArray<MediaServerSharedUser>>([
+        {
+          plexUserId: "42",
+          username: "alice",
+          friendlyName: "alice",
+          email: null,
+          thumb: null,
+          isAdmin: false,
+        },
+      ])
+      yield* registerMock(usersRef)
+      const svc = yield* PlexUserService
+      yield* svc.syncUsers(1)
+
+      const history = yield* SessionHistoryService
+      yield* history.writeHistory([
+        baseSession({ sessionKey: "a", viewOffset: 60_000, duration: 100_000 }),
+        baseSession({ sessionKey: "b", viewOffset: 30_000, duration: 100_000 }),
+      ])
+
+      const users = yield* svc.listUsers(1)
+      const alice = users.find((u) => u.plexUserId === "42")
+      expect(alice?.totalPlayCount).toBe(2)
+      expect(alice?.totalWatchTimeSec).toBe(90)
+      expect(alice?.lastSeenAt).not.toBeNull()
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.effect("syncUsers returns NotFoundError for unknown server", () =>
+    Effect.gen(function* () {
+      const svc = yield* PlexUserService
+      const err = yield* Effect.flip(svc.syncUsers(999))
+      expect(err._tag).toBe("NotFoundError")
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.effect("recordWatch is a no-op when user row is absent", () =>
+    Effect.gen(function* () {
+      yield* seedMediaServer
+      const svc = yield* PlexUserService
+      yield* svc.recordWatch({
+        mediaServerId: 1,
+        plexUserId: "ghost",
+        watchedSec: 30,
+        stoppedAt: new Date(),
+      })
+      const users = yield* svc.listUsers(1)
+      expect(users).toHaveLength(0)
+    }).pipe(Effect.provide(TestLayer)),
+  )
+})

--- a/src/effect/services/PlexUserService.ts
+++ b/src/effect/services/PlexUserService.ts
@@ -1,0 +1,242 @@
+import { SqlError } from "@effect/sql/SqlError"
+import { and, count, desc, eq, max, notInArray, sql } from "drizzle-orm"
+import { Context, Effect, Layer } from "effect"
+
+import { mediaServers, plexUsers, sessionHistory } from "#/db/schema"
+
+import type { SessionMediaType } from "../domain/mediaServer"
+import {
+  MediaServerError,
+  NotFoundError,
+  type EncryptionError,
+  type ValidationError,
+} from "../errors"
+import { AdapterRegistry } from "./AdapterRegistry"
+import { CryptoService } from "./CryptoService"
+import { Db } from "./Db"
+
+// ── Types ──
+
+export type PlexUserRow = typeof plexUsers.$inferSelect
+
+export interface PlexUserSyncResult {
+  readonly added: number
+  readonly updated: number
+  readonly deactivated: number
+}
+
+export interface TopMediaEntry {
+  readonly mediaType: SessionMediaType
+  readonly title: string
+  readonly playCount: number
+  readonly totalWatchedSec: number
+}
+
+export interface PlexUserStats {
+  readonly totalPlayCount: number
+  readonly totalWatchTimeSec: number
+  readonly lastSeenAt: Date | null
+  readonly topMedia: ReadonlyArray<TopMediaEntry>
+}
+
+// ── Service tag ──
+
+export class PlexUserService extends Context.Tag("@arr-hub/PlexUserService")<
+  PlexUserService,
+  {
+    readonly syncUsers: (
+      serverId: number,
+    ) => Effect.Effect<
+      PlexUserSyncResult,
+      NotFoundError | MediaServerError | ValidationError | EncryptionError | SqlError
+    >
+    readonly listUsers: (serverId: number) => Effect.Effect<ReadonlyArray<PlexUserRow>, SqlError>
+    readonly getUserStats: (args: {
+      readonly serverId: number
+      readonly plexUserId: string
+    }) => Effect.Effect<PlexUserStats, SqlError>
+    /** Bump cached counters + lastSeenAt for a recorded watch. No-op if user row missing. */
+    readonly recordWatch: (args: {
+      readonly mediaServerId: number
+      readonly plexUserId: string
+      readonly watchedSec: number
+      readonly stoppedAt: Date
+    }) => Effect.Effect<void, SqlError>
+  }
+>() {}
+
+// ── Live implementation ──
+
+const TOP_MEDIA_LIMIT = 5
+
+export const PlexUserServiceLive = Layer.effect(
+  PlexUserService,
+  Effect.gen(function* () {
+    const db = yield* Db
+    const crypto = yield* CryptoService
+    const registry = yield* AdapterRegistry
+
+    const loadAdapter = (serverId: number) =>
+      Effect.gen(function* () {
+        const rows = yield* db.select().from(mediaServers).where(eq(mediaServers.id, serverId))
+        const server = rows[0]
+        if (!server) return yield* new NotFoundError({ entity: "media_server", id: serverId })
+        const token = yield* crypto.decrypt(server.tokenEncrypted)
+        const factory = yield* registry.getMediaServerFactory(server.type)
+        return factory({
+          id: server.id,
+          name: server.name,
+          type: server.type,
+          host: server.host,
+          port: server.port,
+          token,
+          useSsl: server.useSsl,
+          settings: server.settings,
+        })
+      })
+
+    return {
+      syncUsers: (serverId) =>
+        Effect.gen(function* () {
+          const adapter = yield* loadAdapter(serverId)
+          const users = yield* adapter.getSharedUsers()
+          const now = new Date()
+
+          const existingRows = yield* db
+            .select({ plexUserId: plexUsers.plexUserId })
+            .from(plexUsers)
+            .where(eq(plexUsers.mediaServerId, serverId))
+          const existingIds = new Set(existingRows.map((r) => r.plexUserId))
+
+          let added = 0
+          let updated = 0
+          const seenIds: Array<string> = []
+
+          for (const u of users) {
+            seenIds.push(u.plexUserId)
+            yield* db
+              .insert(plexUsers)
+              .values({
+                mediaServerId: serverId,
+                plexUserId: u.plexUserId,
+                username: u.username,
+                friendlyName: u.friendlyName,
+                email: u.email,
+                thumb: u.thumb,
+                isAdmin: u.isAdmin,
+                isActive: true,
+                syncedAt: now,
+              })
+              .onConflictDoUpdate({
+                target: [plexUsers.mediaServerId, plexUsers.plexUserId],
+                set: {
+                  username: u.username,
+                  friendlyName: u.friendlyName,
+                  email: u.email,
+                  thumb: u.thumb,
+                  isAdmin: u.isAdmin,
+                  isActive: true,
+                  syncedAt: now,
+                },
+              })
+
+            if (existingIds.has(u.plexUserId)) updated++
+            else added++
+          }
+
+          // Mark users missing from the latest sync as inactive.
+          const notSeen =
+            seenIds.length === 0 ? undefined : notInArray(plexUsers.plexUserId, seenIds)
+          const deactivated = yield* db
+            .update(plexUsers)
+            .set({ isActive: false })
+            .where(
+              and(
+                eq(plexUsers.mediaServerId, serverId),
+                eq(plexUsers.isActive, true),
+                ...(notSeen ? [notSeen] : []),
+              ),
+            )
+            .returning({ id: plexUsers.id })
+
+          return { added, updated, deactivated: deactivated.length }
+        }),
+
+      listUsers: (serverId) =>
+        db
+          .select()
+          .from(plexUsers)
+          .where(eq(plexUsers.mediaServerId, serverId))
+          .orderBy(desc(plexUsers.isActive), desc(plexUsers.isAdmin), plexUsers.friendlyName),
+
+      getUserStats: ({ serverId, plexUserId }) =>
+        Effect.gen(function* () {
+          const watchedExpr = sql<number>`SUM(${sessionHistory.viewOffset})`
+          const aggregateRows = yield* db
+            .select({
+              totalPlayCount: count(),
+              totalWatchedMs: watchedExpr,
+              lastSeenAt: max(sessionHistory.stoppedAt),
+            })
+            .from(sessionHistory)
+            .where(
+              and(
+                eq(sessionHistory.mediaServerId, serverId),
+                eq(sessionHistory.plexUserId, plexUserId),
+              ),
+            )
+
+          const agg = aggregateRows[0]
+          const totalWatchedMs = Number(agg?.totalWatchedMs ?? 0)
+          const lastSeenRaw = agg?.lastSeenAt ?? null
+
+          const topRows = yield* db
+            .select({
+              mediaType: sessionHistory.mediaType,
+              title: sql<string>`COALESCE(${sessionHistory.grandparentTitle}, ${sessionHistory.title})`,
+              playCount: count(),
+              totalWatchedMs: watchedExpr,
+            })
+            .from(sessionHistory)
+            .where(
+              and(
+                eq(sessionHistory.mediaServerId, serverId),
+                eq(sessionHistory.plexUserId, plexUserId),
+              ),
+            )
+            .groupBy(
+              sessionHistory.mediaType,
+              sql`COALESCE(${sessionHistory.grandparentTitle}, ${sessionHistory.title})`,
+            )
+            .orderBy(desc(count()))
+            .limit(TOP_MEDIA_LIMIT)
+
+          return {
+            totalPlayCount: agg?.totalPlayCount ?? 0,
+            totalWatchTimeSec: Math.round(totalWatchedMs / 1000),
+            lastSeenAt: lastSeenRaw ? new Date(lastSeenRaw) : null,
+            topMedia: topRows.map((r) => ({
+              mediaType: r.mediaType,
+              title: r.title,
+              playCount: r.playCount,
+              totalWatchedSec: Math.round(Number(r.totalWatchedMs ?? 0) / 1000),
+            })),
+          }
+        }),
+
+      recordWatch: ({ mediaServerId, plexUserId, watchedSec, stoppedAt }) =>
+        Effect.gen(function* () {
+          yield* db
+            .update(plexUsers)
+            .set({
+              lastSeenAt: stoppedAt,
+              totalPlayCount: sql`${plexUsers.totalPlayCount} + 1`,
+              totalWatchTimeSec: sql`${plexUsers.totalWatchTimeSec} + ${watchedSec}`,
+            })
+            .where(
+              and(eq(plexUsers.mediaServerId, mediaServerId), eq(plexUsers.plexUserId, plexUserId)),
+            )
+        }),
+    }
+  }),
+)

--- a/src/effect/services/SessionHistoryService.ts
+++ b/src/effect/services/SessionHistoryService.ts
@@ -1,8 +1,8 @@
 import { SqlError } from "@effect/sql/SqlError"
-import { and, between, desc, eq, lt, type SQL } from "drizzle-orm"
+import { and, between, desc, eq, lt, sql, type SQL } from "drizzle-orm"
 import { Context, Effect, Layer } from "effect"
 
-import { episodes, movies, sessionHistory } from "#/db/schema"
+import { episodes, movies, plexUsers, sessionHistory } from "#/db/schema"
 
 import type { MediaServerSession, SessionMediaType } from "../domain/mediaServer"
 import { Db } from "./Db"
@@ -136,6 +136,22 @@ export const SessionHistoryServiceLive = Layer.effect(
               })
               .returning()
             out.push(row)
+
+            // Bump cached counters on plex_users. No-op if user row hasn't been synced yet.
+            const watchedSec = Math.round(s.viewOffset / 1000)
+            yield* db
+              .update(plexUsers)
+              .set({
+                lastSeenAt: stoppedAt,
+                totalPlayCount: sql`${plexUsers.totalPlayCount} + 1`,
+                totalWatchTimeSec: sql`${plexUsers.totalWatchTimeSec} + ${watchedSec}`,
+              })
+              .where(
+                and(
+                  eq(plexUsers.mediaServerId, s.mediaServerId),
+                  eq(plexUsers.plexUserId, s.userId),
+                ),
+              )
           }
 
           return out

--- a/src/effect/test/TestDb.ts
+++ b/src/effect/test/TestDb.ts
@@ -254,6 +254,24 @@ const runDdl = Effect.gen(function* () {
     UNIQUE(media_server_id, external_id)
   )`
 
+  yield* sql`CREATE TABLE plex_users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    media_server_id INTEGER NOT NULL REFERENCES media_servers(id) ON DELETE CASCADE,
+    plex_user_id TEXT NOT NULL,
+    username TEXT NOT NULL,
+    friendly_name TEXT NOT NULL,
+    email TEXT,
+    thumb TEXT,
+    is_admin INTEGER NOT NULL DEFAULT 0,
+    is_active INTEGER NOT NULL DEFAULT 1,
+    last_seen_at INTEGER,
+    total_play_count INTEGER NOT NULL DEFAULT 0,
+    total_watch_time_sec INTEGER NOT NULL DEFAULT 0,
+    synced_at INTEGER NOT NULL DEFAULT (unixepoch()),
+    created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+    UNIQUE(media_server_id, plex_user_id)
+  )`
+
   yield* sql`CREATE TABLE session_history (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     media_server_id INTEGER NOT NULL REFERENCES media_servers(id) ON DELETE CASCADE,

--- a/src/integrations/trpc/router.ts
+++ b/src/integrations/trpc/router.ts
@@ -8,6 +8,7 @@ import { indexersRouter } from "./routers/indexers"
 import { mediaServersRouter } from "./routers/mediaServers"
 import { moviesRouter } from "./routers/movies"
 import { onboardingRouter } from "./routers/onboarding"
+import { plexUsersRouter } from "./routers/plexUsers"
 import { profilesRouter } from "./routers/profiles"
 import { releasesRouter } from "./routers/releases"
 import { rootFoldersRouter } from "./routers/rootFolders"
@@ -25,6 +26,7 @@ export const trpcRouter = createTRPCRouter({
   indexers: indexersRouter,
   downloadClients: downloadClientsRouter,
   mediaServers: mediaServersRouter,
+  plexUsers: plexUsersRouter,
   history: historyRouter,
   import: importRouter,
   releases: releasesRouter,

--- a/src/integrations/trpc/routers/plexUsers.ts
+++ b/src/integrations/trpc/routers/plexUsers.ts
@@ -1,0 +1,38 @@
+import type { TRPCRouterRecord } from "@trpc/server"
+import { Effect } from "effect"
+import { z } from "zod"
+
+import { PlexUserService } from "#/effect/services/PlexUserService"
+
+import { authedProcedure, runEffect } from "../init"
+
+export const plexUsersRouter = {
+  list: authedProcedure.input(z.object({ serverId: z.number().int() })).query(({ input }) =>
+    runEffect(
+      Effect.gen(function* () {
+        const svc = yield* PlexUserService
+        return yield* svc.listUsers(input.serverId)
+      }),
+    ),
+  ),
+
+  sync: authedProcedure.input(z.object({ serverId: z.number().int() })).mutation(({ input }) =>
+    runEffect(
+      Effect.gen(function* () {
+        const svc = yield* PlexUserService
+        return yield* svc.syncUsers(input.serverId)
+      }),
+    ),
+  ),
+
+  getStats: authedProcedure
+    .input(z.object({ serverId: z.number().int(), plexUserId: z.string() }))
+    .query(({ input }) =>
+      runEffect(
+        Effect.gen(function* () {
+          const svc = yield* PlexUserService
+          return yield* svc.getUserStats(input)
+        }),
+      ),
+    ),
+} satisfies TRPCRouterRecord

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -29,6 +29,7 @@ import { Route as SettingsGeneralRouteImport } from './routes/settings/general'
 import { Route as SettingsDownloadClientsRouteImport } from './routes/settings/download-clients'
 import { Route as OnboardingWizardRouteImport } from './routes/onboarding/wizard'
 import { Route as OnboardingQuickstartRouteImport } from './routes/onboarding/quickstart'
+import { Route as ActivityUsersRouteImport } from './routes/activity/users'
 import { Route as ActivityQueueRouteImport } from './routes/activity/queue'
 import { Route as ActivityHistoryRouteImport } from './routes/activity/history'
 import { Route as ApiTrpcSplatRouteImport } from './routes/api.trpc.$'
@@ -133,6 +134,11 @@ const OnboardingQuickstartRoute = OnboardingQuickstartRouteImport.update({
   path: '/onboarding/quickstart',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ActivityUsersRoute = ActivityUsersRouteImport.update({
+  id: '/activity/users',
+  path: '/activity/users',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ActivityQueueRoute = ActivityQueueRouteImport.update({
   id: '/activity/queue',
   path: '/activity/queue',
@@ -155,6 +161,7 @@ export interface FileRoutesByFullPath {
   '/system': typeof SystemRoute
   '/activity/history': typeof ActivityHistoryRoute
   '/activity/queue': typeof ActivityQueueRoute
+  '/activity/users': typeof ActivityUsersRoute
   '/onboarding/quickstart': typeof OnboardingQuickstartRoute
   '/onboarding/wizard': typeof OnboardingWizardRoute
   '/settings/download-clients': typeof SettingsDownloadClientsRoute
@@ -180,6 +187,7 @@ export interface FileRoutesByTo {
   '/system': typeof SystemRoute
   '/activity/history': typeof ActivityHistoryRoute
   '/activity/queue': typeof ActivityQueueRoute
+  '/activity/users': typeof ActivityUsersRoute
   '/onboarding/quickstart': typeof OnboardingQuickstartRoute
   '/onboarding/wizard': typeof OnboardingWizardRoute
   '/settings/download-clients': typeof SettingsDownloadClientsRoute
@@ -206,6 +214,7 @@ export interface FileRoutesById {
   '/system': typeof SystemRoute
   '/activity/history': typeof ActivityHistoryRoute
   '/activity/queue': typeof ActivityQueueRoute
+  '/activity/users': typeof ActivityUsersRoute
   '/onboarding/quickstart': typeof OnboardingQuickstartRoute
   '/onboarding/wizard': typeof OnboardingWizardRoute
   '/settings/download-clients': typeof SettingsDownloadClientsRoute
@@ -233,6 +242,7 @@ export interface FileRouteTypes {
     | '/system'
     | '/activity/history'
     | '/activity/queue'
+    | '/activity/users'
     | '/onboarding/quickstart'
     | '/onboarding/wizard'
     | '/settings/download-clients'
@@ -258,6 +268,7 @@ export interface FileRouteTypes {
     | '/system'
     | '/activity/history'
     | '/activity/queue'
+    | '/activity/users'
     | '/onboarding/quickstart'
     | '/onboarding/wizard'
     | '/settings/download-clients'
@@ -283,6 +294,7 @@ export interface FileRouteTypes {
     | '/system'
     | '/activity/history'
     | '/activity/queue'
+    | '/activity/users'
     | '/onboarding/quickstart'
     | '/onboarding/wizard'
     | '/settings/download-clients'
@@ -309,6 +321,7 @@ export interface RootRouteChildren {
   SystemRoute: typeof SystemRoute
   ActivityHistoryRoute: typeof ActivityHistoryRoute
   ActivityQueueRoute: typeof ActivityQueueRoute
+  ActivityUsersRoute: typeof ActivityUsersRoute
   OnboardingQuickstartRoute: typeof OnboardingQuickstartRoute
   OnboardingWizardRoute: typeof OnboardingWizardRoute
   SettingsDownloadClientsRoute: typeof SettingsDownloadClientsRoute
@@ -471,6 +484,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof OnboardingQuickstartRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/activity/users': {
+      id: '/activity/users'
+      path: '/activity/users'
+      fullPath: '/activity/users'
+      preLoaderRoute: typeof ActivityUsersRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/activity/queue': {
       id: '/activity/queue'
       path: '/activity/queue'
@@ -501,6 +521,7 @@ const rootRouteChildren: RootRouteChildren = {
   SystemRoute: SystemRoute,
   ActivityHistoryRoute: ActivityHistoryRoute,
   ActivityQueueRoute: ActivityQueueRoute,
+  ActivityUsersRoute: ActivityUsersRoute,
   OnboardingQuickstartRoute: OnboardingQuickstartRoute,
   OnboardingWizardRoute: OnboardingWizardRoute,
   SettingsDownloadClientsRoute: SettingsDownloadClientsRoute,

--- a/src/routes/activity/users.tsx
+++ b/src/routes/activity/users.tsx
@@ -1,0 +1,239 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { createFileRoute } from "@tanstack/react-router"
+import { useMemo, useState } from "react"
+
+import { useTRPC } from "#/integrations/trpc/react"
+
+export const Route = createFileRoute("/activity/users")({ component: Users })
+
+function formatDuration(seconds: number): string {
+  if (seconds <= 0) return "0m"
+  const h = Math.floor(seconds / 3600)
+  const m = Math.floor((seconds % 3600) / 60)
+  if (h === 0) return `${m}m`
+  return `${h}h ${m}m`
+}
+
+function formatLastSeen(date: Date | null | undefined): string {
+  if (!date) return "Never"
+  return new Date(date).toLocaleString()
+}
+
+function Users() {
+  const trpc = useTRPC()
+  const queryClient = useQueryClient()
+  const serversQuery = useQuery(trpc.mediaServers.list.queryOptions())
+
+  const plexServers = useMemo(
+    () => (serversQuery.data ?? []).filter((s) => s.type === "plex"),
+    [serversQuery.data],
+  )
+
+  const [serverId, setServerId] = useState<number | null>(null)
+  const activeId = serverId ?? plexServers[0]?.id ?? null
+
+  const usersQuery = useQuery({
+    ...trpc.plexUsers.list.queryOptions(
+      { serverId: activeId ?? 0 },
+      { enabled: activeId !== null },
+    ),
+  })
+
+  const listKey = trpc.plexUsers.list.queryKey({ serverId: activeId ?? 0 })
+
+  const syncMutation = useMutation(
+    trpc.plexUsers.sync.mutationOptions({
+      onSuccess: () => queryClient.invalidateQueries({ queryKey: listKey }),
+    }),
+  )
+
+  const [selectedUserId, setSelectedUserId] = useState<string | null>(null)
+  const statsQuery = useQuery({
+    ...trpc.plexUsers.getStats.queryOptions(
+      { serverId: activeId ?? 0, plexUserId: selectedUserId ?? "" },
+      { enabled: activeId !== null && selectedUserId !== null },
+    ),
+  })
+
+  return (
+    <div className="p-6">
+      <header className="mb-4 flex items-end justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold">Users</h1>
+          <p className="text-muted-foreground mt-1">Plex users and per-user watch stats</p>
+        </div>
+        <div className="flex items-center gap-2 text-sm">
+          {plexServers.length > 1 && (
+            <>
+              <label htmlFor="server" className="text-muted-foreground">
+                Server
+              </label>
+              <select
+                id="server"
+                className="bg-background rounded border px-2 py-1"
+                value={activeId ?? ""}
+                onChange={(e) => setServerId(Number(e.target.value))}
+              >
+                {plexServers.map((s) => (
+                  <option key={s.id} value={s.id}>
+                    {s.name}
+                  </option>
+                ))}
+              </select>
+            </>
+          )}
+          <button
+            type="button"
+            className="rounded border px-3 py-1 disabled:opacity-50"
+            onClick={() => activeId !== null && syncMutation.mutate({ serverId: activeId })}
+            disabled={activeId === null || syncMutation.isPending}
+          >
+            {syncMutation.isPending ? "Syncing…" : "Sync from Plex"}
+          </button>
+        </div>
+      </header>
+
+      {serversQuery.isLoading && <p className="text-muted-foreground">Loading servers…</p>}
+      {serversQuery.data && plexServers.length === 0 && (
+        <p className="text-muted-foreground">
+          No Plex servers configured. Add one in Settings → Media Servers.
+        </p>
+      )}
+
+      {syncMutation.isError && (
+        <p className="text-destructive mb-2 text-sm">Sync failed: {syncMutation.error.message}</p>
+      )}
+      {syncMutation.data && (
+        <p className="text-muted-foreground mb-2 text-sm">
+          Synced: {syncMutation.data.added} added · {syncMutation.data.updated} updated ·{" "}
+          {syncMutation.data.deactivated} deactivated
+        </p>
+      )}
+
+      {activeId !== null && usersQuery.isLoading && (
+        <p className="text-muted-foreground">Loading users…</p>
+      )}
+
+      {usersQuery.data && usersQuery.data.length === 0 && (
+        <p className="text-muted-foreground">
+          No users found. Click &ldquo;Sync from Plex&rdquo; to pull the shared users list.
+        </p>
+      )}
+
+      {usersQuery.data && usersQuery.data.length > 0 && (
+        <div className="overflow-hidden rounded-md border">
+          <table className="w-full text-sm">
+            <thead className="bg-muted/50 text-muted-foreground">
+              <tr>
+                <th className="px-3 py-2 text-left font-medium">User</th>
+                <th className="px-3 py-2 text-left font-medium">Role</th>
+                <th className="px-3 py-2 text-left font-medium">Last Seen</th>
+                <th className="px-3 py-2 text-right font-medium">Plays</th>
+                <th className="px-3 py-2 text-right font-medium">Watch Time</th>
+                <th className="px-3 py-2 text-left font-medium">Status</th>
+                <th className="px-3 py-2" />
+              </tr>
+            </thead>
+            <tbody>
+              {usersQuery.data.map((u) => (
+                <tr key={u.id} className="border-t">
+                  <td className="px-3 py-2">
+                    <div className="flex items-center gap-2">
+                      {u.thumb ? (
+                        <img src={u.thumb} alt="" className="h-7 w-7 rounded-full object-cover" />
+                      ) : (
+                        <div className="bg-muted text-muted-foreground flex h-7 w-7 items-center justify-center rounded-full text-xs">
+                          {u.friendlyName.slice(0, 1).toUpperCase()}
+                        </div>
+                      )}
+                      <div>
+                        <div>{u.friendlyName}</div>
+                        {u.username !== u.friendlyName && (
+                          <div className="text-muted-foreground text-xs">@{u.username}</div>
+                        )}
+                      </div>
+                    </div>
+                  </td>
+                  <td className="px-3 py-2">
+                    {u.isAdmin ? (
+                      <span className="rounded bg-blue-500/20 px-2 py-0.5 text-xs text-blue-500">
+                        admin
+                      </span>
+                    ) : (
+                      <span className="text-muted-foreground text-xs">member</span>
+                    )}
+                  </td>
+                  <td className="text-muted-foreground px-3 py-2">
+                    {formatLastSeen(u.lastSeenAt)}
+                  </td>
+                  <td className="px-3 py-2 text-right">{u.totalPlayCount}</td>
+                  <td className="px-3 py-2 text-right">{formatDuration(u.totalWatchTimeSec)}</td>
+                  <td className="px-3 py-2">
+                    {u.isActive ? (
+                      <span className="text-xs text-green-500">active</span>
+                    ) : (
+                      <span className="text-muted-foreground text-xs">inactive</span>
+                    )}
+                  </td>
+                  <td className="px-3 py-2 text-right">
+                    <button
+                      type="button"
+                      className="text-xs underline"
+                      onClick={() =>
+                        setSelectedUserId(selectedUserId === u.plexUserId ? null : u.plexUserId)
+                      }
+                    >
+                      {selectedUserId === u.plexUserId ? "Hide" : "Details"}
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {selectedUserId !== null && statsQuery.data && (
+        <div className="mt-4 rounded-md border p-4">
+          <h2 className="mb-2 font-semibold">Details</h2>
+          <div className="text-muted-foreground grid grid-cols-3 gap-4 text-sm">
+            <div>
+              <div className="text-xs uppercase">Plays</div>
+              <div className="text-foreground text-lg">{statsQuery.data.totalPlayCount}</div>
+            </div>
+            <div>
+              <div className="text-xs uppercase">Watch time</div>
+              <div className="text-foreground text-lg">
+                {formatDuration(statsQuery.data.totalWatchTimeSec)}
+              </div>
+            </div>
+            <div>
+              <div className="text-xs uppercase">Last seen</div>
+              <div className="text-foreground text-lg">
+                {formatLastSeen(statsQuery.data.lastSeenAt)}
+              </div>
+            </div>
+          </div>
+          {statsQuery.data.topMedia.length > 0 && (
+            <>
+              <h3 className="text-muted-foreground mt-4 mb-2 text-xs uppercase">Top media</h3>
+              <ul className="space-y-1 text-sm">
+                {statsQuery.data.topMedia.map((m) => (
+                  <li key={`${m.mediaType}:${m.title}`} className="flex justify-between">
+                    <span>
+                      {m.title}{" "}
+                      <span className="text-muted-foreground text-xs">({m.mediaType})</span>
+                    </span>
+                    <span className="text-muted-foreground">
+                      {m.playCount} plays · {formatDuration(m.totalWatchedSec)}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Sync Plex users via `/accounts` into new `plex_users` table
- Per-user watch stats aggregated from `session_history` (top media, total plays, watch time)
- SessionHistoryService bumps cached counters on each write
- New `/activity/users` route + sidebar entry

## Test plan
- [x] `bun run typecheck` clean
- [x] `bun run test` — 240/240 pass (5 new PlexUserService tests)
- [x] `bun run fmt:check` / `bun run lint` clean (warnings only, none new errors)
- [ ] Manual: sync against a live Plex server, verify stats expand in UI