### PR TITLE
feat: activity dashboard at / (closes #25)

### DIFF
--- a/src/components/dashboard/progress-ring.tsx
+++ b/src/components/dashboard/progress-ring.tsx
@@ -1,0 +1,56 @@
+import { cn } from "@/lib/utils"
+
+interface ProgressRingProps {
+  readonly value: number
+  readonly size?: number
+  readonly stroke?: number
+  readonly className?: string
+  readonly children?: React.ReactNode
+}
+
+export function ProgressRing({
+  value,
+  size = 56,
+  stroke = 5,
+  className,
+  children,
+}: ProgressRingProps) {
+  const clamped = Math.max(0, Math.min(100, value))
+  const r = (size - stroke) / 2
+  const c = 2 * Math.PI * r
+  const offset = c - (clamped / 100) * c
+
+  return (
+    <div
+      className={cn("relative inline-flex items-center justify-center", className)}
+      style={{ width: size, height: size }}
+    >
+      <svg width={size} height={size} className="-rotate-90">
+        <circle
+          cx={size / 2}
+          cy={size / 2}
+          r={r}
+          fill="none"
+          stroke="currentColor"
+          strokeOpacity={0.15}
+          strokeWidth={stroke}
+        />
+        <circle
+          cx={size / 2}
+          cy={size / 2}
+          r={r}
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={stroke}
+          strokeDasharray={c}
+          strokeDashoffset={offset}
+          strokeLinecap="round"
+          className="text-primary transition-[stroke-dashoffset] duration-500"
+        />
+      </svg>
+      <div className="absolute inset-0 flex items-center justify-center text-xs font-medium">
+        {children ?? `${Math.round(clamped)}%`}
+      </div>
+    </div>
+  )
+}

--- a/src/components/dashboard/server-health-badge.tsx
+++ b/src/components/dashboard/server-health-badge.tsx
@@ -1,0 +1,32 @@
+import type { MediaServerHealthStatus } from "#/effect/domain/mediaServer"
+import { cn } from "@/lib/utils"
+
+const DOT: Record<MediaServerHealthStatus, string> = {
+  healthy: "bg-green-500",
+  unhealthy: "bg-red-500",
+  unknown: "bg-zinc-400",
+}
+
+const LABEL: Record<MediaServerHealthStatus, string> = {
+  healthy: "Online",
+  unhealthy: "Offline",
+  unknown: "Unknown",
+}
+
+interface ServerHealthBadgeProps {
+  readonly status: MediaServerHealthStatus | null
+  readonly name: string
+  readonly version?: string | null
+}
+
+export function ServerHealthBadge({ status, name, version }: ServerHealthBadgeProps) {
+  const s = status ?? "unknown"
+  return (
+    <div className="flex items-center gap-2 rounded-md border px-3 py-1.5 text-sm">
+      <span className={cn("inline-block h-2 w-2 rounded-full", DOT[s])} aria-label={LABEL[s]} />
+      <span className="font-medium">{name}</span>
+      {version && <span className="text-muted-foreground text-xs">v{version}</span>}
+      <span className="text-muted-foreground text-xs">{LABEL[s]}</span>
+    </div>
+  )
+}

--- a/src/components/dashboard/session-card.tsx
+++ b/src/components/dashboard/session-card.tsx
@@ -1,0 +1,117 @@
+import { Pause, Play, Loader2 } from "lucide-react"
+
+import type { MediaServerSession, SessionState } from "#/effect/domain/mediaServer"
+import { cn } from "@/lib/utils"
+
+import { ProgressRing } from "./progress-ring"
+import { TranscodeBadge } from "./transcode-badge"
+
+const STATE_ICON: Record<SessionState, React.ReactNode> = {
+  playing: <Play className="h-3 w-3" aria-label="playing" />,
+  paused: <Pause className="h-3 w-3" aria-label="paused" />,
+  buffering: <Loader2 className="h-3 w-3 animate-spin" aria-label="buffering" />,
+}
+
+const STATE_TONE: Record<SessionState, string> = {
+  playing: "bg-green-500/15 text-green-500",
+  paused: "bg-zinc-500/20 text-zinc-300",
+  buffering: "bg-blue-500/15 text-blue-400",
+}
+
+function formatBandwidth(kbps: number | null): string | null {
+  if (kbps === null || kbps <= 0) return null
+  if (kbps >= 1000) return `${(kbps / 1000).toFixed(1)} Mbps`
+  return `${kbps} kbps`
+}
+
+const pad2 = (n: number) => String(n).padStart(2, "0")
+
+function formatTime(ms: number): string {
+  const total = Math.max(0, Math.floor(ms / 1000))
+  const h = Math.floor(total / 3600)
+  const m = Math.floor((total % 3600) / 60)
+  const s = total % 60
+  return h > 0 ? `${h}:${pad2(m)}:${pad2(s)}` : `${m}:${pad2(s)}`
+}
+
+function displayTitle(s: MediaServerSession): string {
+  if (s.mediaType === "episode" && s.grandparentTitle) {
+    return s.grandparentTitle
+  }
+  return s.title
+}
+
+function displaySubtitle(s: MediaServerSession): string | null {
+  if (s.mediaType === "episode") {
+    return s.title
+  }
+  return s.year ? String(s.year) : null
+}
+
+function avatarLetter(username: string): string {
+  return (username.trim()[0] ?? "?").toUpperCase()
+}
+
+export function SessionCard({ session }: { readonly session: MediaServerSession }) {
+  const subtitle = displaySubtitle(session)
+  const bandwidth = formatBandwidth(session.bandwidth)
+
+  return (
+    <div className="flex gap-4 rounded-lg border p-4">
+      <ProgressRing value={session.progressPercent} size={64} />
+
+      <div className="min-w-0 flex-1">
+        <div className="flex items-start justify-between gap-2">
+          <div className="min-w-0">
+            <div className="truncate text-sm font-semibold">{displayTitle(session)}</div>
+            {subtitle && <div className="text-muted-foreground truncate text-xs">{subtitle}</div>}
+          </div>
+          <span
+            className={cn(
+              "inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-medium uppercase",
+              STATE_TONE[session.state],
+            )}
+          >
+            {STATE_ICON[session.state]}
+            {session.state}
+          </span>
+        </div>
+
+        <div className="text-muted-foreground mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs">
+          <div className="flex items-center gap-1.5">
+            <div className="bg-muted text-foreground flex h-5 w-5 items-center justify-center rounded-full text-[10px] font-medium">
+              {avatarLetter(session.username)}
+            </div>
+            <span className="text-foreground">{session.username || "anonymous"}</span>
+          </div>
+          <span>·</span>
+          <span>
+            {session.player}
+            {session.platform && ` (${session.platform})`}
+          </span>
+          {session.videoResolution && (
+            <>
+              <span>·</span>
+              <span>{session.videoResolution}p</span>
+            </>
+          )}
+          {bandwidth && (
+            <>
+              <span>·</span>
+              <span>{bandwidth}</span>
+            </>
+          )}
+          <span>·</span>
+          <span>{session.isLocal ? "LAN" : "WAN"}</span>
+        </div>
+
+        <div className="mt-2 flex items-center justify-between gap-2">
+          <TranscodeBadge decision={session.transcodeDecision} />
+          <div className="text-muted-foreground font-mono text-[11px]">
+            {formatTime(session.viewOffset)} / {formatTime(session.duration)}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/dashboard/transcode-badge.tsx
+++ b/src/components/dashboard/transcode-badge.tsx
@@ -1,0 +1,22 @@
+import type { TranscodeDecision } from "#/effect/domain/mediaServer"
+import { cn } from "@/lib/utils"
+
+const LABEL: Record<TranscodeDecision, string> = {
+  direct_play: "Direct Play",
+  direct_stream: "Direct Stream",
+  transcode: "Transcode",
+}
+
+const TONE: Record<TranscodeDecision, string> = {
+  direct_play: "bg-green-500/15 text-green-500",
+  direct_stream: "bg-yellow-500/15 text-yellow-500",
+  transcode: "bg-orange-500/15 text-orange-500",
+}
+
+export function TranscodeBadge({ decision }: { readonly decision: TranscodeDecision }) {
+  return (
+    <span className={cn("rounded px-1.5 py-0.5 text-[10px] font-medium", TONE[decision])}>
+      {LABEL[decision]}
+    </span>
+  )
+}

--- a/src/effect/services/SessionHistoryService.test.ts
+++ b/src/effect/services/SessionHistoryService.test.ts
@@ -188,6 +188,21 @@ describe("SessionHistoryService", () => {
     }).pipe(Effect.provide(TestLayer)),
   )
 
+  it.effect("countSince counts only rows stopped after the cutoff", () =>
+    Effect.gen(function* () {
+      yield* seedMediaServer
+      const svc = yield* SessionHistoryService
+      yield* svc.writeHistory([baseSession({ sessionKey: "old" })])
+
+      const cutoff = new Date(Date.now() - 60_000)
+      const total = yield* svc.countSince(cutoff)
+      expect(total).toBe(1)
+
+      const future = yield* svc.countSince(new Date(Date.now() + 60_000))
+      expect(future).toBe(0)
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
   it.effect("getHistoryForMedia returns watch events for an episode", () =>
     Effect.gen(function* () {
       yield* seedMediaServer

--- a/src/effect/services/SessionHistoryService.ts
+++ b/src/effect/services/SessionHistoryService.ts
@@ -1,5 +1,5 @@
 import { SqlError } from "@effect/sql/SqlError"
-import { and, between, desc, eq, lt, sql, type SQL } from "drizzle-orm"
+import { and, between, count, desc, eq, gte, lt, sql, type SQL } from "drizzle-orm"
 import { Context, Effect, Layer } from "effect"
 
 import { episodes, movies, plexUsers, sessionHistory } from "#/db/schema"
@@ -50,6 +50,8 @@ export class SessionHistoryService extends Context.Tag("@arr-hub/SessionHistoryS
     readonly getHistoryForMedia: (
       ref: MediaRef,
     ) => Effect.Effect<ReadonlyArray<SessionHistoryRow>, SqlError>
+    /** Count history rows whose `stoppedAt` falls within `[since, now]`. */
+    readonly countSince: (since: Date) => Effect.Effect<number, SqlError>
   }
 >() {}
 
@@ -201,6 +203,15 @@ export const SessionHistoryServiceLive = Layer.effect(
             .from(sessionHistory)
             .where(where)
             .orderBy(desc(sessionHistory.stoppedAt))
+        }),
+
+      countSince: (since) =>
+        Effect.gen(function* () {
+          const rows = yield* db
+            .select({ n: count() })
+            .from(sessionHistory)
+            .where(gte(sessionHistory.stoppedAt, since))
+          return rows[0]?.n ?? 0
         }),
     }
   }),

--- a/src/integrations/trpc/routers/history.ts
+++ b/src/integrations/trpc/routers/history.ts
@@ -45,4 +45,13 @@ export const historyRouter = {
       }),
     ),
   ),
+
+  countSince: authedProcedure.input(z.object({ since: z.date() })).query(({ input }) =>
+    runEffect(
+      Effect.gen(function* () {
+        const svc = yield* SessionHistoryService
+        return yield* svc.countSince(input.since)
+      }),
+    ),
+  ),
 } satisfies TRPCRouterRecord

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,12 +1,174 @@
+import { useQuery } from "@tanstack/react-query"
 import { createFileRoute } from "@tanstack/react-router"
