### PR TITLE
feat: add monitoring notification triggers

### DIFF
--- a/src/effect/layers.ts
+++ b/src/effect/layers.ts
@@ -11,6 +11,7 @@ import { DownloadMonitorLive } from "./services/DownloadMonitor"
 import { ImportServiceLive } from "./services/ImportService"
 import { IndexerServiceLive } from "./services/IndexerService"
 import { MediaServerServiceLive } from "./services/MediaServerService"
+import { MonitoringTriggerBusLive } from "./services/MonitoringTriggerBus"
 import { MovieServiceLive } from "./services/MovieService"
 import { OnboardingServiceLive } from "./services/OnboardingService"
 import { PlexSessionMonitorLive } from "./services/PlexSessionMonitor"
@@ -52,6 +53,7 @@ export const AppLive = Layer.mergeAll(
   Layer.provideMerge(ConfigServiceLive),
   Layer.provideMerge(RootFolderServiceLive),
   Layer.provideMerge(ProfileServiceLive),
+  Layer.provideMerge(MonitoringTriggerBusLive),
   Layer.provideMerge(AdapterRegistryLive),
   Layer.provideMerge(CryptoServiceLive),
   Layer.provideMerge(TmdbClientLive),

--- a/src/effect/services/MonitoringTriggerBus.ts
+++ b/src/effect/services/MonitoringTriggerBus.ts
@@ -1,0 +1,41 @@
+import type { Queue, Scope } from "effect"
+import { Context, Effect, Layer, PubSub } from "effect"
+
+import type { MediaServerSession, SessionMediaType } from "../domain/mediaServer"
+
+export type MonitoringTrigger =
+  | { readonly kind: "session_start"; readonly session: MediaServerSession }
+  | {
+      readonly kind: "session_stop"
+      readonly session: MediaServerSession
+      readonly watchedPercent: number
+    }
+  | { readonly kind: "media_watched"; readonly session: MediaServerSession }
+  | { readonly kind: "server_down"; readonly serverId: number; readonly serverName: string }
+  | { readonly kind: "server_up"; readonly serverId: number; readonly serverName: string }
+  | {
+      readonly kind: "new_content"
+      readonly mediaType: SessionMediaType
+      readonly title: string
+      readonly libraryName: string
+    }
+
+export class MonitoringTriggerBus extends Context.Tag("@arr-hub/MonitoringTriggerBus")<
+  MonitoringTriggerBus,
+  {
+    readonly emit: (trigger: MonitoringTrigger) => Effect.Effect<void>
+    readonly subscribe: () => Effect.Effect<Queue.Dequeue<MonitoringTrigger>, never, Scope.Scope>
+  }
+>() {}
+
+export const MonitoringTriggerBusLive = Layer.effect(
+  MonitoringTriggerBus,
+  Effect.gen(function* () {
+    const pubsub = yield* PubSub.sliding<MonitoringTrigger>(256)
+
+    return {
+      emit: (trigger) => PubSub.publish(pubsub, trigger).pipe(Effect.asVoid),
+      subscribe: () => PubSub.subscribe(pubsub),
+    }
+  }),
+)

--- a/src/effect/services/PlexSessionMonitor.test.ts
+++ b/src/effect/services/PlexSessionMonitor.test.ts
@@ -5,16 +5,20 @@ import type { MediaServerSession } from "#/effect/domain/mediaServer"
 import { AdapterRegistryLive } from "#/effect/services/AdapterRegistry"
 import { CryptoServiceLive } from "#/effect/services/CryptoService"
 import { MediaServerService, MediaServerServiceLive } from "#/effect/services/MediaServerService"
+import { MonitoringTriggerBusLive } from "#/effect/services/MonitoringTriggerBus"
 import { SessionHistoryServiceLive } from "#/effect/services/SessionHistoryService"
 import { TestDbLive } from "#/effect/test/TestDb"
 
 import {
   buildWsUrl,
   isPlayingNotification,
+  parseNewContentTriggers,
   PlexSessionMonitor,
   PlexSessionMonitorLive,
   reconcileSessions,
+  sessionLifecycleTriggers,
   snapshotSessions,
+  watchedPercent,
 } from "./PlexSessionMonitor"
 
 // ── Pure helper unit tests ──
@@ -53,7 +57,11 @@ const mkSession = (sessionKey: string, serverId = 1): MediaServerSession => ({
 
 describe("reconcileSessions", () => {
   it("seeds sessions when prev is empty", () => {
-    const { map, stopped } = reconcileSessions(new Map(), 1, [mkSession("a"), mkSession("b")])
+    const { map, started, stopped } = reconcileSessions(new Map(), 1, [
+      mkSession("a"),
+      mkSession("b"),
+    ])
+    expect(started.map((s) => s.sessionKey)).toEqual(["a", "b"])
     expect(stopped).toEqual([])
     expect(map.get(1)?.size).toBe(2)
   })
@@ -68,7 +76,8 @@ describe("reconcileSessions", () => {
         ]),
       ],
     ])
-    const { stopped } = reconcileSessions(prev, 1, [mkSession("a")])
+    const { started, stopped } = reconcileSessions(prev, 1, [mkSession("a")])
+    expect(started).toEqual([])
     expect(stopped.map((s) => s.sessionKey)).toEqual(["b"])
   })
 
