### PR TITLE
feat: Watch Statistics & Analytics (closes #26)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -35,6 +35,7 @@
         "radix-ui": "^1.4.3",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
+        "recharts": "^3.8.1",
         "superjson": "^2.2.2",
         "tailwind-merge": "^3.5.0",
         "tailwindcss": "^4.1.18",
@@ -477,6 +478,8 @@
 
     "@radix-ui/rect": ["@radix-ui/rect@1.1.1", "", {}, "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw=="],
 
+    "@reduxjs/toolkit": ["@reduxjs/toolkit@2.11.2", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@standard-schema/utils": "^0.3.0", "immer": "^11.0.0", "redux": "^5.0.1", "redux-thunk": "^3.1.0", "reselect": "^5.1.0" }, "peerDependencies": { "react": "^16.9.0 || ^17.0.0 || ^18 || ^19", "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0" }, "optionalPeers": ["react", "react-redux"] }, "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ=="],
+
     "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-rc.5", "", { "os": "android", "cpu": "arm64" }, "sha512-zCEmUrt1bggwgBgeKLxNj217J1OrChrp3jJt24VK9jAharSTeVaHODNL+LpcQVhRz+FktYWfT9cjo5oZ99ZLpg=="],
 
     "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.0.0-rc.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-ZP9xb9lPAex36pvkNWCjSEJW/Gfdm9I3ssiqOFLmpZ/vosPXgpoGxCmh+dX1Qs+/bWQE6toNFXWWL8vYoKoK9Q=="],