+import { Activity, PlayCircle, Wifi } from "lucide-react"
+import { useMemo } from "react"
+
+import { ServerHealthBadge } from "@/components/dashboard/server-health-badge"
+import { SessionCard } from "@/components/dashboard/session-card"
+import { Skeleton } from "@/components/ui/skeleton"
+import { useTRPC } from "@/integrations/trpc/react"
 
 export const Route = createFileRoute("/")({ component: Dashboard })
 
-function Dashboard() {
+const REFRESH_MS = 5000
+
+function startOfToday(): Date {
+  const d = new Date()
+  d.setHours(0, 0, 0, 0)
+  return d
+}
+
+function formatBandwidth(kbps: number): string {
+  if (kbps <= 0) return "0 kbps"
+  if (kbps >= 1000) return `${(kbps / 1000).toFixed(1)} Mbps`
+  return `${kbps} kbps`
+}
+
+function StatCard({
+  icon,
+  label,
+  value,
+  hint,
+}: {
+  readonly icon: React.ReactNode
+  readonly label: string
+  readonly value: React.ReactNode
+  readonly hint?: string
+}) {
   return (
-    <div className="p-6">
-      <h1 className="text-2xl font-bold">Dashboard</h1>
-      <p className="text-muted-foreground mt-1">Overview of your media library</p>
+    <div className="flex items-center gap-3 rounded-lg border p-4">
+      <div className="bg-accent text-accent-foreground rounded-md p-2">{icon}</div>
+      <div className="min-w-0">
+        <div className="text-muted-foreground text-xs tracking-wide uppercase">{label}</div>
+        <div className="text-xl font-semibold">{value}</div>
+        {hint && <div className="text-muted-foreground text-xs">{hint}</div>}
+      </div>
+    </div>
+  )
+}
+
+function Dashboard() {
+  const trpc = useTRPC()
+  const todayStart = useMemo(() => startOfToday(), [])
+
+  const sessionsQuery = useQuery(
+    trpc.mediaServers.activeSessions.queryOptions(undefined, {
+      refetchInterval: REFRESH_MS,
+      refetchIntervalInBackground: false,
+    }),
+  )
+
+  const serversQuery = useQuery(
+    trpc.mediaServers.list.queryOptions(undefined, {
+      refetchInterval: REFRESH_MS * 6,
+    }),
+  )
+
+  const todayQuery = useQuery(
+    trpc.history.countSince.queryOptions(
+      { since: todayStart },
+      { refetchInterval: REFRESH_MS * 6 },
+    ),
+  )
+
+  const sessions = sessionsQuery.data ?? []
+  const totalBandwidth = sessions.reduce((acc, s) => acc + (s.bandwidth ?? 0), 0)
+  const servers = serversQuery.data ?? []
+  const monitoringEnabled = servers.some((s) => s.enabled && s.settings.monitoringEnabled)
+
+  return (
+    <div className="space-y-6 p-6">
+      <header>
+        <h1 className="text-2xl font-bold">Dashboard</h1>
+        <p className="text-muted-foreground mt-1 text-sm">
+          Live activity across your media servers
+        </p>
+      </header>
+
+      <section className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+        <StatCard
+          icon={<PlayCircle className="h-4 w-4" />}
+          label="Active streams"
+          value={sessions.length}
+        />
+        <StatCard
+          icon={<Wifi className="h-4 w-4" />}
+          label="Total bandwidth"
+          value={formatBandwidth(totalBandwidth)}
+        />
+        <StatCard
+          icon={<Activity className="h-4 w-4" />}
+          label="Plays today"
+          value={todayQuery.data ?? 0}
+          hint="from session history"
+        />
+      </section>
+
+      <section>
+        <h2 className="text-muted-foreground mb-2 text-xs font-semibold tracking-wide uppercase">
+          Servers
+        </h2>
+        {serversQuery.isLoading && <Skeleton className="h-10 w-full max-w-md" />}
+        {serversQuery.data && servers.length === 0 && (
+          <p className="text-muted-foreground text-sm">
+            No media servers configured. Add one in Settings → Media Servers.
+          </p>
+        )}
+        {servers.length > 0 && (
+          <div className="flex flex-wrap gap-2">
+            {servers.map((s) => (
+              <ServerHealthBadge
+                key={s.id}
+                name={s.name}
+                status={s.health?.status ?? null}
+                version={null}
+              />
+            ))}
+          </div>
+        )}
+      </section>
+
+      <section>
+        <div className="mb-2 flex items-baseline justify-between">
+          <h2 className="text-muted-foreground text-xs font-semibold tracking-wide uppercase">
+            Active sessions
+          </h2>
+          {sessionsQuery.isFetching && (
+            <span className="text-muted-foreground text-[10px]">refreshing…</span>
+          )}
+        </div>
+
+        {sessionsQuery.isLoading && (
+          <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
+            <Skeleton className="h-28" />
+            <Skeleton className="h-28" />
+          </div>
+        )}
+
+        {sessionsQuery.error && (
+          <p className="text-destructive text-sm">
+            Failed to load sessions: {sessionsQuery.error.message}
+          </p>
+        )}
+
+        {sessionsQuery.data && sessions.length === 0 && (
+          <div className="text-muted-foreground rounded-md border border-dashed p-8 text-center text-sm">
+            {servers.length === 0
+              ? "Connect a media server to start monitoring streams."
+              : monitoringEnabled
+                ? "No active streams right now."
+                : "Live monitoring is disabled. Enable it in your media server settings."}
+          </div>
+        )}
+
+        {sessions.length > 0 && (
+          <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
+            {sessions.map((s) => (
+              <SessionCard key={`${s.mediaServerId}:${s.sessionKey}`} session={s} />
+            ))}
+          </div>
+        )}
+      </section>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Replaces the placeholder `Dashboard` at `/` with a live monitoring view: active streams panel, server health strip, and quick stats (streams, total bandwidth, plays today)
- Active sessions auto-refresh every 5s via tRPC polling on `mediaServers.activeSessions`; server health on a 30s cadence
- Adds `SessionCard`, `ServerHealthBadge`, `TranscodeBadge`, `ProgressRing` under `src/components/dashboard/`
- Adds `SessionHistoryService.countSince` + `history.countSince` tRPC query for the today-plays stat (sourced from `session_history.stoppedAt`)

## Test plan
- [x] `bun run typecheck` clean
- [x] `bun run test` — 241/241 pass, including new `countSince` test
- [x] `bun run build` succeeds
- [x] App boots without console errors
- [ ] Live verification with a real Plex server (deferred — requires onboarding + Plex connection)