### PR TITLE
feat: add local plugin system

### DIFF
--- a/drizzle/0005_violet_rhodey.sql
+++ b/drizzle/0005_violet_rhodey.sql
@@ -1,0 +1,14 @@
+CREATE TABLE `plugins` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`name` text NOT NULL,
+	`path` text NOT NULL,
+	`version` text NOT NULL,
+	`enabled` integer DEFAULT false NOT NULL,
+	`capabilities` text NOT NULL,
+	`loaded_at` integer,
+	`error_message` text,
+	`created_at` integer DEFAULT (unixepoch()) NOT NULL,
+	`updated_at` integer DEFAULT (unixepoch()) NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `plugins_name_unique` ON `plugins` (`name`);

--- a/drizzle/meta/0005_snapshot.json
+++ b/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,2722 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "925f5f3e-fc06-4878-88ba-4f126cf98bec",
+  "prevId": "91624a2b-c185-43ed-881a-faf02c94e6f9",
+  "tables": {
+    "api_keys": {
+      "name": "api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "api_keys_token_hash_unique": {
+          "name": "api_keys_token_hash_unique",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "api_keys_user_id_users_id_fk": {
+          "name": "api_keys_user_id_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "custom_format_scores": {
+      "name": "custom_format_scores",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "custom_format_id": {
+          "name": "custom_format_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "custom_format_scores_profile_id_custom_format_id_unique": {
+          "name": "custom_format_scores_profile_id_custom_format_id_unique",
+          "columns": [
+            "profile_id",
+            "custom_format_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "custom_format_scores_profile_id_quality_profiles_id_fk": {
+          "name": "custom_format_scores_profile_id_quality_profiles_id_fk",
+          "tableFrom": "custom_format_scores",
+          "tableTo": "quality_profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "custom_format_scores_custom_format_id_custom_formats_id_fk": {
+          "name": "custom_format_scores_custom_format_id_custom_formats_id_fk",
+          "tableFrom": "custom_format_scores",
+          "tableTo": "custom_formats",
+          "columnsFrom": [
+            "custom_format_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "custom_format_specs": {
+      "name": "custom_format_specs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "custom_format_id": {
+          "name": "custom_format_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field": {
+          "name": "field",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "negate": {
+          "name": "negate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "required": {
+          "name": "required",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "custom_format_specs_custom_format_id_custom_formats_id_fk": {
+          "name": "custom_format_specs_custom_format_id_custom_formats_id_fk",
+          "tableFrom": "custom_format_specs",
+          "tableTo": "custom_formats",
+          "columnsFrom": [
+            "custom_format_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "custom_formats": {
+      "name": "custom_formats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "include_when_renaming": {
+          "name": "include_when_renaming",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "custom_formats_name_unique": {
+          "name": "custom_formats_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "download_client_health": {
+      "name": "download_client_health",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "download_client_id": {
+          "name": "download_client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_check": {
+          "name": "last_check",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unknown'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response_time_ms": {
+          "name": "response_time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "download_client_health_download_client_id_unique": {
+          "name": "download_client_health_download_client_id_unique",
+          "columns": [
+            "download_client_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "download_client_health_download_client_id_download_clients_id_fk": {
+          "name": "download_client_health_download_client_id_download_clients_id_fk",
+          "tableFrom": "download_client_health",
+          "tableTo": "download_clients",
+          "columnsFrom": [
+            "download_client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "download_clients": {
+      "name": "download_clients",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "port": {
+          "name": "port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_encrypted": {
+          "name": "password_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "use_ssl": {
+          "name": "use_ssl",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 50
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "settings": {
+          "name": "settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{\"pollIntervalMs\":5000}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "download_queue": {
+      "name": "download_queue",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "download_client_id": {
+          "name": "download_client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "movie_id": {
+          "name": "movie_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "series_id": {
+          "name": "series_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "episode_ids": {
+          "name": "episode_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'queued'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "progress": {
+          "name": "progress",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "eta_seconds": {
+          "name": "eta_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "download_queue_external_id_unique": {
+          "name": "download_queue_external_id_unique",
+          "columns": [
+            "external_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "download_queue_download_client_id_download_clients_id_fk": {
+          "name": "download_queue_download_client_id_download_clients_id_fk",
+          "tableFrom": "download_queue",
+          "tableTo": "download_clients",
+          "columnsFrom": [
+            "download_client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "download_queue_movie_id_movies_id_fk": {
+          "name": "download_queue_movie_id_movies_id_fk",
+          "tableFrom": "download_queue",
+          "tableTo": "movies",
+          "columnsFrom": [
+            "movie_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "download_queue_series_id_series_id_fk": {
+          "name": "download_queue_series_id_series_id_fk",
+          "tableFrom": "download_queue",
+          "tableTo": "series",
+          "columnsFrom": [
+            "series_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "episodes": {
+      "name": "episodes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tvdb_id": {
+          "name": "tvdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "episode_number": {
+          "name": "episode_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "air_date": {
+          "name": "air_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "overview": {
+          "name": "overview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "has_file": {
+          "name": "has_file",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "monitored": {
+          "name": "monitored",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "existing_quality_name": {
+          "name": "existing_quality_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "existing_quality_rank": {
+          "name": "existing_quality_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "existing_format_score": {
+          "name": "existing_format_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "episodes_tvdb_id_unique": {
+          "name": "episodes_tvdb_id_unique",
+          "columns": [
+            "tvdb_id"
+          ],
+          "isUnique": true
+        },
+        "episodes_season_id_episode_number_unique": {
+          "name": "episodes_season_id_episode_number_unique",
+          "columns": [
+            "season_id",
+            "episode_number"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "episodes_season_id_seasons_id_fk": {
+          "name": "episodes_season_id_seasons_id_fk",
+          "tableFrom": "episodes",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "indexer_health": {
+      "name": "indexer_health",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "indexer_id": {
+          "name": "indexer_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_check": {
+          "name": "last_check",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unknown'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response_time_ms": {
+          "name": "response_time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "indexer_health_indexer_id_unique": {
+          "name": "indexer_health_indexer_id_unique",
+          "columns": [
+            "indexer_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "indexer_health_indexer_id_indexers_id_fk": {
+          "name": "indexer_health_indexer_id_indexers_id_fk",
+          "tableFrom": "indexer_health",
+          "tableTo": "indexers",
+          "columnsFrom": [
+            "indexer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "indexers": {
+      "name": "indexers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key_encrypted": {
+          "name": "api_key_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 50
+        },
+        "categories": {
+          "name": "categories",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'null'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media_server_health": {
+      "name": "media_server_health",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "media_server_id": {
+          "name": "media_server_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_check": {
+          "name": "last_check",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unknown'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response_time_ms": {
+          "name": "response_time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "media_server_health_media_server_id_unique": {
+          "name": "media_server_health_media_server_id_unique",
+          "columns": [
+            "media_server_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "media_server_health_media_server_id_media_servers_id_fk": {
+          "name": "media_server_health_media_server_id_media_servers_id_fk",
+          "tableFrom": "media_server_health",
+          "tableTo": "media_servers",
+          "columnsFrom": [
+            "media_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media_server_libraries": {
+      "name": "media_server_libraries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "media_server_id": {
+          "name": "media_server_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "last_synced": {
+          "name": "last_synced",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "media_server_libraries_media_server_id_external_id_unique": {
+          "name": "media_server_libraries_media_server_id_external_id_unique",
+          "columns": [
+            "media_server_id",
+            "external_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "media_server_libraries_media_server_id_media_servers_id_fk": {
+          "name": "media_server_libraries_media_server_id_media_servers_id_fk",
+          "tableFrom": "media_server_libraries",
+          "tableTo": "media_servers",
+          "columnsFrom": [
+            "media_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media_servers": {
+      "name": "media_servers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "port": {
+          "name": "port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_encrypted": {
+          "name": "token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "use_ssl": {
+          "name": "use_ssl",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "settings": {
+          "name": "settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{\"syncIntervalMs\":3600000,\"monitoringEnabled\":true}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "movies": {
+      "name": "movies",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "tmdb_id": {
+          "name": "tmdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "overview": {
+          "name": "overview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "poster_path": {
+          "name": "poster_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'wanted'"
+        },
+        "quality_profile_id": {
+          "name": "quality_profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "root_folder_path": {
+          "name": "root_folder_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "monitored": {
+          "name": "monitored",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "has_file": {
+          "name": "has_file",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "existing_quality_name": {
+          "name": "existing_quality_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "existing_quality_rank": {
+          "name": "existing_quality_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "existing_format_score": {
+          "name": "existing_format_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "movies_tmdb_id_unique": {
+          "name": "movies_tmdb_id_unique",
+          "columns": [
+            "tmdb_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "movies_quality_profile_id_quality_profiles_id_fk": {
+          "name": "movies_quality_profile_id_quality_profiles_id_fk",
+          "tableFrom": "movies",
+          "tableTo": "quality_profiles",
+          "columnsFrom": [
+            "quality_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "plex_users": {
+      "name": "plex_users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "media_server_id": {
+          "name": "media_server_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plex_user_id": {
+          "name": "plex_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "friendly_name": {
+          "name": "friendly_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thumb": {
+          "name": "thumb",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_play_count": {
+          "name": "total_play_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_watch_time_sec": {
+          "name": "total_watch_time_sec",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "plex_users_media_server_id_plex_user_id_unique": {
+          "name": "plex_users_media_server_id_plex_user_id_unique",
+          "columns": [
+            "media_server_id",
+            "plex_user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "plex_users_media_server_id_media_servers_id_fk": {
+          "name": "plex_users_media_server_id_media_servers_id_fk",
+          "tableFrom": "plex_users",
+          "tableTo": "media_servers",
+          "columnsFrom": [
+            "media_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "plugins": {
+      "name": "plugins",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "loaded_at": {
+          "name": "loaded_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "plugins_name_unique": {
+          "name": "plugins_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "quality_items": {
+      "name": "quality_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quality_name": {
+          "name": "quality_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "group_name": {
+          "name": "group_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "allowed": {
+          "name": "allowed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "quality_items_profile_id_quality_profiles_id_fk": {
+          "name": "quality_items_profile_id_quality_profiles_id_fk",
+          "tableFrom": "quality_items",
+          "tableTo": "quality_profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "quality_profiles": {
+      "name": "quality_profiles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "upgrade_allowed": {
+          "name": "upgrade_allowed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "min_format_score": {
+          "name": "min_format_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cutoff_format_score": {
+          "name": "cutoff_format_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "min_upgrade_format_score": {
+          "name": "min_upgrade_format_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "applied_bundle_id": {
+          "name": "applied_bundle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "applied_bundle_version": {
+          "name": "applied_bundle_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "quality_profiles_name_unique": {
+          "name": "quality_profiles_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "release_decisions": {
+      "name": "release_decisions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "candidate_title": {
+          "name": "candidate_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "indexer_id": {
+          "name": "indexer_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "indexer_name": {
+          "name": "indexer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quality_rank": {
+          "name": "quality_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "format_score": {
+          "name": "format_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reasons": {
+          "name": "reasons",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "root_folders": {
+      "name": "root_folders",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "free_space_bytes": {
+          "name": "free_space_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_space_bytes": {
+          "name": "total_space_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "root_folders_path_unique": {
+          "name": "root_folders_path_unique",
+          "columns": [
+            "path"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scheduler_config": {
+      "name": "scheduler_config",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "job_type": {
+          "name": "job_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "interval_minutes": {
+          "name": "interval_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "retry_delay_seconds": {
+          "name": "retry_delay_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 60
+        },
+        "max_retries": {
+          "name": "max_retries",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 3
+        },
+        "backoff_multiplier": {
+          "name": "backoff_multiplier",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "scheduler_config_job_type_unique": {
+          "name": "scheduler_config_job_type_unique",
+          "columns": [
+            "job_type"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scheduler_jobs": {
+      "name": "scheduler_jobs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "job_type": {
+          "name": "job_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 3
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "seasons": {
+      "name": "seasons",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "series_id": {
+          "name": "series_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "season_number": {
+          "name": "season_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "monitored": {
+          "name": "monitored",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "seasons_series_id_season_number_unique": {
+          "name": "seasons_series_id_season_number_unique",
+          "columns": [
+            "series_id",
+            "season_number"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "seasons_series_id_series_id_fk": {
+          "name": "seasons_series_id_series_id_fk",
+          "tableFrom": "seasons",
+          "tableTo": "series",
+          "columnsFrom": [
+            "series_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "series": {
+      "name": "series",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "tvdb_id": {
+          "name": "tvdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "overview": {
+          "name": "overview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "poster_path": {
+          "name": "poster_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'wanted'"
+        },
+        "network": {
+          "name": "network",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "root_folder_path": {
+          "name": "root_folder_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "monitored": {
+          "name": "monitored",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "quality_profile_id": {
+          "name": "quality_profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "season_folder": {
+          "name": "season_folder",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "series_tvdb_id_unique": {
+          "name": "series_tvdb_id_unique",
+          "columns": [
+            "tvdb_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "series_quality_profile_id_quality_profiles_id_fk": {
+          "name": "series_quality_profile_id_quality_profiles_id_fk",
+          "tableFrom": "series",
+          "tableTo": "quality_profiles",
+          "columnsFrom": [
+            "quality_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_history": {
+      "name": "session_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "media_server_id": {
+          "name": "media_server_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plex_user_id": {
+          "name": "plex_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plex_username": {
+          "name": "plex_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rating_key": {
+          "name": "rating_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_title": {
+          "name": "parent_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "grandparent_title": {
+          "name": "grandparent_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thumb": {
+          "name": "thumb",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stopped_at": {
+          "name": "stopped_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "view_offset": {
+          "name": "view_offset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "paused_duration_sec": {
+          "name": "paused_duration_sec",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "transcode_decision": {
+          "name": "transcode_decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "video_resolution": {
+          "name": "video_resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "audio_codec": {
+          "name": "audio_codec",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "player": {
+          "name": "player",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "product": {
+          "name": "product",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bandwidth": {
+          "name": "bandwidth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_local": {
+          "name": "is_local",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "movie_id": {
+          "name": "movie_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "episode_id": {
+          "name": "episode_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_history_media_server_id_media_servers_id_fk": {
+          "name": "session_history_media_server_id_media_servers_id_fk",
+          "tableFrom": "session_history",
+          "tableTo": "media_servers",
+          "columnsFrom": [
+            "media_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_history_movie_id_movies_id_fk": {
+          "name": "session_history_movie_id_movies_id_fk",
+          "tableFrom": "session_history",
+          "tableTo": "movies",
+          "columnsFrom": [
+            "movie_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "session_history_episode_id_episodes_id_fk": {
+          "name": "session_history_episode_id_episodes_id_fk",
+          "tableFrom": "session_history",
+          "tableTo": "episodes",
+          "columnsFrom": [
+            "episode_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "settings": {
+      "name": "settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "setup_log": {
+      "name": "setup_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "step_name": {
+          "name": "step_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reversible": {
+          "name": "reversible",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "rolled_back": {
+          "name": "rolled_back",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "setup_state": {
+      "name": "setup_state",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "current_step": {
+          "name": "current_step",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_steps": {
+          "name": "completed_steps",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{\"movies\":true,\"tv\":true}'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -29,6 +29,20 @@
       "when": 1776489632438,
       "tag": "0003_hard_morph",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "6",
+      "when": 1777890000000,
+      "tag": "0004_stale_agent_zero",
+      "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "6",
+      "when": 1777892947972,
+      "tag": "0005_violet_rhodey",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -424,6 +424,27 @@ export const sessionHistory = sqliteTable("session_history", {
   episodeId: integer("episode_id").references(() => episodes.id, { onDelete: "set null" }),
 })
 
+// ── Local Plugins ──
+
+export type PluginCapability = "download_client" | "indexer" | "media_server"
+
+export const plugins = sqliteTable("plugins", {
+  id: integer().primaryKey({ autoIncrement: true }),
+  name: text().notNull().unique(),
+  path: text().notNull(),
+  version: text().notNull(),
+  enabled: integer({ mode: "boolean" }).notNull().default(false),
+  capabilities: text({ mode: "json" }).$type<ReadonlyArray<PluginCapability>>().notNull(),
+  loadedAt: integer("loaded_at", { mode: "timestamp" }),
+  errorMessage: text("error_message"),
+  createdAt: integer("created_at", { mode: "timestamp" })
+    .notNull()
+    .default(sql`(unixepoch())`),
+  updatedAt: integer("updated_at", { mode: "timestamp" })
+    .notNull()
+    .default(sql`(unixepoch())`),
+})
+
 // ── Release Decisions ──
 
 export const releaseDecisions = sqliteTable("release_decisions", {

--- a/src/effect/errors.ts
+++ b/src/effect/errors.ts
@@ -148,3 +148,16 @@ export class ImportError extends Data.TaggedError("ImportError")<{
   readonly reason: ImportErrorReason
   readonly message: string
 }> {}
+
+export type PluginErrorReason =
+  | "manifest_invalid"
+  | "contract_violation"
+  | "load_failed"
+  | "plugin_already_registered"
+  | "plugin_not_found"
+
+export class PluginError extends Data.TaggedError("PluginError")<{
+  readonly reason: PluginErrorReason
+  readonly pluginName: string
+  readonly message: string
+}> {}

--- a/src/effect/layers.ts
+++ b/src/effect/layers.ts
@@ -15,6 +15,7 @@ import { MovieServiceLive } from "./services/MovieService"
 import { OnboardingServiceLive } from "./services/OnboardingService"
 import { PlexSessionMonitorLive } from "./services/PlexSessionMonitor"
 import { PlexUserServiceLive } from "./services/PlexUserService"
+import { PluginLoaderLive } from "./services/PluginLoader"
 import { ProfileDefaultsEngineLive } from "./services/ProfileDefaultsEngine"
 import { ProfileServiceLive } from "./services/ProfileService"
 import { ReleasePolicyEngineLive } from "./services/ReleasePolicyEngine"
@@ -31,6 +32,7 @@ export const AppLive = Layer.mergeAll(
   AcquisitionPipelineLive,
   DownloadMonitorLive,
   PlexSessionMonitorLive,
+  PluginLoaderLive,
   ImportServiceLive,
 ).pipe(
   Layer.provideMerge(OnboardingServiceLive),

--- a/src/effect/services/AdapterRegistry.test.ts
+++ b/src/effect/services/AdapterRegistry.test.ts
@@ -50,4 +50,27 @@ describe("AdapterRegistry", () => {
       expect(mediaError._tag).toBe("ValidationError")
     }).pipe(Effect.provide(AdapterRegistryLive)),
   )
+
+  it.effect("unregisters adapter types", () =>
+    Effect.gen(function* () {
+      const registry = yield* AdapterRegistry
+      registry.registerDownloadClient(
+        "temp-download",
+        {
+          displayName: "Temp",
+          protocolAffinity: "any",
+          defaultPort: 1,
+          authModel: "none",
+        },
+        () => ({}) as never,
+      )
+      expect(
+        registry.listDownloadClientTypes().some((entry) => entry.type === "temp-download"),
+      ).toBe(true)
+
+      registry.unregisterDownloadClient("temp-download")
+      const error = yield* Effect.flip(registry.getDownloadClientFactory("temp-download"))
+      expect(error._tag).toBe("ValidationError")
+    }).pipe(Effect.provide(AdapterRegistryLive)),
+  )
 })

--- a/src/effect/services/AdapterRegistry.ts
+++ b/src/effect/services/AdapterRegistry.ts
@@ -53,6 +53,7 @@ export class AdapterRegistry extends Context.Tag("@arr-hub/AdapterRegistry")<
       metadata: AdapterMetadata,
       factory: AdapterFactory,
     ) => void
+    readonly unregisterDownloadClient: (type: DownloadClientType) => void
     readonly getDownloadClientFactory: (
       type: DownloadClientType,
     ) => Effect.Effect<AdapterFactory, ValidationError>
@@ -67,6 +68,7 @@ export class AdapterRegistry extends Context.Tag("@arr-hub/AdapterRegistry")<
       metadata: IndexerAdapterMetadata,
       factory: IndexerAdapterFactory,
     ) => void
+    readonly unregisterIndexer: (type: IndexerType) => void
     readonly getIndexerFactory: (
       type: IndexerType,
     ) => Effect.Effect<IndexerAdapterFactory, ValidationError>
@@ -81,6 +83,7 @@ export class AdapterRegistry extends Context.Tag("@arr-hub/AdapterRegistry")<
       metadata: MediaServerAdapterMetadata,
       factory: MediaServerAdapterFactory,
     ) => void
+    readonly unregisterMediaServer: (type: MediaServerType) => void
     readonly getMediaServerFactory: (
       type: MediaServerType,
     ) => Effect.Effect<MediaServerAdapterFactory, ValidationError>
@@ -103,6 +106,9 @@ export const AdapterRegistryLive = Layer.sync(AdapterRegistry, () => {
     registerDownloadClient: (type, metadata, factory) => {
       downloadAdapters.set(type, { metadata, factory })
     },
+    unregisterDownloadClient: (type) => {
+      downloadAdapters.delete(type)
+    },
 
     getDownloadClientFactory: (type) => {
       const entry = downloadAdapters.get(type)
@@ -121,6 +127,9 @@ export const AdapterRegistryLive = Layer.sync(AdapterRegistry, () => {
     registerIndexer: (type, metadata, factory) => {
       indexerAdapters.set(type, { metadata, factory })
     },
+    unregisterIndexer: (type) => {
+      indexerAdapters.delete(type)
+    },
 
     getIndexerFactory: (type) => {
       const entry = indexerAdapters.get(type)
@@ -136,6 +145,9 @@ export const AdapterRegistryLive = Layer.sync(AdapterRegistry, () => {
     // Media servers
     registerMediaServer: (type, metadata, factory) => {
       mediaServerAdapters.set(type, { metadata, factory })
+    },
+    unregisterMediaServer: (type) => {
+      mediaServerAdapters.delete(type)
     },
 
     getMediaServerFactory: (type) => {

--- a/src/effect/services/PluginLoader.test.ts
+++ b/src/effect/services/PluginLoader.test.ts
@@ -1,0 +1,216 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import path from "node:path"
+
+import { describe, expect, it } from "@effect/vitest"
+import { Effect, Layer } from "effect"
+
+import { TestDbLive } from "../test/TestDb"
+import { AdapterRegistry, AdapterRegistryLive } from "./AdapterRegistry"
+import { CryptoServiceLive } from "./CryptoService"
+import { DownloadClientService, DownloadClientServiceLive } from "./DownloadClientService"
+import { IndexerService, IndexerServiceLive } from "./IndexerService"
+import { PluginLoader, PluginLoaderLive } from "./PluginLoader"
+
+const TestLayer = Layer.mergeAll(
+  PluginLoaderLive,
+  DownloadClientServiceLive,
+  IndexerServiceLive,
+).pipe(
+  Layer.provideMerge(CryptoServiceLive),
+  Layer.provideMerge(AdapterRegistryLive),
+  Layer.provideMerge(TestDbLive),
+)
+
+const withTempDir = Effect.acquireRelease(
+  Effect.tryPromise(() => mkdtemp(path.join(tmpdir(), "arr-hub-plugin-test-"))),
+  (dir) => Effect.tryPromise(() => rm(dir, { recursive: true, force: true })).pipe(Effect.orDie),
+)
+
+const validPluginModule = `
+import { Effect } from "effect"
+
+export const downloadClient = {
+  type: "mock-download",
+  metadata: {
+    displayName: "Mock Download",
+    protocolAffinity: "any",
+    defaultPort: 1234,
+    authModel: "none"
+  },
+  factory: () => ({
+    testConnection: () => Effect.succeed({
+      connected: true,
+      version: "1.0.0",
+      freeSpaceBytes: null,
+      errorMessage: null
+    }),
+    addDownload: () => Effect.succeed("mock-id"),
+    getQueue: () => Effect.succeed([]),
+    removeDownload: () => Effect.void,
+    getHealth: () => Effect.succeed({
+      connected: true,
+      version: "1.0.0",
+      freeSpaceBytes: null,
+      errorMessage: null
+    })
+  })
+}
+
+export const indexer = {
+  type: "mock-indexer",
+  metadata: {
+    displayName: "Mock Indexer",
+    protocolAffinity: "torrent",
+    authModel: "api_key"
+  },
+  factory: (config) => ({
+    testConnection: () => Effect.succeed({
+      searchTypes: ["movie", "tv", "general"],
+      categories: [{ id: 2000, name: "Movies" }]
+    }),
+    search: () => Effect.succeed([{
+      title: "Example.Movie.2024.1080p.WEB-DL",
+      indexerId: config.id,
+      indexerName: config.name,
+      indexerPriority: config.priority,
+      size: 1000,
+      seeders: 10,
+      leechers: 1,
+      age: 1,
+      downloadUrl: "magnet:?xt=urn:btih:abc",
+      infoUrl: null,
+      category: "Movies",
+      protocol: "torrent",
+      publishedAt: new Date(0),
+      infohash: "abc",
+      downloadFactor: 1,
+      uploadFactor: 1
+    }])
+  })
+}
+`
+
+const invalidPluginModule = `
+export const downloadClient = {
+  type: "bad-download",
+  metadata: {
+    displayName: "Bad Download",
+    protocolAffinity: "any",
+    defaultPort: 1234,
+    authModel: "none"
+  },
+  factory: () => ({})
+}
+`
+
+const writePlugin = (
+  root: string,
+  folder: string,
+  manifest: Record<string, unknown>,
+  moduleSource: string,
+) =>
+  Effect.tryPromise(async () => {
+    const pluginDir = path.join(root, folder)
+    await mkdir(pluginDir, { recursive: true })
+    await writeFile(path.join(pluginDir, "plugin.json"), JSON.stringify(manifest), "utf8")
+    await writeFile(path.join(pluginDir, String(manifest.entrypoint)), moduleSource, "utf8")
+  })
+
+describe("PluginLoader", () => {
+  it.scoped("discovers, enables, disables, and removes a valid plugin", () =>
+    Effect.gen(function* () {
+      const root = yield* withTempDir
+      yield* writePlugin(
+        root,
+        "mock",
+        {
+          name: "mock-plugin",
+          version: "1.0.0",
+          capabilities: ["download_client", "indexer"],
+          entrypoint: "index.mjs",
+        },
+        validPluginModule,
+      )
+
+      const loader = yield* PluginLoader
+      const registry = yield* AdapterRegistry
+      const scanned = yield* loader.scan(root)
+      expect(scanned.map((plugin) => plugin.name)).toEqual(["mock-plugin"])
+      expect(scanned[0].enabled).toBe(false)
+
+      const enabled = yield* loader.enable("mock-plugin")
+      expect(enabled.status).toBe("loaded")
+      expect(
+        registry.listDownloadClientTypes().some((entry) => entry.type === "mock-download"),
+      ).toBe(true)
+      expect(registry.listIndexerTypes().some((entry) => entry.type === "mock-indexer")).toBe(true)
+
+      const downloadClients = yield* DownloadClientService
+      const client = yield* downloadClients.add({
+        name: "Mock Download",
+        type: "mock-download",
+        host: "localhost",
+        port: 1234,
+        username: "",
+        password: "secret",
+      })
+      const externalId = yield* downloadClients.addDownload(client.id, "magnet:?xt=urn:btih:abc")
+      expect(externalId).toBe("mock-id")
+
+      const indexers = yield* IndexerService
+      yield* indexers.add({
+        name: "Mock Indexer",
+        type: "mock-indexer",
+        baseUrl: "http://localhost",
+        apiKey: "secret",
+      })
+      const search = yield* indexers.search({ term: "example", type: "movie" })
+      expect(search.releases.map((release) => release.title)).toEqual([
+        "Example.Movie.2024.1080p.WEB-DL",
+      ])
+
+      const health = yield* loader.health("mock-plugin")
+      expect(health.contractStatus).toBe("valid")
+
+      const disabled = yield* loader.disable("mock-plugin")
+      expect(disabled.status).toBe("disabled")
+      const missing = yield* Effect.flip(registry.getDownloadClientFactory("mock-download"))
+      expect(missing._tag).toBe("ValidationError")
+      const missingIndexer = yield* Effect.flip(registry.getIndexerFactory("mock-indexer"))
+      expect(missingIndexer._tag).toBe("ValidationError")
+
+      yield* loader.remove("mock-plugin")
+      expect(yield* loader.list()).toEqual([])
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.scoped("records invalid contract errors with actionable messages", () =>
+    Effect.gen(function* () {
+      const root = yield* withTempDir
+      yield* writePlugin(
+        root,
+        "bad",
+        {
+          name: "bad-plugin",
+          version: "1.0.0",
+          capabilities: ["download_client"],
+          entrypoint: "index.mjs",
+        },
+        invalidPluginModule,
+      )
+
+      const loader = yield* PluginLoader
+      yield* loader.scan(root)
+      const error = yield* Effect.flip(loader.enable("bad-plugin"))
+      expect(error._tag).toBe("PluginError")
+      if (error._tag === "PluginError") {
+        expect(error.reason).toBe("contract_violation")
+      }
+
+      const health = yield* loader.health("bad-plugin")
+      expect(health.contractStatus).toBe("invalid")
+      expect(health.errorMessage).toContain("methods are incomplete")
+    }).pipe(Effect.provide(TestLayer)),
+  )
+})

--- a/src/effect/services/PluginLoader.ts
+++ b/src/effect/services/PluginLoader.ts
@@ -1,0 +1,540 @@
+import { mkdir, readdir, readFile, stat } from "node:fs/promises"
+import path from "node:path"
+import { pathToFileURL } from "node:url"
+
+import { SqlError } from "@effect/sql/SqlError"
+import { eq } from "drizzle-orm"
+import { Context, Effect, Layer } from "effect"
+
+import { plugins, type PluginCapability } from "#/db/schema"
+
+import type { AdapterMetadata, DownloadClientConfig } from "../domain/downloadClient"
+import type { IndexerAdapterMetadata, IndexerConfig } from "../domain/indexer"
+import type { MediaServerAdapterMetadata, MediaServerConfig } from "../domain/mediaServer"
+import { PluginError } from "../errors"
+import type { AdapterFactory } from "./AdapterRegistry"
+import {
+  AdapterRegistry,
+  type IndexerAdapterFactory,
+  type MediaServerAdapterFactory,
+} from "./AdapterRegistry"
+import { Db } from "./Db"
+
+export type PluginRow = typeof plugins.$inferSelect
+
+export interface PluginManifest {
+  readonly name: string
+  readonly version: string
+  readonly capabilities: ReadonlyArray<PluginCapability>
+  readonly entrypoint: string
+}
+
+export interface PluginDownloadClientExport {
+  readonly type?: string
+  readonly metadata: AdapterMetadata
+  readonly factory: AdapterFactory
+}
+
+export interface PluginIndexerExport {
+  readonly type?: string
+  readonly metadata: IndexerAdapterMetadata
+  readonly factory: IndexerAdapterFactory
+}
+
+export interface PluginMediaServerExport {
+  readonly type?: string
+  readonly metadata: MediaServerAdapterMetadata
+  readonly factory: MediaServerAdapterFactory
+}
+
+export interface PluginModule {
+  readonly downloadClient?: PluginDownloadClientExport
+  readonly indexer?: PluginIndexerExport
+  readonly mediaServer?: PluginMediaServerExport
+}
+
+export interface PluginStatus extends PluginRow {
+  readonly status: "disabled" | "error" | "loaded"
+}
+
+export interface PluginHealth {
+  readonly name: string
+  readonly enabled: boolean
+  readonly status: PluginStatus["status"]
+  readonly contractStatus: "not_loaded" | "valid" | "invalid"
+  readonly capabilities: ReadonlyArray<PluginCapability>
+  readonly errorMessage: string | null
+}
+
+export class PluginLoader extends Context.Tag("@arr-hub/PluginLoader")<
+  PluginLoader,
+  {
+    readonly list: () => Effect.Effect<ReadonlyArray<PluginStatus>, SqlError>
+    readonly scan: (
+      directory?: string,
+    ) => Effect.Effect<ReadonlyArray<PluginStatus>, SqlError | PluginError>
+    readonly enable: (name: string) => Effect.Effect<PluginStatus, SqlError | PluginError>
+    readonly disable: (name: string) => Effect.Effect<PluginStatus, SqlError | PluginError>
+    readonly remove: (name: string) => Effect.Effect<void, SqlError | PluginError>
+    readonly health: (name: string) => Effect.Effect<PluginHealth, SqlError | PluginError>
+  }
+>() {}
+
+const DEFAULT_PLUGIN_DIR = path.resolve(process.cwd(), "plugins")
+const CAPABILITIES: ReadonlySet<string> = new Set(["download_client", "indexer", "media_server"])
+
+function statusFor(row: PluginRow): PluginStatus {
+  return {
+    ...row,
+    status: row.errorMessage ? "error" : row.enabled ? "loaded" : "disabled",
+  }
+}
+
+function pluginError(pluginName: string, reason: PluginError["reason"], message: string) {
+  return new PluginError({ pluginName, reason, message })
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+function parseManifest(
+  raw: string,
+  fallbackName: string,
+): Effect.Effect<PluginManifest, PluginError> {
+  return Effect.gen(function* () {
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(raw)
+    } catch (error) {
+      return yield* pluginError(
+        fallbackName,
+        "manifest_invalid",
+        error instanceof Error ? error.message : "invalid JSON",
+      )
+    }
+
+    if (!isObject(parsed)) {
+      return yield* pluginError(fallbackName, "manifest_invalid", "manifest must be an object")
+    }
+
+    const name = parsed.name
+    const version = parsed.version
+    const entrypoint = parsed.entrypoint
+    const capabilities = parsed.capabilities
+    if (typeof name !== "string" || name.trim() === "") {
+      return yield* pluginError(fallbackName, "manifest_invalid", "manifest name is required")
+    }
+    if (typeof version !== "string" || version.trim() === "") {
+      return yield* pluginError(name, "manifest_invalid", "manifest version is required")
+    }
+    if (typeof entrypoint !== "string" || entrypoint.trim() === "") {
+      return yield* pluginError(name, "manifest_invalid", "manifest entrypoint is required")
+    }
+    if (!Array.isArray(capabilities) || capabilities.length === 0) {
+      return yield* pluginError(name, "manifest_invalid", "at least one capability is required")
+    }
+    for (const capability of capabilities) {
+      if (typeof capability !== "string" || !CAPABILITIES.has(capability)) {
+        return yield* pluginError(
+          name,
+          "manifest_invalid",
+          `unknown capability: ${String(capability)}`,
+        )
+      }
+    }
+
+    return {
+      name,
+      version,
+      entrypoint,
+      capabilities: capabilities as ReadonlyArray<PluginCapability>,
+    }
+  })
+}
+
+function hasFunctions(adapter: unknown, methods: ReadonlyArray<string>): boolean {
+  if (!isObject(adapter)) return false
+  return methods.every((method) => typeof adapter[method] === "function")
+}
+
+function validateDownloadClient(
+  pluginName: string,
+  exported: PluginDownloadClientExport | undefined,
+): Effect.Effect<string, PluginError> {
+  return Effect.gen(function* () {
+    if (!exported || typeof exported.factory !== "function" || !isObject(exported.metadata)) {
+      return yield* pluginError(
+        pluginName,
+        "contract_violation",
+        "downloadClient export is invalid",
+      )
+    }
+    const type = exported.type ?? pluginName
+    const adapter = exported.factory({
+      id: 0,
+      name: pluginName,
+      type,
+      host: "localhost",
+      port: exported.metadata.defaultPort,
+      username: "",
+      password: "",
+      useSsl: false,
+      category: null,
+      settings: { pollIntervalMs: 60000 },
+    } satisfies DownloadClientConfig)
+    if (
+      !hasFunctions(adapter, [
+        "testConnection",
+        "addDownload",
+        "getQueue",
+        "removeDownload",
+        "getHealth",
+      ])
+    ) {
+      return yield* pluginError(
+        pluginName,
+        "contract_violation",
+        "download client adapter methods are incomplete",
+      )
+    }
+    return type
+  })
+}
+
+function validateIndexer(
+  pluginName: string,
+  exported: PluginIndexerExport | undefined,
+): Effect.Effect<string, PluginError> {
+  return Effect.gen(function* () {
+    if (!exported || typeof exported.factory !== "function" || !isObject(exported.metadata)) {
+      return yield* pluginError(pluginName, "contract_violation", "indexer export is invalid")
+    }
+    const type = exported.type ?? pluginName
+    const adapter = exported.factory({
+      id: 0,
+      name: pluginName,
+      type,
+      baseUrl: "http://localhost",
+      apiKey: "",
+      priority: 25,
+      categories: [],
+      protocol: exported.metadata.protocolAffinity,
+    } satisfies IndexerConfig)
+    if (!hasFunctions(adapter, ["testConnection", "search"])) {
+      return yield* pluginError(
+        pluginName,
+        "contract_violation",
+        "indexer adapter methods are incomplete",
+      )
+    }
+    return type
+  })
+}
+
+function validateMediaServer(
+  pluginName: string,
+  exported: PluginMediaServerExport | undefined,
+): Effect.Effect<string, PluginError> {
+  return Effect.gen(function* () {
+    if (!exported || typeof exported.factory !== "function" || !isObject(exported.metadata)) {
+      return yield* pluginError(pluginName, "contract_violation", "mediaServer export is invalid")
+    }
+    const type = exported.type ?? pluginName
+    const adapter = exported.factory({
+      id: 0,
+      name: pluginName,
+      type,
+      host: "localhost",
+      port: exported.metadata.defaultPort,
+      token: "",
+      useSsl: false,
+      settings: { syncIntervalMs: 3600000, monitoringEnabled: false },
+    } satisfies MediaServerConfig)
+    if (
+      !hasFunctions(adapter, [
+        "testConnection",
+        "getLibraries",
+        "syncLibrary",
+        "refreshLibrary",
+        "getHealth",
+        "getActiveSessions",
+        "getSharedUsers",
+      ])
+    ) {
+      return yield* pluginError(
+        pluginName,
+        "contract_violation",
+        "media server adapter methods are incomplete",
+      )
+    }
+    return type
+  })
+}
+
+export const PluginLoaderLive = Layer.effect(
+  PluginLoader,
+  Effect.gen(function* () {
+    const db = yield* Db
+    const registry = yield* AdapterRegistry
+    const registeredTypes = new Map<
+      string,
+      ReadonlyArray<{ capability: PluginCapability; type: string }>
+    >()
+
+    const getByName = (name: string): Effect.Effect<PluginRow, SqlError | PluginError> =>
+      Effect.gen(function* () {
+        const rows = yield* db.select().from(plugins).where(eq(plugins.name, name))
+        const row = rows[0]
+        if (!row) return yield* pluginError(name, "plugin_not_found", "plugin was not discovered")
+        return row
+      })
+
+    const readManifest = (pluginPath: string, fallbackName: string) =>
+      Effect.tryPromise({
+        try: () => readFile(path.join(pluginPath, "plugin.json"), "utf8"),
+        catch: (error) =>
+          pluginError(
+            fallbackName,
+            "manifest_invalid",
+            error instanceof Error ? error.message : "manifest read failed",
+          ),
+      }).pipe(Effect.flatMap((raw) => parseManifest(raw, fallbackName)))
+
+    const importModule = (
+      row: PluginRow,
+      manifest: PluginManifest,
+    ): Effect.Effect<PluginModule, PluginError> =>
+      Effect.tryPromise({
+        try: async () => {
+          const entrypoint = path.resolve(row.path, manifest.entrypoint)
+          await stat(entrypoint)
+          const url = pathToFileURL(entrypoint)
+          url.searchParams.set("mtime", String(Date.now()))
+          return (await import(/* @vite-ignore */ url.href)) as PluginModule
+        },
+        catch: (error) =>
+          pluginError(
+            row.name,
+            "load_failed",
+            error instanceof Error ? error.message : "plugin import failed",
+          ),
+      })
+
+    const unregister = (name: string) => {
+      for (const registration of registeredTypes.get(name) ?? []) {
+        if (registration.capability === "download_client")
+          registry.unregisterDownloadClient(registration.type)
+        if (registration.capability === "indexer") registry.unregisterIndexer(registration.type)
+        if (registration.capability === "media_server")
+          registry.unregisterMediaServer(registration.type)
+      }
+      registeredTypes.delete(name)
+    }
+
+    const ensureAvailable = (
+      name: string,
+      capability: PluginCapability,
+      type: string,
+    ): Effect.Effect<void, PluginError> => {
+      const exists =
+        capability === "download_client"
+          ? registry.listDownloadClientTypes().some((entry) => entry.type === type)
+          : capability === "indexer"
+            ? registry.listIndexerTypes().some((entry) => entry.type === type)
+            : registry.listMediaServerTypes().some((entry) => entry.type === type)
+      return exists
+        ? Effect.fail(
+            pluginError(
+              name,
+              "plugin_already_registered",
+              `adapter type is already registered: ${type}`,
+            ),
+          )
+        : Effect.void
+    }
+
+    const load = (
+      row: PluginRow,
+    ): Effect.Effect<ReadonlyArray<{ capability: PluginCapability; type: string }>, PluginError> =>
+      Effect.gen(function* () {
+        unregister(row.name)
+        const manifest = yield* readManifest(row.path, row.name)
+        const module = yield* importModule(row, manifest)
+        const registrations: Array<{ capability: PluginCapability; type: string }> = []
+
+        for (const capability of manifest.capabilities) {
+          if (capability === "download_client") {
+            const type = yield* validateDownloadClient(row.name, module.downloadClient)
+            yield* ensureAvailable(row.name, capability, type)
+            registry.registerDownloadClient(
+              type,
+              module.downloadClient!.metadata,
+              module.downloadClient!.factory,
+            )
+            registrations.push({ capability, type })
+          }
+          if (capability === "indexer") {
+            const type = yield* validateIndexer(row.name, module.indexer)
+            yield* ensureAvailable(row.name, capability, type)
+            registry.registerIndexer(type, module.indexer!.metadata, module.indexer!.factory)
+            registrations.push({ capability, type })
+          }
+          if (capability === "media_server") {
+            const type = yield* validateMediaServer(row.name, module.mediaServer)
+            yield* ensureAvailable(row.name, capability, type)
+            registry.registerMediaServer(
+              type,
+              module.mediaServer!.metadata,
+              module.mediaServer!.factory,
+            )
+            registrations.push({ capability, type })
+          }
+        }
+
+        registeredTypes.set(row.name, registrations)
+        return registrations
+      }).pipe(
+        Effect.catchAll((error) =>
+          Effect.sync(() => unregister(row.name)).pipe(Effect.zipRight(Effect.fail(error))),
+        ),
+      )
+
+    const upsertDiscovered = (
+      values: Pick<PluginRow, "name" | "path" | "version" | "capabilities" | "errorMessage">,
+    ) =>
+      db
+        .insert(plugins)
+        .values({
+          name: values.name,
+          path: values.path,
+          version: values.version,
+          capabilities: values.capabilities,
+          errorMessage: values.errorMessage,
+        })
+        .onConflictDoUpdate({
+          target: plugins.name,
+          set: {
+            path: values.path,
+            version: values.version,
+            capabilities: values.capabilities,
+            errorMessage: values.errorMessage,
+            updatedAt: new Date(),
+          },
+        })
+
+    return {
+      list: () =>
+        Effect.gen(function* () {
+          const rows = yield* db.select().from(plugins).orderBy(plugins.name)
+          return rows.map(statusFor)
+        }),
+
+      scan: (directory) =>
+        Effect.gen(function* () {
+          const root = path.resolve(
+            directory ?? process.env.ARR_HUB_PLUGIN_DIR ?? DEFAULT_PLUGIN_DIR,
+          )
+          yield* Effect.tryPromise({
+            try: () => mkdir(root, { recursive: true }),
+            catch: (error) =>
+              pluginError(
+                root,
+                "load_failed",
+                error instanceof Error ? error.message : "plugin directory unavailable",
+              ),
+          })
+          const entries = yield* Effect.tryPromise({
+            try: () => readdir(root, { withFileTypes: true }),
+            catch: (error) =>
+              pluginError(
+                root,
+                "load_failed",
+                error instanceof Error ? error.message : "plugin scan failed",
+              ),
+          })
+
+          for (const entry of entries) {
+            if (!entry.isDirectory()) continue
+            const pluginPath = path.join(root, entry.name)
+            const result = yield* Effect.either(readManifest(pluginPath, entry.name))
+            if (result._tag === "Left") {
+              yield* upsertDiscovered({
+                name: entry.name,
+                path: pluginPath,
+                version: "unknown",
+                capabilities: [],
+                errorMessage: result.left.message,
+              })
+            } else {
+              yield* upsertDiscovered({
+                name: result.right.name,
+                path: pluginPath,
+                version: result.right.version,
+                capabilities: result.right.capabilities,
+                errorMessage: null,
+              })
+            }
+          }
+
+          const rows = yield* db.select().from(plugins).orderBy(plugins.name)
+          return rows.map(statusFor)
+        }),
+
+      enable: (name) =>
+        Effect.gen(function* () {
+          const row = yield* getByName(name)
+          const registrations = yield* load(row).pipe(
+            Effect.catchAll((error) =>
+              db
+                .update(plugins)
+                .set({ enabled: false, errorMessage: error.message, updatedAt: new Date() })
+                .where(eq(plugins.name, name))
+                .pipe(Effect.zipRight(Effect.fail(error))),
+            ),
+          )
+          const [updated] = yield* db
+            .update(plugins)
+            .set({ enabled: true, loadedAt: new Date(), errorMessage: null, updatedAt: new Date() })
+            .where(eq(plugins.name, name))
+            .returning()
+          registeredTypes.set(name, registrations)
+          return statusFor(updated)
+        }),
+
+      disable: (name) =>
+        Effect.gen(function* () {
+          yield* getByName(name)
+          unregister(name)
+          const [updated] = yield* db
+            .update(plugins)
+            .set({ enabled: false, updatedAt: new Date() })
+            .where(eq(plugins.name, name))
+            .returning()
+          return statusFor(updated)
+        }),
+
+      remove: (name) =>
+        Effect.gen(function* () {
+          yield* getByName(name)
+          unregister(name)
+          yield* db.delete(plugins).where(eq(plugins.name, name))
+        }),
+
+      health: (name) =>
+        Effect.gen(function* () {
+          const row = yield* getByName(name)
+          const status = statusFor(row)
+          const isRegistered = (registeredTypes.get(name)?.length ?? 0) > 0
+          return {
+            name: row.name,
+            enabled: row.enabled,
+            status: status.status,
+            contractStatus: row.errorMessage ? "invalid" : isRegistered ? "valid" : "not_loaded",
+            capabilities: row.capabilities,
+            errorMessage: row.errorMessage,
+          }
+        }),
+    }
+  }),
+)

--- a/src/effect/test/TestDb.ts
+++ b/src/effect/test/TestDb.ts
@@ -302,6 +302,19 @@ const runDdl = Effect.gen(function* () {
     episode_id INTEGER REFERENCES episodes(id) ON DELETE SET NULL
   )`
 
+  yield* sql`CREATE TABLE plugins (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL UNIQUE,
+    path TEXT NOT NULL,
+    version TEXT NOT NULL,
+    enabled INTEGER NOT NULL DEFAULT 0,
+    capabilities TEXT NOT NULL,
+    loaded_at INTEGER,
+    error_message TEXT,
+    created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+    updated_at INTEGER NOT NULL DEFAULT (unixepoch())
+  )`
+
   yield* sql`CREATE TABLE release_decisions (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     media_id INTEGER NOT NULL,

--- a/src/integrations/trpc/init.ts
+++ b/src/integrations/trpc/init.ts
@@ -18,6 +18,7 @@ import type {
   NotFoundError,
   OnboardingError,
   ParseFailed,
+  PluginError,
   ProfileInUseError,
   SchedulerError,
   ValidationError,
@@ -63,6 +64,7 @@ type DomainError =
   | MetadataError
   | OnboardingError
   | ImportError
+  | PluginError
 
 export function domainToTRPC(error: DomainError): TRPCError {
   switch (error._tag) {
@@ -186,6 +188,19 @@ export function domainToTRPC(error: DomainError): TRPCError {
       return new TRPCError({
         code: codeMap[error.reason] ?? "BAD_REQUEST",
         message: `[${error.source}] ${error.message}`,
+      })
+    }
+    case "PluginError": {
+      const codeMap: Record<string, TRPCError["code"]> = {
+        manifest_invalid: "BAD_REQUEST",
+        contract_violation: "BAD_REQUEST",
+        load_failed: "BAD_GATEWAY",
+        plugin_already_registered: "CONFLICT",
+        plugin_not_found: "NOT_FOUND",
+      }
+      return new TRPCError({
+        code: codeMap[error.reason] ?? "BAD_REQUEST",
+        message: `[${error.pluginName}] ${error.message}`,
       })
     }
   }

--- a/src/integrations/trpc/router.ts
+++ b/src/integrations/trpc/router.ts
@@ -9,6 +9,7 @@ import { mediaServersRouter } from "./routers/mediaServers"
 import { moviesRouter } from "./routers/movies"
 import { onboardingRouter } from "./routers/onboarding"
 import { plexUsersRouter } from "./routers/plexUsers"
+import { pluginsRouter } from "./routers/plugins"
 import { profilesRouter } from "./routers/profiles"
 import { releasesRouter } from "./routers/releases"
 import { rootFoldersRouter } from "./routers/rootFolders"
@@ -27,6 +28,7 @@ export const trpcRouter = createTRPCRouter({
   downloadClients: downloadClientsRouter,
   mediaServers: mediaServersRouter,
   plexUsers: plexUsersRouter,
+  plugins: pluginsRouter,
   history: historyRouter,
   import: importRouter,
   releases: releasesRouter,

--- a/src/integrations/trpc/routers/plugins.ts
+++ b/src/integrations/trpc/routers/plugins.ts
@@ -1,0 +1,65 @@
+import type { TRPCRouterRecord } from "@trpc/server"
+import { Effect } from "effect"
+import { z } from "zod"
+
+import { PluginLoader } from "#/effect/services/PluginLoader"
+
+import { authedProcedure, runEffect } from "../init"
+
+export const pluginsRouter = {
+  list: authedProcedure.query(() =>
+    runEffect(
+      Effect.gen(function* () {
+        const loader = yield* PluginLoader
+        return yield* loader.list()
+      }),
+    ),
+  ),
+
+  scan: authedProcedure
+    .input(z.object({ directory: z.string().optional() }).optional())
+    .mutation(({ input }) =>
+      runEffect(
+        Effect.gen(function* () {
+          const loader = yield* PluginLoader
+          return yield* loader.scan(input?.directory)
+        }),
+      ),
+    ),
+
+  enable: authedProcedure.input(z.object({ name: z.string().min(1) })).mutation(({ input }) =>
+    runEffect(
+      Effect.gen(function* () {
+        const loader = yield* PluginLoader
+        return yield* loader.enable(input.name)
+      }),
+    ),
+  ),
+
+  disable: authedProcedure.input(z.object({ name: z.string().min(1) })).mutation(({ input }) =>
+    runEffect(
+      Effect.gen(function* () {
+        const loader = yield* PluginLoader
+        return yield* loader.disable(input.name)
+      }),
+    ),
+  ),
+
+  remove: authedProcedure.input(z.object({ name: z.string().min(1) })).mutation(({ input }) =>
+    runEffect(
+      Effect.gen(function* () {
+        const loader = yield* PluginLoader
+        return yield* loader.remove(input.name)
+      }),
+    ),
+  ),
+
+  health: authedProcedure.input(z.object({ name: z.string().min(1) })).query(({ input }) =>
+    runEffect(
+      Effect.gen(function* () {
+        const loader = yield* PluginLoader
+        return yield* loader.health(input.name)
+      }),
+    ),
+  ),
+} satisfies TRPCRouterRecord

--- a/src/routes/settings/plugins.tsx
+++ b/src/routes/settings/plugins.tsx
@@ -1,12 +1,126 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { createFileRoute } from "@tanstack/react-router"
+
+import { useTRPC } from "#/integrations/trpc/react"
 
 export const Route = createFileRoute("/settings/plugins")({ component: Plugins })
 
 function Plugins() {
+  const trpc = useTRPC()
+  const queryClient = useQueryClient()
+  const listQuery = useQuery(trpc.plugins.list.queryOptions())
+  const listKey = trpc.plugins.list.queryKey()
+
+  const invalidate = () => queryClient.invalidateQueries({ queryKey: listKey })
+
+  const scan = useMutation(trpc.plugins.scan.mutationOptions({ onSuccess: invalidate }))
+  const enable = useMutation(trpc.plugins.enable.mutationOptions({ onSuccess: invalidate }))
+  const disable = useMutation(trpc.plugins.disable.mutationOptions({ onSuccess: invalidate }))
+  const remove = useMutation(trpc.plugins.remove.mutationOptions({ onSuccess: invalidate }))
+
+  const pending = scan.isPending || enable.isPending || disable.isPending || remove.isPending
+  const error = scan.error ?? enable.error ?? disable.error ?? remove.error ?? listQuery.error
+
   return (
     <div className="p-6">
-      <h1 className="text-2xl font-bold">Plugins</h1>
-      <p className="text-muted-foreground mt-1">Manage installed plugins</p>
+      <header className="mb-4 flex items-end justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold">Plugins</h1>
+          <p className="text-muted-foreground mt-1">Manage trusted local plugin drop-ins</p>
+        </div>
+        <button
+          type="button"
+          className="rounded border px-3 py-1 text-sm disabled:opacity-50"
+          onClick={() => scan.mutate({})}
+          disabled={pending}
+        >
+          {scan.isPending ? "Scanning..." : "Scan"}
+        </button>
+      </header>
+
+      <p className="text-muted-foreground mb-4 max-w-3xl text-sm">
+        V1 plugins are trusted in-process modules loaded from local folders. Drop a folder with a
+        plugin.json manifest into the configured plugin directory, scan, then enable it here.
+      </p>
+
+      {error && (
+        <p className="text-destructive mb-3 text-sm">Plugin action failed: {error.message}</p>
+      )}
+      {listQuery.isLoading && <p className="text-muted-foreground">Loading plugins...</p>}
+
+      {listQuery.data && listQuery.data.length === 0 && (
+        <p className="text-muted-foreground">No plugins discovered yet.</p>
+      )}
+
+      {listQuery.data && listQuery.data.length > 0 && (
+        <div className="overflow-hidden rounded-md border">
+          <table className="w-full text-sm">
+            <thead className="bg-muted/50 text-muted-foreground">
+              <tr>
+                <th className="px-3 py-2 text-left font-medium">Name</th>
+                <th className="px-3 py-2 text-left font-medium">Version</th>
+                <th className="px-3 py-2 text-left font-medium">Capabilities</th>
+                <th className="px-3 py-2 text-left font-medium">Status</th>
+                <th className="px-3 py-2 text-left font-medium">Path</th>
+                <th className="px-3 py-2 text-right font-medium">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {listQuery.data.map((plugin) => (
+                <tr key={plugin.name} className="border-t">
+                  <td className="px-3 py-2 font-medium">{plugin.name}</td>
+                  <td className="px-3 py-2">{plugin.version}</td>
+                  <td className="px-3 py-2">
+                    {plugin.capabilities.length > 0 ? plugin.capabilities.join(", ") : "none"}
+                  </td>
+                  <td className="px-3 py-2">
+                    <div>{plugin.status}</div>
+                    {plugin.errorMessage && (
+                      <div className="text-destructive max-w-xs truncate text-xs">
+                        {plugin.errorMessage}
+                      </div>
+                    )}
+                  </td>
+                  <td className="text-muted-foreground max-w-sm truncate px-3 py-2">
+                    {plugin.path}
+                  </td>
+                  <td className="px-3 py-2 text-right">
+                    <div className="flex justify-end gap-2">
+                      {plugin.enabled ? (
+                        <button
+                          type="button"
+                          className="rounded border px-2 py-1 text-xs disabled:opacity-50"
+                          onClick={() => disable.mutate({ name: plugin.name })}
+                          disabled={pending}
+                        >
+                          Disable
+                        </button>
+                      ) : (
+                        <button
+                          type="button"
+                          className="rounded border px-2 py-1 text-xs disabled:opacity-50"
+                          onClick={() => enable.mutate({ name: plugin.name })}
+                          disabled={pending || plugin.capabilities.length === 0}
+                        >
+                          Enable
+                        </button>
+                      )}
+                      <button
+                        type="button"
+                        className="rounded border px-2 py-1 text-xs disabled:opacity-50"
+                        onClick={() => remove.mutate({ name: plugin.name })}
+                        disabled={pending}
+                      >
+                        Remove
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- add plugins schema/migration and Effect PluginLoader for trusted local plugin folders
- add scan, manifest validation, contract validation, enable/disable/remove, and health procedures
- register/unregister plugin download client, indexer, and media server adapters through AdapterRegistry
- add settings UI controls for scanning and managing local plugins
- cover valid plugin registration, invalid contract failure, DownloadClientService integration, and IndexerService.search integration

## Verification
- bun run fmt:check
- bun run lint (0 errors; existing warnings remain)
- bun run typecheck
- bun run test
- bun run build

Closes #10