@@ -568,6 +571,8 @@
     "@solid-primitives/utils": ["@solid-primitives/utils@6.3.2", "", { "peerDependencies": { "solid-js": "^1.6.12" } }, "sha512-hZ/M/qr25QOCcwDPOHtGjxTD8w2mNyVAYvcfgwzBHq2RwNqHNdDNsMZYap20+ruRwW4A3Cdkczyoz0TSxLCAPQ=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
+    "@standard-schema/utils": ["@standard-schema/utils@0.3.0", "", {}, "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="],
 
     "@t3-oss/env-core": ["@t3-oss/env-core@0.13.10", "", { "peerDependencies": { "arktype": "^2.1.0", "typescript": ">=5.0.0", "valibot": "^1.0.0-beta.7 || ^1.0.0", "zod": "^3.24.0 || ^4.0.0" }, "optionalPeers": ["arktype", "typescript", "valibot", "zod"] }, "sha512-NNFfdlJ+HmPHkLi2HKy7nwuat9SIYOxei9K10lO2YlcSObDILY7mHZNSHsieIM3A0/5OOzw/P/b+yLvPdaG52g=="],
 
@@ -693,6 +698,24 @@
 
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
+    "@types/d3-array": ["@types/d3-array@3.2.2", "", {}, "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="],
+
+    "@types/d3-color": ["@types/d3-color@3.1.3", "", {}, "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="],
+
+    "@types/d3-ease": ["@types/d3-ease@3.0.2", "", {}, "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="],
+
+    "@types/d3-interpolate": ["@types/d3-interpolate@3.0.4", "", { "dependencies": { "@types/d3-color": "*" } }, "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA=="],
+
+    "@types/d3-path": ["@types/d3-path@3.1.1", "", {}, "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg=="],
+
+    "@types/d3-scale": ["@types/d3-scale@4.0.9", "", { "dependencies": { "@types/d3-time": "*" } }, "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw=="],
+
+    "@types/d3-shape": ["@types/d3-shape@3.1.8", "", { "dependencies": { "@types/d3-path": "*" } }, "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w=="],
+
+    "@types/d3-time": ["@types/d3-time@3.0.4", "", {}, "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="],
+
+    "@types/d3-timer": ["@types/d3-timer@3.0.2", "", {}, "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="],
+
     "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
@@ -704,6 +727,8 @@
     "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
+
+    "@types/use-sync-external-store": ["@types/use-sync-external-store@0.0.6", "", {}, "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg=="],
 
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
@@ -819,6 +844,28 @@
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
+    "d3-array": ["d3-array@3.2.4", "", { "dependencies": { "internmap": "1 - 2" } }, "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg=="],
+
+    "d3-color": ["d3-color@3.1.0", "", {}, "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="],
+
+    "d3-ease": ["d3-ease@3.0.1", "", {}, "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="],
+
+    "d3-format": ["d3-format@3.1.2", "", {}, "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg=="],
+
+    "d3-interpolate": ["d3-interpolate@3.0.1", "", { "dependencies": { "d3-color": "1 - 3" } }, "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g=="],
+
+    "d3-path": ["d3-path@3.1.0", "", {}, "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ=="],
+
+    "d3-scale": ["d3-scale@4.0.2", "", { "dependencies": { "d3-array": "2.10.0 - 3", "d3-format": "1 - 3", "d3-interpolate": "1.2.0 - 3", "d3-time": "2.1.1 - 3", "d3-time-format": "2 - 4" } }, "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ=="],
+
+    "d3-shape": ["d3-shape@3.2.0", "", { "dependencies": { "d3-path": "^3.1.0" } }, "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA=="],
+
+    "d3-time": ["d3-time@3.1.0", "", { "dependencies": { "d3-array": "2 - 3" } }, "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q=="],
+
+    "d3-time-format": ["d3-time-format@4.1.0", "", { "dependencies": { "d3-time": "1 - 3" } }, "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg=="],
+
+    "d3-timer": ["d3-timer@3.0.1", "", {}, "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="],
+
     "data-uri-to-buffer": ["data-uri-to-buffer@4.0.1", "", {}, "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="],
 
     "data-urls": ["data-urls@6.0.1", "", { "dependencies": { "whatwg-mimetype": "^5.0.0", "whatwg-url": "^15.1.0" } }, "sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ=="],
@@ -828,6 +875,8 @@
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
+
+    "decimal.js-light": ["decimal.js-light@2.5.1", "", {}, "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="],
 
     "decompress-response": ["decompress-response@6.0.0", "", { "dependencies": { "mimic-response": "^3.1.0" } }, "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ=="],
 
@@ -873,6 +922,8 @@
 
     "es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
 
+    "es-toolkit": ["es-toolkit@1.46.1", "", {}, "sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ=="],
+
     "esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
 
     "esbuild-register": ["esbuild-register@3.6.0", "", { "dependencies": { "debug": "^4.3.4" }, "peerDependencies": { "esbuild": ">=0.12 <1" } }, "sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg=="],
@@ -882,6 +933,8 @@
     "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
 
     "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
+    "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
 
     "expand-template": ["expand-template@2.0.3", "", {}, "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="],
 
@@ -945,9 +998,13 @@
 
     "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
 
+    "immer": ["immer@10.2.0", "", {}, "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw=="],
+
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
     "ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
+
+    "internmap": ["internmap@2.0.3", "", {}, "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="],
 
     "is-binary-path": ["is-binary-path@2.1.0", "", { "dependencies": { "binary-extensions": "^2.0.0" } }, "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw=="],
 
@@ -1127,6 +1184,8 @@
 
     "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 
+    "react-redux": ["react-redux@9.2.0", "", { "dependencies": { "@types/use-sync-external-store": "^0.0.6", "use-sync-external-store": "^1.4.0" }, "peerDependencies": { "@types/react": "^18.2.25 || ^19", "react": "^18.0 || ^19", "redux": "^5.0.0" }, "optionalPeers": ["@types/react", "redux"] }, "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g=="],
+
     "react-refresh": ["react-refresh@0.18.0", "", {}, "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw=="],
 
     "react-remove-scroll": ["react-remove-scroll@2.7.2", "", { "dependencies": { "react-remove-scroll-bar": "^2.3.7", "react-style-singleton": "^2.2.3", "tslib": "^2.1.0", "use-callback-ref": "^1.3.3", "use-sidecar": "^1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q=="],
@@ -1141,7 +1200,15 @@
 
     "recast": ["recast@0.23.11", "", { "dependencies": { "ast-types": "^0.16.1", "esprima": "~4.0.0", "source-map": "~0.6.1", "tiny-invariant": "^1.3.3", "tslib": "^2.0.1" } }, "sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA=="],
 
+    "recharts": ["recharts@3.8.1", "", { "dependencies": { "@reduxjs/toolkit": "^1.9.0 || 2.x.x", "clsx": "^2.1.1", "decimal.js-light": "^2.5.1", "es-toolkit": "^1.39.3", "eventemitter3": "^5.0.1", "immer": "^10.1.1", "react-redux": "8.x.x || 9.x.x", "reselect": "5.1.1", "tiny-invariant": "^1.3.3", "use-sync-external-store": "^1.2.2", "victory-vendor": "^37.0.2" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg=="],
+
+    "redux": ["redux@5.0.1", "", {}, "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="],
+
+    "redux-thunk": ["redux-thunk@3.1.0", "", { "peerDependencies": { "redux": "^5.0.0" } }, "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw=="],
+
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "reselect": ["reselect@5.1.1", "", {}, "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w=="],
 
     "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
 
@@ -1275,6 +1342,8 @@
 
     "uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
 
+    "victory-vendor": ["victory-vendor@37.3.6", "", { "dependencies": { "@types/d3-array": "^3.0.3", "@types/d3-ease": "^3.0.0", "@types/d3-interpolate": "^3.0.1", "@types/d3-scale": "^4.0.2", "@types/d3-shape": "^3.1.0", "@types/d3-time": "^3.0.0", "@types/d3-timer": "^3.0.0", "d3-array": "^3.1.6", "d3-ease": "^3.0.1", "d3-interpolate": "^3.0.1", "d3-scale": "^4.0.2", "d3-shape": "^3.1.0", "d3-time": "^3.0.0", "d3-timer": "^3.0.1" } }, "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ=="],
+
     "vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
 
     "vite-node": ["vite-node@3.2.4", "", { "dependencies": { "cac": "^6.7.14", "debug": "^4.4.1", "es-module-lexer": "^1.7.0", "pathe": "^2.0.3", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0" }, "bin": { "vite-node": "vite-node.mjs" } }, "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg=="],
@@ -1320,6 +1389,8 @@
     "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
     "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
+
+    "@reduxjs/toolkit/immer": ["immer@11.1.4", "", {}, "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.8.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" }, "bundled": true }, "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg=="],
 

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "radix-ui": "^1.4.3",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
+    "recharts": "^3.8.1",
     "superjson": "^2.2.2",
     "tailwind-merge": "^3.5.0",
     "tailwindcss": "^4.1.18",

--- a/src/components/sidebar/nav-data.ts
+++ b/src/components/sidebar/nav-data.ts
@@ -1,6 +1,7 @@
 import type { LucideIcon } from "lucide-react"
 import {
   Activity,
+  BarChart3,
   Bell,
   Calendar,
   Clapperboard,
@@ -54,6 +55,7 @@ const collapsibleGroups = [
       { title: "Queue", to: "/activity/queue", icon: ListOrdered },
       { title: "History", to: "/activity/history", icon: History },
       { title: "Users", to: "/activity/users", icon: Users },
+      { title: "Stats", to: "/activity/stats", icon: BarChart3 },
     ],
   },
   {

--- a/src/effect/layers.ts
+++ b/src/effect/layers.ts
@@ -22,6 +22,7 @@ import { RootFolderServiceLive } from "./services/RootFolderService"
 import { SchedulerServiceLive } from "./services/SchedulerService"
 import { SeriesServiceLive } from "./services/SeriesService"
 import { SessionHistoryServiceLive } from "./services/SessionHistoryService"
+import { StatsServiceLive } from "./services/StatsService"
 import { TitleParserServiceLive } from "./services/TitleParserService"
 import { TmdbClientLive } from "./services/TmdbClient"
 
@@ -45,6 +46,7 @@ export const AppLive = Layer.mergeAll(
       ReleasePolicyEngineLive,
       SessionHistoryServiceLive,
       PlexUserServiceLive,
+      StatsServiceLive,
     ),
   ),
   Layer.provideMerge(TitleParserServiceLive),

--- a/src/effect/services/StatsService.test.ts
+++ b/src/effect/services/StatsService.test.ts
@@ -1,0 +1,318 @@
+import { SqlClient } from "@effect/sql"
+import { describe, expect, it } from "@effect/vitest"
+import { Effect, Layer } from "effect"
+
+import { TestDbLive } from "#/effect/test/TestDb"
+
+import { StatsService, StatsServiceLive } from "./StatsService"
+
+const TestLayer = StatsServiceLive.pipe(Layer.provideMerge(TestDbLive))
+
+const seedMediaServer = Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient
+  yield* sql`INSERT INTO media_servers (name, type, host, port, token_encrypted) VALUES ('plex', 'plex', '127.0.0.1', 32400, 'enc:tok')`
+  return 1
+})
+
+/** Insert a history row at a precise stoppedAt + viewOffset — bypasses stoppedAt=now() in writeHistory. */
+const insertAt = (overrides: {
+  readonly stoppedAt: Date
+  readonly viewOffsetMs: number
+  readonly mediaType?: "movie" | "episode"
+  readonly title?: string
+  readonly grandparentTitle?: string | null
+  readonly transcodeDecision?: "direct_play" | "direct_stream" | "transcode"
+  readonly userId?: string
+  readonly username?: string
+  readonly mediaServerId?: number
+}) =>
+  Effect.gen(function* () {
+    const sql = yield* SqlClient.SqlClient
+    const epoch = Math.floor(overrides.stoppedAt.getTime() / 1000)
+    yield* sql`INSERT INTO session_history (
+      media_server_id, plex_user_id, plex_username, rating_key, media_type, title,
+      parent_title, grandparent_title, year, thumb, started_at, stopped_at, duration,
+      view_offset, paused_duration_sec, transcode_decision, video_resolution, audio_codec,
+      player, platform, product, ip_address, bandwidth, is_local
+    ) VALUES (
+      ${overrides.mediaServerId ?? 1},
+      ${overrides.userId ?? "u-1"},
+      ${overrides.username ?? "alice"},
+      'rk',
+      ${overrides.mediaType ?? "movie"},
+      ${overrides.title ?? "Title"},
+      NULL,
+      ${overrides.grandparentTitle ?? null},
+      2024,
+      NULL,
+      ${epoch - 60},
+      ${epoch},
+      ${overrides.viewOffsetMs * 2},
+      ${overrides.viewOffsetMs},
+      0,
+      ${overrides.transcodeDecision ?? "direct_play"},
+      '1080',
+      'aac',
+      'PlexWeb',
+      'Chrome',
+      'Plex',
+      '10.0.0.1',
+      5000,
+      1
+    )`
+  })
+
+const range = (startMs: number, endMs: number) => ({
+  start: new Date(startMs),
+  end: new Date(endMs),
+})
+
+describe("StatsService", () => {
+  it.effect("getPlaysByDay buckets by UTC day with movie/episode split", () =>
+    Effect.gen(function* () {
+      yield* seedMediaServer
+      // Use mid-day UTC timestamps to avoid TZ flakiness on day boundaries
+      const day1 = new Date("2024-06-01T12:00:00Z").getTime()
+      const day2 = new Date("2024-06-02T12:00:00Z").getTime()
+
+      yield* insertAt({ stoppedAt: new Date(day1), viewOffsetMs: 60_000, mediaType: "movie" })
+      yield* insertAt({ stoppedAt: new Date(day1), viewOffsetMs: 30_000, mediaType: "movie" })
+      yield* insertAt({ stoppedAt: new Date(day1), viewOffsetMs: 45_000, mediaType: "episode" })
+      yield* insertAt({ stoppedAt: new Date(day2), viewOffsetMs: 60_000, mediaType: "episode" })
+
+      const svc = yield* StatsService
+      const buckets = yield* svc.getPlaysByDay(
+        range(
+          new Date("2024-06-01T00:00:00Z").getTime(),
+          new Date("2024-06-03T00:00:00Z").getTime(),
+        ),
+      )
+      expect(buckets).toHaveLength(2)
+      expect(buckets[0].date).toBe("2024-06-01")
+      expect(buckets[0].movies).toBe(2)
+      expect(buckets[0].episodes).toBe(1)
+      expect(buckets[0].total).toBe(3)
+      expect(buckets[1].date).toBe("2024-06-02")
+      expect(buckets[1].episodes).toBe(1)
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.effect("getWatchTimeByDay sums viewOffset converted to seconds", () =>
+    Effect.gen(function* () {
+      yield* seedMediaServer
+      const day1 = new Date("2024-06-01T12:00:00Z")
+      yield* insertAt({ stoppedAt: day1, viewOffsetMs: 60_000 })
+      yield* insertAt({ stoppedAt: day1, viewOffsetMs: 90_000 })
+
+      const svc = yield* StatsService
+      const buckets = yield* svc.getWatchTimeByDay(
+        range(
+          new Date("2024-06-01T00:00:00Z").getTime(),
+          new Date("2024-06-02T00:00:00Z").getTime(),
+        ),
+      )
+      expect(buckets).toHaveLength(1)
+      expect(buckets[0].seconds).toBe(150)
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.effect("getTopMedia ranks by plays and groups episodes by series", () =>
+    Effect.gen(function* () {
+      yield* seedMediaServer
+      const t = new Date("2024-06-01T12:00:00Z")
+      yield* insertAt({ stoppedAt: t, viewOffsetMs: 60_000, mediaType: "movie", title: "Movie A" })
+      yield* insertAt({ stoppedAt: t, viewOffsetMs: 60_000, mediaType: "movie", title: "Movie B" })
+      yield* insertAt({
+        stoppedAt: t,
+        viewOffsetMs: 60_000,
+        mediaType: "episode",
+        title: "S01E01",
+        grandparentTitle: "Show X",
+      })
+      yield* insertAt({
+        stoppedAt: t,
+        viewOffsetMs: 60_000,
+        mediaType: "episode",
+        title: "S01E02",
+        grandparentTitle: "Show X",
+      })
+
+      const svc = yield* StatsService
+      const top = yield* svc.getTopMedia({
+        range: range(
+          new Date("2024-06-01T00:00:00Z").getTime(),
+          new Date("2024-06-02T00:00:00Z").getTime(),
+        ),
+      })
+      expect(top[0].title).toBe("Show X")
+      expect(top[0].playCount).toBe(2)
+      expect(top.find((m) => m.title === "Movie A")?.playCount).toBe(1)
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.effect("getTopMedia sort=duration orders by total watched ms", () =>
+    Effect.gen(function* () {
+      yield* seedMediaServer
+      const t = new Date("2024-06-01T12:00:00Z")
+      yield* insertAt({ stoppedAt: t, viewOffsetMs: 10_000, title: "Short" })
+      yield* insertAt({ stoppedAt: t, viewOffsetMs: 10_000, title: "Short" })
+      yield* insertAt({ stoppedAt: t, viewOffsetMs: 1_000_000, title: "Long" })
+
+      const svc = yield* StatsService
+      const top = yield* svc.getTopMedia({
+        range: range(
+          new Date("2024-06-01T00:00:00Z").getTime(),
+          new Date("2024-06-02T00:00:00Z").getTime(),
+        ),
+        sort: "duration",
+      })
+      expect(top[0].title).toBe("Long")
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.effect("getTopUsers ranks users by play count", () =>
+    Effect.gen(function* () {
+      yield* seedMediaServer
+      const t = new Date("2024-06-01T12:00:00Z")
+      yield* insertAt({ stoppedAt: t, viewOffsetMs: 60_000, userId: "1", username: "alice" })
+      yield* insertAt({ stoppedAt: t, viewOffsetMs: 60_000, userId: "1", username: "alice" })
+      yield* insertAt({ stoppedAt: t, viewOffsetMs: 60_000, userId: "2", username: "bob" })
+
+      const svc = yield* StatsService
+      const top = yield* svc.getTopUsers({
+        range: range(
+          new Date("2024-06-01T00:00:00Z").getTime(),
+          new Date("2024-06-02T00:00:00Z").getTime(),
+        ),
+      })
+      expect(top[0].plexUsername).toBe("alice")
+      expect(top[0].playCount).toBe(2)
+      expect(top[1].plexUsername).toBe("bob")
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.effect("getStreamTypeDistribution counts each transcode_decision bucket", () =>
+    Effect.gen(function* () {
+      yield* seedMediaServer
+      const t = new Date("2024-06-01T12:00:00Z")
+      yield* insertAt({ stoppedAt: t, viewOffsetMs: 60_000, transcodeDecision: "direct_play" })
+      yield* insertAt({ stoppedAt: t, viewOffsetMs: 60_000, transcodeDecision: "direct_play" })
+      yield* insertAt({ stoppedAt: t, viewOffsetMs: 60_000, transcodeDecision: "direct_stream" })
+      yield* insertAt({ stoppedAt: t, viewOffsetMs: 60_000, transcodeDecision: "transcode" })
+
+      const svc = yield* StatsService
+      const dist = yield* svc.getStreamTypeDistribution(
+        range(
+          new Date("2024-06-01T00:00:00Z").getTime(),
+          new Date("2024-06-02T00:00:00Z").getTime(),
+        ),
+      )
+      expect(dist.directPlay).toBe(2)
+      expect(dist.directStream).toBe(1)
+      expect(dist.transcode).toBe(1)
+      expect(dist.total).toBe(4)
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.effect("getPlaysByHourOfDay returns 24 buckets even when sparse", () =>
+    Effect.gen(function* () {
+      yield* seedMediaServer
+      yield* insertAt({ stoppedAt: new Date("2024-06-01T03:30:00Z"), viewOffsetMs: 60_000 })
+      yield* insertAt({ stoppedAt: new Date("2024-06-01T20:15:00Z"), viewOffsetMs: 60_000 })
+      yield* insertAt({ stoppedAt: new Date("2024-06-01T20:45:00Z"), viewOffsetMs: 60_000 })
+
+      const svc = yield* StatsService
+      const buckets = yield* svc.getPlaysByHourOfDay(
+        range(
+          new Date("2024-06-01T00:00:00Z").getTime(),
+          new Date("2024-06-02T00:00:00Z").getTime(),
+        ),
+      )
+      expect(buckets).toHaveLength(24)
+      expect(buckets[3].playCount).toBe(1)
+      expect(buckets[20].playCount).toBe(2)
+      expect(buckets[0].playCount).toBe(0)
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.effect("filters limit results to selected mediaType + user + server", () =>
+    Effect.gen(function* () {
+      yield* seedMediaServer
+      // Add a second media server row
+      const sql = yield* SqlClient.SqlClient
+      yield* sql`INSERT INTO media_servers (name, type, host, port, token_encrypted) VALUES ('plex2', 'plex', '127.0.0.1', 32401, 'enc:tok2')`
+
+      const t = new Date("2024-06-01T12:00:00Z")
+      yield* insertAt({ stoppedAt: t, viewOffsetMs: 60_000, mediaType: "movie", userId: "alice" })
+      yield* insertAt({
+        stoppedAt: t,
+        viewOffsetMs: 60_000,
+        mediaType: "episode",
+        userId: "alice",
+      })
+      yield* insertAt({ stoppedAt: t, viewOffsetMs: 60_000, mediaType: "movie", userId: "bob" })
+      yield* insertAt({
+        stoppedAt: t,
+        viewOffsetMs: 60_000,
+        mediaType: "movie",
+        mediaServerId: 2,
+      })
+
+      const svc = yield* StatsService
+      const r = range(
+        new Date("2024-06-01T00:00:00Z").getTime(),
+        new Date("2024-06-02T00:00:00Z").getTime(),
+      )
+
+      const aliceMovies = yield* svc.getPlaysByDay(r, { userId: "alice", mediaType: "movie" })
+      expect(aliceMovies[0].total).toBe(1)
+
+      const server2 = yield* svc.getPlaysByDay(r, { mediaServerId: 2 })
+      expect(server2[0].total).toBe(1)
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.effect("range filter excludes rows outside [start, end]", () =>
+    Effect.gen(function* () {
+      yield* seedMediaServer
+      yield* insertAt({ stoppedAt: new Date("2024-05-31T12:00:00Z"), viewOffsetMs: 60_000 })
+      yield* insertAt({ stoppedAt: new Date("2024-06-01T12:00:00Z"), viewOffsetMs: 60_000 })
+      yield* insertAt({ stoppedAt: new Date("2024-06-05T12:00:00Z"), viewOffsetMs: 60_000 })
+
+      const svc = yield* StatsService
+      const dist = yield* svc.getStreamTypeDistribution(
+        range(
+          new Date("2024-06-01T00:00:00Z").getTime(),
+          new Date("2024-06-02T00:00:00Z").getTime(),
+        ),
+      )
+      expect(dist.total).toBe(1)
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.effect("empty range returns empty arrays / zero distribution", () =>
+    Effect.gen(function* () {
+      yield* seedMediaServer
+      const svc = yield* StatsService
+      const r = range(
+        new Date("2024-06-01T00:00:00Z").getTime(),
+        new Date("2024-06-02T00:00:00Z").getTime(),
+      )
+
+      const days = yield* svc.getPlaysByDay(r)
+      const watch = yield* svc.getWatchTimeByDay(r)
+      const top = yield* svc.getTopMedia({ range: r })
+      const users = yield* svc.getTopUsers({ range: r })
+      const dist = yield* svc.getStreamTypeDistribution(r)
+      const hours = yield* svc.getPlaysByHourOfDay(r)
+
+      expect(days).toEqual([])
+      expect(watch).toEqual([])
+      expect(top).toEqual([])
+      expect(users).toEqual([])
+      expect(dist).toEqual({ directPlay: 0, directStream: 0, transcode: 0, total: 0 })
+      expect(hours).toHaveLength(24)
+      expect(hours.every((h) => h.playCount === 0)).toBe(true)
+    }).pipe(Effect.provide(TestLayer)),
+  )
+})

--- a/src/effect/services/StatsService.ts
+++ b/src/effect/services/StatsService.ts
@@ -1,0 +1,268 @@
+import { SqlError } from "@effect/sql/SqlError"
+import { and, between, count, desc, eq, sql, type SQL } from "drizzle-orm"
+import { Context, Effect, Layer } from "effect"
+
+import { sessionHistory } from "#/db/schema"
+
+import type { SessionMediaType, TranscodeDecision } from "../domain/mediaServer"
+import { Db } from "./Db"
+
+// ── Types ──
+
+export interface StatsRange {
+  readonly start: Date
+  readonly end: Date
+}
+
+export interface StatsFilters {
+  readonly userId?: string
+  readonly mediaType?: SessionMediaType
+  readonly mediaServerId?: number
+}
+
+export interface PlaysByDayBucket {
+  readonly date: string
+  readonly movies: number
+  readonly episodes: number
+  readonly total: number
+}
+
+export interface WatchTimeByDayBucket {
+  readonly date: string
+  readonly seconds: number
+}
+
+export type TopMediaSort = "plays" | "duration"
+
+export interface TopMediaEntry {
+  readonly mediaType: SessionMediaType
+  readonly title: string
+  readonly playCount: number
+  readonly totalWatchedSec: number
+}
+
+export interface TopUserEntry {
+  readonly plexUserId: string
+  readonly plexUsername: string
+  readonly playCount: number
+  readonly totalWatchedSec: number
+}
+
+export interface StreamTypeDistribution {
+  readonly directPlay: number
+  readonly directStream: number
+  readonly transcode: number
+  readonly total: number
+}
+
+export interface PlaysByHourBucket {
+  readonly hour: number
+  readonly playCount: number
+}
+
+const DEFAULT_TOP_LIMIT = 10
+const MAX_TOP_LIMIT = 100
+
+// ── Service tag ──
+
+export class StatsService extends Context.Tag("@arr-hub/StatsService")<
+  StatsService,
+  {
+    readonly getPlaysByDay: (
+      range: StatsRange,
+      filters?: StatsFilters,
+    ) => Effect.Effect<ReadonlyArray<PlaysByDayBucket>, SqlError>
+    readonly getWatchTimeByDay: (
+      range: StatsRange,
+      filters?: StatsFilters,
+    ) => Effect.Effect<ReadonlyArray<WatchTimeByDayBucket>, SqlError>
+    readonly getTopMedia: (args: {
+      readonly range: StatsRange
+      readonly mediaType?: SessionMediaType
+      readonly limit?: number
+      readonly sort?: TopMediaSort
+      readonly userId?: string
+      readonly mediaServerId?: number
+    }) => Effect.Effect<ReadonlyArray<TopMediaEntry>, SqlError>
+    readonly getTopUsers: (args: {
+      readonly range: StatsRange
+      readonly limit?: number
+      readonly mediaServerId?: number
+      readonly mediaType?: SessionMediaType
+    }) => Effect.Effect<ReadonlyArray<TopUserEntry>, SqlError>
+    readonly getStreamTypeDistribution: (
+      range: StatsRange,
+      filters?: StatsFilters,
+    ) => Effect.Effect<StreamTypeDistribution, SqlError>
+    readonly getPlaysByHourOfDay: (
+      range: StatsRange,
+      filters?: StatsFilters,
+    ) => Effect.Effect<ReadonlyArray<PlaysByHourBucket>, SqlError>
+  }
+>() {}
+
+// ── Helpers ──
+
+const buildFilterConditions = (range: StatsRange, filters?: StatsFilters): Array<SQL> => {
+  const conditions: Array<SQL> = [between(sessionHistory.stoppedAt, range.start, range.end)]
+  if (filters?.userId) conditions.push(eq(sessionHistory.plexUserId, filters.userId))
+  if (filters?.mediaType) conditions.push(eq(sessionHistory.mediaType, filters.mediaType))
+  if (filters?.mediaServerId !== undefined)
+    conditions.push(eq(sessionHistory.mediaServerId, filters.mediaServerId))
+  return conditions
+}
+
+const dayBucket = sql<string>`strftime('%Y-%m-%d', ${sessionHistory.stoppedAt}, 'unixepoch')`
+const hourBucket = sql<number>`CAST(strftime('%H', ${sessionHistory.stoppedAt}, 'unixepoch') AS INTEGER)`
+const watchedMs = sql<number>`COALESCE(SUM(${sessionHistory.viewOffset}), 0)`
+const moviePlays = sql<number>`SUM(CASE WHEN ${sessionHistory.mediaType} = 'movie' THEN 1 ELSE 0 END)`
+const episodePlays = sql<number>`SUM(CASE WHEN ${sessionHistory.mediaType} = 'episode' THEN 1 ELSE 0 END)`
+
+const decisionCount = (decision: TranscodeDecision) =>
+  sql<number>`SUM(CASE WHEN ${sessionHistory.transcodeDecision} = ${decision} THEN 1 ELSE 0 END)`
+
+const clampLimit = (n: number | undefined): number =>
+  Math.min(MAX_TOP_LIMIT, Math.max(1, Math.floor(n ?? DEFAULT_TOP_LIMIT)))
+
+// ── Live ──
+
+export const StatsServiceLive = Layer.effect(
+  StatsService,
+  Effect.gen(function* () {
+    const db = yield* Db
+
+    return {
+      getPlaysByDay: (range, filters) =>
+        Effect.gen(function* () {
+          const where = and(...buildFilterConditions(range, filters))
+          const rows = yield* db
+            .select({
+              date: dayBucket,
+              movies: moviePlays,
+              episodes: episodePlays,
+              total: count(),
+            })
+            .from(sessionHistory)
+            .where(where)
+            .groupBy(dayBucket)
+            .orderBy(dayBucket)
+
+          return rows.map((r) => ({
+            date: r.date,
+            movies: Number(r.movies ?? 0),
+            episodes: Number(r.episodes ?? 0),
+            total: r.total,
+          }))
+        }),
+
+      getWatchTimeByDay: (range, filters) =>
+        Effect.gen(function* () {
+          const where = and(...buildFilterConditions(range, filters))
+          const rows = yield* db
+            .select({
+              date: dayBucket,
+              watchedMs,
+            })
+            .from(sessionHistory)
+            .where(where)
+            .groupBy(dayBucket)
+            .orderBy(dayBucket)
+
+          return rows.map((r) => ({
+            date: r.date,
+            seconds: Math.round(Number(r.watchedMs ?? 0) / 1000),
+          }))
+        }),
+
+      getTopMedia: ({ range, mediaType, limit, sort, userId, mediaServerId }) =>
+        Effect.gen(function* () {
+          const where = and(...buildFilterConditions(range, { mediaType, userId, mediaServerId }))
+          const titleExpr = sql<string>`COALESCE(${sessionHistory.grandparentTitle}, ${sessionHistory.title})`
+          const orderExpr = sort === "duration" ? watchedMs : count()
+          const rows = yield* db
+            .select({
+              mediaType: sessionHistory.mediaType,
+              title: titleExpr,
+              playCount: count(),
+              watchedMs,
+            })
+            .from(sessionHistory)
+            .where(where)
+            .groupBy(sessionHistory.mediaType, titleExpr)
+            .orderBy(desc(orderExpr))
+            .limit(clampLimit(limit))
+
+          return rows.map((r) => ({
+            mediaType: r.mediaType,
+            title: r.title,
+            playCount: r.playCount,
+            totalWatchedSec: Math.round(Number(r.watchedMs ?? 0) / 1000),
+          }))
+        }),
+
+      getTopUsers: ({ range, limit, mediaServerId, mediaType }) =>
+        Effect.gen(function* () {
+          const where = and(...buildFilterConditions(range, { mediaServerId, mediaType }))
+          const rows = yield* db
+            .select({
+              plexUserId: sessionHistory.plexUserId,
+              plexUsername: sessionHistory.plexUsername,
+              playCount: count(),
+              watchedMs,
+            })
+            .from(sessionHistory)
+            .where(where)
+            .groupBy(sessionHistory.plexUserId, sessionHistory.plexUsername)
+            .orderBy(desc(count()))
+            .limit(clampLimit(limit))
+
+          return rows.map((r) => ({
+            plexUserId: r.plexUserId,
+            plexUsername: r.plexUsername,
+            playCount: r.playCount,
+            totalWatchedSec: Math.round(Number(r.watchedMs ?? 0) / 1000),
+          }))
+        }),
+
+      getStreamTypeDistribution: (range, filters) =>
+        Effect.gen(function* () {
+          const where = and(...buildFilterConditions(range, filters))
+          const rows = yield* db
+            .select({
+              directPlay: decisionCount("direct_play"),
+              directStream: decisionCount("direct_stream"),
+              transcode: decisionCount("transcode"),
+              total: count(),
+            })
+            .from(sessionHistory)
+            .where(where)
+
+          const r = rows[0]
+          return {
+            directPlay: Number(r?.directPlay ?? 0),
+            directStream: Number(r?.directStream ?? 0),
+            transcode: Number(r?.transcode ?? 0),
+            total: r?.total ?? 0,
+          }
+        }),
+
+      getPlaysByHourOfDay: (range, filters) =>
+        Effect.gen(function* () {
+          const where = and(...buildFilterConditions(range, filters))
+          const rows = yield* db
+            .select({
+              hour: hourBucket,
+              playCount: count(),
+            })
+            .from(sessionHistory)
+            .where(where)
+            .groupBy(hourBucket)
+            .orderBy(hourBucket)
+
+          const map = new Map<number, number>()
+          for (const r of rows) map.set(Number(r.hour), r.playCount)
+          return Array.from({ length: 24 }, (_, h) => ({ hour: h, playCount: map.get(h) ?? 0 }))
+        }),
+    }
+  }),
+)

--- a/src/integrations/trpc/router.ts
+++ b/src/integrations/trpc/router.ts
@@ -14,6 +14,7 @@ import { releasesRouter } from "./routers/releases"
 import { rootFoldersRouter } from "./routers/rootFolders"
 import { schedulerRouter } from "./routers/scheduler"
 import { seriesRouter } from "./routers/series"
+import { statsRouter } from "./routers/stats"
 import { tmdbRouter } from "./routers/tmdb"
 
 export const trpcRouter = createTRPCRouter({
@@ -32,6 +33,7 @@ export const trpcRouter = createTRPCRouter({
   releases: releasesRouter,
   rootFolders: rootFoldersRouter,
   scheduler: schedulerRouter,
+  stats: statsRouter,
   tmdb: tmdbRouter,
 })
 

--- a/src/integrations/trpc/routers/stats.ts
+++ b/src/integrations/trpc/routers/stats.ts
@@ -1,0 +1,101 @@
+import type { TRPCRouterRecord } from "@trpc/server"
+import { Effect } from "effect"
+import { z } from "zod"
+
+import { StatsService } from "#/effect/services/StatsService"
+
+import { authedProcedure, runEffect } from "../init"
+
+const rangeSchema = z.object({ start: z.date(), end: z.date() })
+
+const filtersSchema = z
+  .object({
+    userId: z.string().optional(),
+    mediaType: z.enum(["movie", "episode"]).optional(),
+    mediaServerId: z.number().int().optional(),
+  })
+  .optional()
+
+export const statsRouter = {
+  playsByDay: authedProcedure
+    .input(z.object({ range: rangeSchema, filters: filtersSchema }))
+    .query(({ input }) =>
+      runEffect(
+        Effect.gen(function* () {
+          const svc = yield* StatsService
+          return yield* svc.getPlaysByDay(input.range, input.filters)
+        }),
+      ),
+    ),
+
+  watchTimeByDay: authedProcedure
+    .input(z.object({ range: rangeSchema, filters: filtersSchema }))
+    .query(({ input }) =>
+      runEffect(
+        Effect.gen(function* () {
+          const svc = yield* StatsService
+          return yield* svc.getWatchTimeByDay(input.range, input.filters)
+        }),
+      ),
+    ),
+
+  topMedia: authedProcedure
+    .input(
+      z.object({
+        range: rangeSchema,
+        mediaType: z.enum(["movie", "episode"]).optional(),
+        limit: z.number().int().min(1).max(100).optional(),
+        sort: z.enum(["plays", "duration"]).optional(),
+        userId: z.string().optional(),
+        mediaServerId: z.number().int().optional(),
+      }),
+    )
+    .query(({ input }) =>
+      runEffect(
+        Effect.gen(function* () {
+          const svc = yield* StatsService
+          return yield* svc.getTopMedia(input)
+        }),
+      ),
+    ),
+
+  topUsers: authedProcedure
+    .input(
+      z.object({
+        range: rangeSchema,
+        limit: z.number().int().min(1).max(100).optional(),
+        mediaServerId: z.number().int().optional(),
+        mediaType: z.enum(["movie", "episode"]).optional(),
+      }),
+    )
+    .query(({ input }) =>
+      runEffect(
+        Effect.gen(function* () {
+          const svc = yield* StatsService
+          return yield* svc.getTopUsers(input)
+        }),
+      ),
+    ),
+
+  streamTypes: authedProcedure
+    .input(z.object({ range: rangeSchema, filters: filtersSchema }))
+    .query(({ input }) =>
+      runEffect(
+        Effect.gen(function* () {
+          const svc = yield* StatsService
+          return yield* svc.getStreamTypeDistribution(input.range, input.filters)
+        }),
+      ),
+    ),
+
+  playsByHourOfDay: authedProcedure
+    .input(z.object({ range: rangeSchema, filters: filtersSchema }))
+    .query(({ input }) =>
+      runEffect(
+        Effect.gen(function* () {
+          const svc = yield* StatsService
+          return yield* svc.getPlaysByHourOfDay(input.range, input.filters)
+        }),
+      ),
+    ),
+} satisfies TRPCRouterRecord

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -30,6 +30,7 @@ import { Route as SettingsDownloadClientsRouteImport } from './routes/settings/d
 import { Route as OnboardingWizardRouteImport } from './routes/onboarding/wizard'
 import { Route as OnboardingQuickstartRouteImport } from './routes/onboarding/quickstart'
 import { Route as ActivityUsersRouteImport } from './routes/activity/users'
+import { Route as ActivityStatsRouteImport } from './routes/activity/stats'
 import { Route as ActivityQueueRouteImport } from './routes/activity/queue'
 import { Route as ActivityHistoryRouteImport } from './routes/activity/history'
 import { Route as ApiTrpcSplatRouteImport } from './routes/api.trpc.$'
@@ -139,6 +140,11 @@ const ActivityUsersRoute = ActivityUsersRouteImport.update({
   path: '/activity/users',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ActivityStatsRoute = ActivityStatsRouteImport.update({
+  id: '/activity/stats',
+  path: '/activity/stats',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ActivityQueueRoute = ActivityQueueRouteImport.update({
   id: '/activity/queue',
   path: '/activity/queue',
@@ -161,6 +167,7 @@ export interface FileRoutesByFullPath {
   '/system': typeof SystemRoute
   '/activity/history': typeof ActivityHistoryRoute
   '/activity/queue': typeof ActivityQueueRoute
+  '/activity/stats': typeof ActivityStatsRoute
   '/activity/users': typeof ActivityUsersRoute
   '/onboarding/quickstart': typeof OnboardingQuickstartRoute
   '/onboarding/wizard': typeof OnboardingWizardRoute
@@ -187,6 +194,7 @@ export interface FileRoutesByTo {
   '/system': typeof SystemRoute
   '/activity/history': typeof ActivityHistoryRoute
   '/activity/queue': typeof ActivityQueueRoute
+  '/activity/stats': typeof ActivityStatsRoute
   '/activity/users': typeof ActivityUsersRoute
   '/onboarding/quickstart': typeof OnboardingQuickstartRoute
   '/onboarding/wizard': typeof OnboardingWizardRoute
@@ -214,6 +222,7 @@ export interface FileRoutesById {
   '/system': typeof SystemRoute
   '/activity/history': typeof ActivityHistoryRoute
   '/activity/queue': typeof ActivityQueueRoute
+  '/activity/stats': typeof ActivityStatsRoute
   '/activity/users': typeof ActivityUsersRoute
   '/onboarding/quickstart': typeof OnboardingQuickstartRoute
   '/onboarding/wizard': typeof OnboardingWizardRoute
@@ -242,6 +251,7 @@ export interface FileRouteTypes {
     | '/system'
     | '/activity/history'
     | '/activity/queue'
+    | '/activity/stats'
     | '/activity/users'
     | '/onboarding/quickstart'
     | '/onboarding/wizard'
@@ -268,6 +278,7 @@ export interface FileRouteTypes {
     | '/system'
     | '/activity/history'
     | '/activity/queue'
+    | '/activity/stats'
     | '/activity/users'
     | '/onboarding/quickstart'
     | '/onboarding/wizard'
@@ -294,6 +305,7 @@ export interface FileRouteTypes {
     | '/system'
     | '/activity/history'
     | '/activity/queue'
+    | '/activity/stats'
     | '/activity/users'
     | '/onboarding/quickstart'
     | '/onboarding/wizard'
@@ -321,6 +333,7 @@ export interface RootRouteChildren {
   SystemRoute: typeof SystemRoute
   ActivityHistoryRoute: typeof ActivityHistoryRoute
   ActivityQueueRoute: typeof ActivityQueueRoute
+  ActivityStatsRoute: typeof ActivityStatsRoute
   ActivityUsersRoute: typeof ActivityUsersRoute
   OnboardingQuickstartRoute: typeof OnboardingQuickstartRoute
   OnboardingWizardRoute: typeof OnboardingWizardRoute
@@ -491,6 +504,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ActivityUsersRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/activity/stats': {
+      id: '/activity/stats'
+      path: '/activity/stats'
+      fullPath: '/activity/stats'
+      preLoaderRoute: typeof ActivityStatsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/activity/queue': {
       id: '/activity/queue'
       path: '/activity/queue'
@@ -521,6 +541,7 @@ const rootRouteChildren: RootRouteChildren = {
   SystemRoute: SystemRoute,
   ActivityHistoryRoute: ActivityHistoryRoute,
   ActivityQueueRoute: ActivityQueueRoute,
+  ActivityStatsRoute: ActivityStatsRoute,
   ActivityUsersRoute: ActivityUsersRoute,
   OnboardingQuickstartRoute: OnboardingQuickstartRoute,
   OnboardingWizardRoute: OnboardingWizardRoute,

--- a/src/routes/activity/stats.tsx
+++ b/src/routes/activity/stats.tsx
@@ -1,0 +1,385 @@
+import { useQuery } from "@tanstack/react-query"
+import { createFileRoute } from "@tanstack/react-router"
+import { useMemo, useState } from "react"
+import {
+  Area,
+  AreaChart,
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  Legend,
+  Pie,
+  PieChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts"
+
+import { Skeleton } from "@/components/ui/skeleton"
+import { useTRPC } from "@/integrations/trpc/react"
+
+export const Route = createFileRoute("/activity/stats")({ component: Stats })
+
+type RangePreset = "7d" | "30d" | "90d" | "custom"
+type MediaTypeFilter = "all" | "movie" | "episode"
+
+function startOfDay(d: Date): Date {
+  const x = new Date(d)
+  x.setHours(0, 0, 0, 0)
+  return x
+}
+
+function endOfDay(d: Date): Date {
+  const x = new Date(d)
+  x.setHours(23, 59, 59, 999)
+  return x
+}
+
+function presetRange(preset: RangePreset, customStart: string, customEnd: string) {
+  const now = new Date()
+  if (preset === "custom") {
+    const start = customStart ? startOfDay(new Date(customStart)) : startOfDay(new Date(now))
+    const end = customEnd ? endOfDay(new Date(customEnd)) : endOfDay(now)
+    return { start, end }
+  }
+  const days = preset === "7d" ? 7 : preset === "30d" ? 30 : 90
+  const start = startOfDay(new Date(now.getTime() - (days - 1) * 86_400_000))
+  return { start, end: endOfDay(now) }
+}
+
+function formatDuration(seconds: number): string {
+  if (seconds <= 0) return "0m"
+  const h = Math.floor(seconds / 3600)
+  const m = Math.floor((seconds % 3600) / 60)
+  if (h === 0) return `${m}m`
+  return `${h}h ${m}m`
+}
+
+function formatHour(h: number): string {
+  const period = h < 12 ? "am" : "pm"
+  const display = h % 12 === 0 ? 12 : h % 12
+  return `${display}${period}`
+}
+
+const STREAM_COLORS: Record<string, string> = {
+  "Direct Play": "#22c55e",
+  "Direct Stream": "#3b82f6",
+  Transcode: "#f97316",
+}
+
+function Card({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="rounded-lg border p-4">
+      <h2 className="text-muted-foreground mb-3 text-sm font-semibold tracking-wide uppercase">
+        {title}
+      </h2>
+      {children}
+    </div>
+  )
+}
+
+function EmptyState({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="text-muted-foreground flex h-[260px] items-center justify-center text-sm">
+      {children}
+    </div>
+  )
+}
+
+function Stats() {
+  const trpc = useTRPC()
+  const [preset, setPreset] = useState<RangePreset>("30d")
+  const [customStart, setCustomStart] = useState<string>("")
+  const [customEnd, setCustomEnd] = useState<string>("")
+  const [mediaType, setMediaType] = useState<MediaTypeFilter>("all")
+  const [userId, setUserId] = useState<string>("")
+  const [serverId, setServerId] = useState<number | null>(null)
+
+  const range = useMemo(
+    () => presetRange(preset, customStart, customEnd),
+    [preset, customStart, customEnd],
+  )
+
+  const filters = useMemo(
+    () => ({
+      ...(mediaType === "all" ? {} : { mediaType }),
+      ...(userId ? { userId } : {}),
+      ...(serverId !== null ? { mediaServerId: serverId } : {}),
+    }),
+    [mediaType, userId, serverId],
+  )
+
+  const serversQuery = useQuery(trpc.mediaServers.list.queryOptions())
+  const usersQuery = useQuery({
+    ...trpc.plexUsers.list.queryOptions(
+      { serverId: serverId ?? 0 },
+      { enabled: serverId !== null },
+    ),
+  })
+
+  const playsByDayQuery = useQuery(trpc.stats.playsByDay.queryOptions({ range, filters }))
+  const watchTimeQuery = useQuery(trpc.stats.watchTimeByDay.queryOptions({ range, filters }))
+  const topMediaQuery = useQuery(
+    trpc.stats.topMedia.queryOptions({
+      range,
+      mediaType: mediaType === "all" ? undefined : mediaType,
+      userId: userId || undefined,
+      mediaServerId: serverId ?? undefined,
+      limit: 10,
+    }),
+  )
+  const topUsersQuery = useQuery(
+    trpc.stats.topUsers.queryOptions({
+      range,
+      mediaType: mediaType === "all" ? undefined : mediaType,
+      mediaServerId: serverId ?? undefined,
+      limit: 10,
+    }),
+  )
+  const streamTypesQuery = useQuery(trpc.stats.streamTypes.queryOptions({ range, filters }))
+  const hoursQuery = useQuery(trpc.stats.playsByHourOfDay.queryOptions({ range, filters }))
+
+  const playsData = playsByDayQuery.data ?? []
+  const watchData = (watchTimeQuery.data ?? []).map((b) => ({
+    date: b.date,
+    minutes: Math.round(b.seconds / 60),
+  }))
+  const hoursData = (hoursQuery.data ?? []).map((b) => ({
+    hour: b.hour,
+    label: formatHour(b.hour),
+    plays: b.playCount,
+  }))
+  const streamData = streamTypesQuery.data
+    ? [
+        { name: "Direct Play", value: streamTypesQuery.data.directPlay },
+        { name: "Direct Stream", value: streamTypesQuery.data.directStream },
+        { name: "Transcode", value: streamTypesQuery.data.transcode },
+      ].filter((d) => d.value > 0)
+    : []
+
+  const topMedia = topMediaQuery.data ?? []
+  const topUsers = topUsersQuery.data ?? []
+
+  return (
+    <div className="space-y-6 p-6">
+      <header className="flex flex-wrap items-end justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold">Stats</h1>
+          <p className="text-muted-foreground mt-1 text-sm">Watch analytics across your library</p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2 text-sm">
+          <select
+            aria-label="Range"
+            className="bg-background rounded border px-2 py-1"
+            value={preset}
+            onChange={(e) => setPreset(e.target.value as RangePreset)}
+          >
+            <option value="7d">Last 7 days</option>
+            <option value="30d">Last 30 days</option>
+            <option value="90d">Last 90 days</option>
+            <option value="custom">Custom</option>
+          </select>
+          {preset === "custom" && (
+            <>
+              <input
+                type="date"
+                aria-label="Start date"
+                className="bg-background rounded border px-2 py-1"
+                value={customStart}
+                onChange={(e) => setCustomStart(e.target.value)}
+              />
+              <input
+                type="date"
+                aria-label="End date"
+                className="bg-background rounded border px-2 py-1"
+                value={customEnd}
+                onChange={(e) => setCustomEnd(e.target.value)}
+              />
+            </>
+          )}
+          <select
+            aria-label="Media type"
+            className="bg-background rounded border px-2 py-1"
+            value={mediaType}
+            onChange={(e) => setMediaType(e.target.value as MediaTypeFilter)}
+          >
+            <option value="all">All media</option>
+            <option value="movie">Movies</option>
+            <option value="episode">Episodes</option>
+          </select>
+          <select
+            aria-label="Server"
+            className="bg-background rounded border px-2 py-1"
+            value={serverId ?? ""}
+            onChange={(e) => {
+              const v = e.target.value
+              setServerId(v === "" ? null : Number(v))
+              setUserId("")
+            }}
+          >
+            <option value="">All servers</option>
+            {(serversQuery.data ?? []).map((s) => (
+              <option key={s.id} value={s.id}>
+                {s.name}
+              </option>
+            ))}
+          </select>
+          <select
+            aria-label="User"
+            className="bg-background rounded border px-2 py-1 disabled:opacity-50"
+            value={userId}
+            onChange={(e) => setUserId(e.target.value)}
+            disabled={serverId === null}
+          >
+            <option value="">All users</option>
+            {(usersQuery.data ?? []).map((u) => (
+              <option key={u.id} value={u.plexUserId}>
+                {u.friendlyName}
+              </option>
+            ))}
+          </select>
+        </div>
+      </header>
+
+      <section className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        <Card title="Daily plays">
+          {playsByDayQuery.isLoading && <Skeleton className="h-[260px] w-full" />}
+          {playsByDayQuery.data && playsData.length === 0 && <EmptyState>No data</EmptyState>}
+          {playsData.length > 0 && (
+            <ResponsiveContainer width="100%" height={260}>
+              <BarChart data={playsData}>
+                <CartesianGrid strokeDasharray="3 3" stroke="#444" opacity={0.3} />
+                <XAxis dataKey="date" stroke="#888" fontSize={11} />
+                <YAxis stroke="#888" fontSize={11} allowDecimals={false} />
+                <Tooltip />
+                <Legend />
+                <Bar dataKey="movies" stackId="a" fill="#3b82f6" name="Movies" />
+                <Bar dataKey="episodes" stackId="a" fill="#a855f7" name="Episodes" />
+              </BarChart>
+            </ResponsiveContainer>
+          )}
+        </Card>
+
+        <Card title="Watch time">
+          {watchTimeQuery.isLoading && <Skeleton className="h-[260px] w-full" />}
+          {watchTimeQuery.data && watchData.length === 0 && <EmptyState>No data</EmptyState>}
+          {watchData.length > 0 && (
+            <ResponsiveContainer width="100%" height={260}>
+              <AreaChart data={watchData}>
+                <CartesianGrid strokeDasharray="3 3" stroke="#444" opacity={0.3} />
+                <XAxis dataKey="date" stroke="#888" fontSize={11} />
+                <YAxis
+                  stroke="#888"
+                  fontSize={11}
+                  tickFormatter={(v) => formatDuration(Number(v) * 60)}
+                />
+                <Tooltip formatter={(v) => formatDuration(Number(v) * 60)} />
+                <Area
+                  type="monotone"
+                  dataKey="minutes"
+                  stroke="#22c55e"
+                  fill="#22c55e"
+                  fillOpacity={0.3}
+                  name="Watched"
+                />
+              </AreaChart>
+            </ResponsiveContainer>
+          )}
+        </Card>
+
+        <Card title="Stream type distribution">
+          {streamTypesQuery.isLoading && <Skeleton className="h-[260px] w-full" />}
+          {streamTypesQuery.data && streamData.length === 0 && <EmptyState>No data</EmptyState>}
+          {streamData.length > 0 && (
+            <ResponsiveContainer width="100%" height={260}>
+              <PieChart>
+                <Pie
+                  data={streamData}
+                  dataKey="value"
+                  nameKey="name"
+                  cx="50%"
+                  cy="50%"
+                  innerRadius={50}
+                  outerRadius={90}
+                  paddingAngle={2}
+                  label={({ name, value }) => `${name ?? ""}: ${value ?? 0}`}
+                >
+                  {streamData.map((d) => (
+                    <Cell key={d.name} fill={STREAM_COLORS[d.name] ?? "#888"} />
+                  ))}
+                </Pie>
+                <Tooltip />
+              </PieChart>
+            </ResponsiveContainer>
+          )}
+        </Card>
+
+        <Card title="Peak viewing hours">
+          {hoursQuery.isLoading && <Skeleton className="h-[260px] w-full" />}
+          {hoursQuery.data && hoursData.every((h) => h.plays === 0) && (
+            <EmptyState>No data</EmptyState>
+          )}
+          {hoursQuery.data && hoursData.some((h) => h.plays > 0) && (
+            <ResponsiveContainer width="100%" height={260}>
+              <BarChart data={hoursData}>
+                <CartesianGrid strokeDasharray="3 3" stroke="#444" opacity={0.3} />
+                <XAxis dataKey="label" stroke="#888" fontSize={11} interval={1} />
+                <YAxis stroke="#888" fontSize={11} allowDecimals={false} />
+                <Tooltip />
+                <Bar dataKey="plays" fill="#f59e0b" name="Plays" />
+              </BarChart>
+            </ResponsiveContainer>
+          )}
+        </Card>
+      </section>
+
+      <section className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        <Card title="Top media">
+          {topMediaQuery.isLoading && <Skeleton className="h-32 w-full" />}
+          {topMediaQuery.data && topMedia.length === 0 && <EmptyState>No data</EmptyState>}
+          {topMedia.length > 0 && (
+            <ol className="space-y-2 text-sm">
+              {topMedia.map((m, i) => (
+                <li
+                  key={`${m.mediaType}:${m.title}`}
+                  className="flex items-center justify-between gap-2"
+                >
+                  <span className="flex min-w-0 items-center gap-2">
+                    <span className="text-muted-foreground w-5 tabular-nums">{i + 1}.</span>
+                    <span className="truncate">{m.title}</span>
+                    <span className="text-muted-foreground text-xs">({m.mediaType})</span>
+                  </span>
+                  <span className="text-muted-foreground whitespace-nowrap tabular-nums">
+                    {m.playCount} plays · {formatDuration(m.totalWatchedSec)}
+                  </span>
+                </li>
+              ))}
+            </ol>
+          )}
+        </Card>
+
+        <Card title="Top users">
+          {topUsersQuery.isLoading && <Skeleton className="h-32 w-full" />}
+          {topUsersQuery.data && topUsers.length === 0 && <EmptyState>No data</EmptyState>}
+          {topUsers.length > 0 && (
+            <ol className="space-y-2 text-sm">
+              {topUsers.map((u, i) => (
+                <li key={u.plexUserId} className="flex items-center justify-between gap-2">
+                  <span className="flex min-w-0 items-center gap-2">
+                    <span className="text-muted-foreground w-5 tabular-nums">{i + 1}.</span>
+                    <span className="truncate">{u.plexUsername}</span>
+                  </span>
+                  <span className="text-muted-foreground whitespace-nowrap tabular-nums">
+                    {u.playCount} plays · {formatDuration(u.totalWatchedSec)}
+                  </span>
+                </li>
+              ))}
+            </ol>
+          )}
+        </Card>
+      </section>
+    </div>
+  )
+}


### PR DESCRIPTION
Closes #26.

Adds aggregated watch analytics computed on-the-fly from `session_history` — no materialized stats tables.

## What's new

**Backend**
- New `StatsService` Effect service (`src/effect/services/StatsService.ts`) with the six aggregation queries from the issue:
  - `getPlaysByDay` — daily play counts split by movie / episode
  - `getWatchTimeByDay` — daily watch duration in seconds
  - `getTopMedia` — top media by plays or duration (movies by title, episodes grouped by series)
  - `getTopUsers` — most active users by play count
  - `getStreamTypeDistribution` — direct play / direct stream / transcode breakdown
  - `getPlaysByHourOfDay` — 24-bucket peak viewing hours
- `stats` tRPC router exposing each query (`stats.playsByDay`, `stats.watchTimeByDay`, `stats.topMedia`, `stats.topUsers`, `stats.streamTypes`, `stats.playsByHourOfDay`).
- `StatsServiceLive` wired into `AppLive`.

**Frontend**
- New `/activity/stats` route using `recharts`:
  - Stacked bar — daily plays (movies vs episodes)
  - Area chart — daily watch time
  - Donut — stream type distribution
  - Bar — peak viewing hours
  - Ranked lists — top media + top users
- Filters: date range (7d / 30d / 90d / custom), media type, server, user.
- Skeleton loaders + empty states everywhere.
- Sidebar nav entry added under **Activity → Stats**.

## Tests

10 new tests in `StatsService.test.ts` covering:
- Day bucketing with movie/episode split
- Watch-time aggregation in seconds
- Top-media plays vs duration ordering, episodes grouped by series
- Top-users ranking
- Transcode decision distribution
- 24-bucket hour-of-day output (sparse data filled with zeros)
- Filter combinations (user / mediaType / server)
- Range bounds excluding rows outside [start, end]
- Empty-state shapes

`bun run typecheck`, `bun run lint`, `bun run fmt:check`, and `bun run test` (251 tests) all pass locally.

## Acceptance criteria

- [x] All 6 stat queries return correct aggregations from session history
- [x] Date range filtering works for all queries
- [x] Charts render with correct data and respond to filter changes
- [x] Empty state when no history data exists
- [x] Performance acceptable for large datasets — pure SQL aggregations on indexed columns