@@ -77,7 +86,8 @@ describe("reconcileSessions", () => {
       [1, new Map([["a", mkSession("a", 1)]])],
       [2, new Map([["x", mkSession("x", 2)]])],
     ])
-    const { map, stopped } = reconcileSessions(prev, 1, [])
+    const { map, started, stopped } = reconcileSessions(prev, 1, [])
+    expect(started).toEqual([])
     expect(stopped.map((s) => s.sessionKey)).toEqual(["a"])
     expect(map.get(2)?.size).toBe(1)
     expect(map.get(1)?.size).toBe(0)
@@ -86,7 +96,8 @@ describe("reconcileSessions", () => {
   it("upserts existing keys with new state", () => {
     const prev = new Map([[1, new Map([["a", { ...mkSession("a"), state: "playing" as const }]])]])
     const updated: MediaServerSession = { ...mkSession("a"), state: "paused" }
-    const { map, stopped } = reconcileSessions(prev, 1, [updated])
+    const { map, started, stopped } = reconcileSessions(prev, 1, [updated])
+    expect(started).toEqual([])
     expect(stopped).toEqual([])
     expect(map.get(1)?.get("a")?.state).toBe("paused")
   })
@@ -156,11 +167,75 @@ describe("isPlayingNotification", () => {
   })
 })
 
+describe("parseNewContentTriggers", () => {
+  it("extracts created movie and episode timeline events", () => {
+    const raw = JSON.stringify({
+      NotificationContainer: {
+        type: "timeline",
+        TimelineEntry: [
+          {
+            type: "movie",
+            title: "Movie A",
+            sectionTitle: "Movies",
+            metadataState: "created",
+          },
+          {
+            type: "episode",
+            title: "Episode B",
+            libraryName: "TV",
+            metadata_state: "created",
+          },
+        ],
+      },
+    })
+
+    expect(parseNewContentTriggers(raw)).toEqual([
+      { kind: "new_content", mediaType: "movie", title: "Movie A", libraryName: "Movies" },
+      { kind: "new_content", mediaType: "episode", title: "Episode B", libraryName: "TV" },
+    ])
+  })
+
+  it("ignores non-created timeline entries and unsupported media types", () => {
+    const raw = JSON.stringify({
+      NotificationContainer: {
+        type: "timeline",
+        TimelineEntry: [
+          { type: "movie", title: "Deleted", sectionTitle: "Movies", metadataState: "deleted" },
+          { type: "album", title: "Music", sectionTitle: "Music", metadataState: "created" },
+        ],
+      },
+    })
+
+    expect(parseNewContentTriggers(raw)).toEqual([])
+  })
+})
+
+describe("watchedPercent", () => {
+  it("calculates bounded playback progress", () => {
+    expect(watchedPercent(mkSession("a", 1))).toBe(0)
+    expect(watchedPercent({ ...mkSession("b", 1), viewOffset: 90, duration: 100 })).toBe(90)
+    expect(watchedPercent({ ...mkSession("c", 1), viewOffset: 150, duration: 100 })).toBe(100)
+  })
+})
+
+describe("sessionLifecycleTriggers", () => {
+  it("builds session_start and session_stop triggers with watched percentage", () => {
+    const triggers = sessionLifecycleTriggers({
+      started: [mkSession("a")],
+      stopped: [{ ...mkSession("b"), viewOffset: 75, duration: 100 }],
+    })
+
+    expect(triggers.map((t) => t.kind)).toEqual(["session_start", "session_stop"])
+    expect(triggers[1]).toMatchObject({ kind: "session_stop", watchedPercent: 75 })
+  })
+})
+
 // ── Service lifecycle tests ──
 
 const TestLayer = PlexSessionMonitorLive.pipe(
   Layer.provideMerge(MediaServerServiceLive),
   Layer.provideMerge(SessionHistoryServiceLive),
+  Layer.provideMerge(MonitoringTriggerBusLive),
   Layer.provideMerge(CryptoServiceLive),
   Layer.provideMerge(AdapterRegistryLive),
   Layer.provideMerge(TestDbLive),

--- a/src/effect/services/PlexSessionMonitor.ts
+++ b/src/effect/services/PlexSessionMonitor.ts
@@ -15,6 +15,7 @@ import { AdapterRegistry } from "./AdapterRegistry"
 import { CryptoService } from "./CryptoService"
 import { Db } from "./Db"
 import type { MediaServerAdapter } from "./MediaServerAdapter"
+import { MonitoringTriggerBus, type MonitoringTrigger } from "./MonitoringTriggerBus"
 import { SessionHistoryService } from "./SessionHistoryService"
 
 // ── Notification payload (Plex `/:/websockets/notifications`) ──
@@ -24,9 +25,20 @@ interface PlaySessionStateNotification {
   readonly state?: string
 }
 
+interface TimelineEntry {
+  readonly type?: string
+  readonly title?: string
+  readonly sectionTitle?: string
+  readonly libraryName?: string
+  readonly librarySectionTitle?: string
+  readonly metadataState?: string
+  readonly metadata_state?: string
+}
+
 interface NotificationContainer {
   readonly type?: string
   readonly PlaySessionStateNotification?: ReadonlyArray<PlaySessionStateNotification>
+  readonly TimelineEntry?: ReadonlyArray<TimelineEntry>
 }
 
 interface NotificationEnvelope {
@@ -74,10 +86,19 @@ export function reconcileSessions(
   prev: SessionMap,
   serverId: number,
   next: ReadonlyArray<MediaServerSession>,
-): { readonly map: SessionMap; readonly stopped: ReadonlyArray<MediaServerSession> } {
+): {
+  readonly map: SessionMap
+  readonly started: ReadonlyArray<MediaServerSession>
+  readonly stopped: ReadonlyArray<MediaServerSession>
+} {
   const prevForServer = prev.get(serverId) ?? new Map<string, MediaServerSession>()
   const nextForServer = new Map<string, MediaServerSession>()
   for (const s of next) nextForServer.set(s.sessionKey, s)
+
+  const started: Array<MediaServerSession> = []
+  for (const [key, session] of nextForServer) {
+    if (!prevForServer.has(key)) started.push(session)
+  }
 
   const stopped: Array<MediaServerSession> = []
   for (const [key, session] of prevForServer) {
@@ -86,7 +107,7 @@ export function reconcileSessions(
 
   const map = new Map(prev)
   map.set(serverId, nextForServer)
-  return { map, stopped }
+  return { map, started, stopped }
 }
 
 export function snapshotSessions(state: SessionMap): ReadonlyArray<MediaServerSession> {
@@ -109,6 +130,55 @@ export function isPlayingNotification(raw: string): boolean {
   return container?.type === "playing" && (container.PlaySessionStateNotification?.length ?? 0) > 0
 }
 
+export function watchedPercent(session: MediaServerSession): number {
+  if (session.duration <= 0) return 0
+  return Math.min(100, Math.max(0, (session.viewOffset / session.duration) * 100))
+}
+
+export function sessionLifecycleTriggers(changes: {
+  readonly started: ReadonlyArray<MediaServerSession>
+  readonly stopped: ReadonlyArray<MediaServerSession>
+}): ReadonlyArray<MonitoringTrigger> {
+  return [
+    ...changes.started.map((session) => ({ kind: "session_start" as const, session })),
+    ...changes.stopped.map((session) => ({
+      kind: "session_stop" as const,
+      session,
+      watchedPercent: watchedPercent(session),
+    })),
+  ]
+}
+
+export function parseNewContentTriggers(raw: string): ReadonlyArray<MonitoringTrigger> {
+  let envelope: NotificationEnvelope
+  try {
+    envelope = JSON.parse(raw) as NotificationEnvelope
+  } catch {
+    return []
+  }
+
+  const container = envelope.NotificationContainer
+  if (container?.type !== "timeline") return []
+
+  const entries = container.TimelineEntry ?? []
+  const triggers: Array<MonitoringTrigger> = []
+  for (const entry of entries) {
+    const metadataState = entry.metadataState ?? entry.metadata_state
+    if (metadataState !== "created") continue
+    if (entry.type !== "movie" && entry.type !== "episode") continue
+    if (!entry.title) continue
+
+    triggers.push({
+      kind: "new_content",
+      mediaType: entry.type,
+      title: entry.title,
+      libraryName:
+        entry.libraryName ?? entry.librarySectionTitle ?? entry.sectionTitle ?? "Unknown",
+    })
+  }
+  return triggers
+}
+
 // ── Live implementation ──
 
 export const PlexSessionMonitorLive = Layer.scoped(
@@ -118,6 +188,7 @@ export const PlexSessionMonitorLive = Layer.scoped(
     const crypto = yield* CryptoService
     const registry = yield* AdapterRegistry
     const history = yield* SessionHistoryService
+    const triggers = yield* MonitoringTriggerBus
 
     const sessionsRef = yield* Ref.make<SessionMap>(new Map())
     const fibersRef = yield* Ref.make<FiberMap>(new Map())
@@ -128,14 +199,19 @@ export const PlexSessionMonitorLive = Layer.scoped(
     ): Effect.Effect<void, MediaServerError> =>
       Effect.gen(function* () {
         const sessions = yield* adapter.getActiveSessions()
-        const stopped = yield* Ref.modify(sessionsRef, (prev) => {
+        const changes = yield* Ref.modify(sessionsRef, (prev) => {
           const result = reconcileSessions(prev, serverId, sessions)
-          return [result.stopped, result.map]
+          return [{ started: result.started, stopped: result.stopped }, result.map]
         })
-        if (stopped.length > 0) {
-          yield* Effect.log(`[plex-monitor] server=${serverId} sessions ended: ${stopped.length}`)
+        for (const trigger of sessionLifecycleTriggers(changes)) {
+          yield* triggers.emit(trigger)
+        }
+        if (changes.stopped.length > 0) {
+          yield* Effect.log(
+            `[plex-monitor] server=${serverId} sessions ended: ${changes.stopped.length}`,
+          )
           yield* history
-            .writeHistory(stopped)
+            .writeHistory(changes.stopped)
             .pipe(
               Effect.catchAll((e) =>
                 Effect.logWarning(`[plex-monitor] history write failed: ${String(e)}`),
@@ -150,6 +226,9 @@ export const PlexSessionMonitorLive = Layer.scoped(
       raw: string,
     ): Effect.Effect<void, never> =>
       Effect.gen(function* () {
+        for (const trigger of parseNewContentTriggers(raw)) {
+          yield* triggers.emit(trigger)
+        }
         if (!isPlayingNotification(raw)) return
         yield* refreshFromAdapter(serverId, adapter).pipe(
           Effect.catchAll((e) =>
@@ -208,10 +287,29 @@ export const PlexSessionMonitorLive = Layer.scoped(
           resolved = true
           resume(effect)
         }
+        let serverDownEmitted = false
+        const emitServerDown = () => {
+          if (serverDownEmitted) return
+          serverDownEmitted = true
+          Runtime.runFork(runtime)(
+            triggers.emit({
+              kind: "server_down",
+              serverId: config.id,
+              serverName: config.name,
+            }),
+          )
+        }
 
         ws.addEventListener("open", () => {
           Runtime.runFork(runtime)(
-            Effect.log(`[plex-monitor] WS open server=${config.id} (${config.name})`),
+            Effect.gen(function* () {
+              yield* triggers.emit({
+                kind: "server_up",
+                serverId: config.id,
+                serverName: config.name,
+              })
+              yield* Effect.log(`[plex-monitor] WS open server=${config.id} (${config.name})`)
+            }),
           )
           // Cold-start reconcile on connect.
           Runtime.runFork(runtime)(
@@ -234,6 +332,7 @@ export const PlexSessionMonitorLive = Layer.scoped(
         })
 
         ws.addEventListener("error", () => {
+          emitServerDown()
           finish(
             Effect.fail(
               new MediaServerError({
@@ -248,6 +347,7 @@ export const PlexSessionMonitorLive = Layer.scoped(
         })
 
         ws.addEventListener("close", () => {
+          emitServerDown()
           finish(
             Effect.fail(
               new MediaServerError({

--- a/src/effect/services/PlexUserService.test.ts
+++ b/src/effect/services/PlexUserService.test.ts
@@ -10,6 +10,7 @@ import type {
 import { AdapterRegistry, AdapterRegistryLive } from "#/effect/services/AdapterRegistry"
 import { CryptoService, CryptoServiceLive } from "#/effect/services/CryptoService"
 import type { MediaServerAdapter } from "#/effect/services/MediaServerAdapter"
+import { MonitoringTriggerBusLive } from "#/effect/services/MonitoringTriggerBus"
 import {
   SessionHistoryService,
   SessionHistoryServiceLive,
@@ -20,6 +21,7 @@ import { PlexUserService, PlexUserServiceLive } from "./PlexUserService"
 
 const TestLayer = PlexUserServiceLive.pipe(
   Layer.provideMerge(SessionHistoryServiceLive),
+  Layer.provideMerge(MonitoringTriggerBusLive),
   Layer.provideMerge(CryptoServiceLive),
   Layer.provideMerge(AdapterRegistryLive),
   Layer.provideMerge(TestDbLive),

--- a/src/effect/services/SessionHistoryService.test.ts
+++ b/src/effect/services/SessionHistoryService.test.ts
@@ -1,17 +1,23 @@
 import { SqlClient } from "@effect/sql"
 import { describe, expect, it } from "@effect/vitest"
-import { Effect, Layer } from "effect"
+import { Effect, Layer, Queue } from "effect"
 
 import type { MediaServerSession } from "#/effect/domain/mediaServer"
 import { SeriesService, SeriesServiceLive } from "#/effect/services/SeriesService"
 import { TestDbLive } from "#/effect/test/TestDb"
 
+import { MonitoringTriggerBus, MonitoringTriggerBusLive } from "./MonitoringTriggerBus"
 import { MovieService, MovieServiceLive } from "./MovieService"
-import { SessionHistoryService, SessionHistoryServiceLive } from "./SessionHistoryService"
+import {
+  isWatchedSession,
+  SessionHistoryService,
+  SessionHistoryServiceLive,
+} from "./SessionHistoryService"
 
 const TestLayer = SessionHistoryServiceLive.pipe(
   Layer.provideMerge(MovieServiceLive),
   Layer.provideMerge(SeriesServiceLive),
+  Layer.provideMerge(MonitoringTriggerBusLive),
   Layer.provideMerge(TestDbLive),
 )
 
@@ -56,6 +62,11 @@ const baseSession = (overrides: Partial<MediaServerSession> = {}): MediaServerSe
 })
 
 describe("SessionHistoryService", () => {
+  it("isWatchedSession requires more than 80% progress", () => {
+    expect(isWatchedSession(baseSession({ viewOffset: 80_000, duration: 100_000 }))).toBe(false)
+    expect(isWatchedSession(baseSession({ viewOffset: 80_001, duration: 100_000 }))).toBe(true)
+  })
+
   it.effect("writeHistory persists a row with no FK match when GUIDs are null", () =>
     Effect.gen(function* () {
       yield* seedMediaServer
@@ -121,6 +132,23 @@ describe("SessionHistoryService", () => {
       const svc = yield* SessionHistoryService
       const rows = yield* svc.writeHistory([baseSession({ duration: 0 })])
       expect(rows).toHaveLength(0)
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.scoped("writeHistory emits media_watched when watch progress exceeds 80%", () =>
+    Effect.gen(function* () {
+      yield* seedMediaServer
+      const bus = yield* MonitoringTriggerBus
+      const subscription = yield* bus.subscribe()
+      const svc = yield* SessionHistoryService
+
+      yield* svc.writeHistory([baseSession({ viewOffset: 81_000, duration: 100_000 })])
+
+      const trigger = yield* Queue.take(subscription)
+      expect(trigger.kind).toBe("media_watched")
+      if (trigger.kind === "media_watched") {
+        expect(trigger.session.title).toBe("The Movie")
+      }
     }).pipe(Effect.provide(TestLayer)),
   )
 

--- a/src/effect/services/SessionHistoryService.ts
+++ b/src/effect/services/SessionHistoryService.ts
@@ -6,6 +6,7 @@ import { episodes, movies, plexUsers, sessionHistory } from "#/db/schema"
 
 import type { MediaServerSession, SessionMediaType } from "../domain/mediaServer"
 import { Db } from "./Db"
+import { MonitoringTriggerBus } from "./MonitoringTriggerBus"
 
 // ── Types ──
 
@@ -59,10 +60,16 @@ export class SessionHistoryService extends Context.Tag("@arr-hub/SessionHistoryS
 
 /** Below this watched fraction we drop the row — likely a quick scrub or accidental open. */
 const MIN_WATCHED_FRACTION = 0.01
+const WATCHED_TRIGGER_FRACTION = 0.8
 
 function shouldRecord(session: MediaServerSession): boolean {
   if (session.duration <= 0) return false
   return session.viewOffset / session.duration >= MIN_WATCHED_FRACTION
+}
+
+export function isWatchedSession(session: MediaServerSession): boolean {
+  if (session.duration <= 0) return false
+  return session.viewOffset / session.duration > WATCHED_TRIGGER_FRACTION
 }
 
 // ── Live ──
@@ -71,6 +78,7 @@ export const SessionHistoryServiceLive = Layer.effect(
   SessionHistoryService,
   Effect.gen(function* () {
     const db = yield* Db
+    const triggers = yield* MonitoringTriggerBus
 
     const resolveMovieId = (tmdbId: number | null): Effect.Effect<number | null, SqlError> =>
       tmdbId === null
@@ -154,6 +162,10 @@ export const SessionHistoryServiceLive = Layer.effect(
                   eq(plexUsers.plexUserId, s.userId),
                 ),
               )
+
+            if (isWatchedSession(s)) {
+              yield* triggers.emit({ kind: "media_watched", session: s })
+            }
           }
 
           return out


### PR DESCRIPTION
## Summary
- add a typed MonitoringTrigger discriminated union and Effect trigger bus for notification routing
- emit session_start/session_stop, server_up/server_down, media_watched, and new_content triggers from Plex monitoring/history flows
- parse Plex timeline created events using the Tautulli-style metadataState created signal

## Verification
- bun run fmt:check
- bun run lint (0 errors; existing warnings remain)
- bun run typecheck
- bun run test
- bun run build

Closes #27