### PR TITLE
feat: add diagnostics and queue dashboard

### DIFF
--- a/src/effect/errors.ts
+++ b/src/effect/errors.ts
@@ -100,6 +100,20 @@ export class SchedulerError extends Data.TaggedError("SchedulerError")<{
   readonly message: string
 }> {}
 
+export type DiagnosticsErrorReason = "log_access_failed"
+
+export class DiagnosticsError extends Data.TaggedError("DiagnosticsError")<{
+  readonly reason: DiagnosticsErrorReason
+  readonly message: string
+}> {}
+
+export type SettingsErrorReason = "invalid_key" | "invalid_value"
+
+export class SettingsError extends Data.TaggedError("SettingsError")<{
+  readonly reason: SettingsErrorReason
+  readonly message: string
+}> {}
+
 export type AcquisitionStage = "search" | "evaluate" | "grab"
 
 export type AcquisitionMediaKind = "movie" | "series" | "season" | "episode"

--- a/src/effect/layers.ts
+++ b/src/effect/layers.ts
@@ -6,6 +6,7 @@ import { AuthServiceLive } from "./services/AuthService"
 import { ConfigServiceLive } from "./services/ConfigService"
 import { CryptoServiceLive } from "./services/CryptoService"
 import { DbLive } from "./services/Db"
+import { DiagnosticsServiceLive } from "./services/DiagnosticsService"
 import { DownloadClientServiceLive } from "./services/DownloadClientService"
 import { DownloadMonitorLive } from "./services/DownloadMonitor"
 import { ImportServiceLive } from "./services/ImportService"
@@ -17,23 +18,27 @@ import { PlexSessionMonitorLive } from "./services/PlexSessionMonitor"
 import { PlexUserServiceLive } from "./services/PlexUserService"
 import { ProfileDefaultsEngineLive } from "./services/ProfileDefaultsEngine"
 import { ProfileServiceLive } from "./services/ProfileService"
+import { QueueServiceLive } from "./services/QueueService"
 import { ReleasePolicyEngineLive } from "./services/ReleasePolicyEngine"
 import { RootFolderServiceLive } from "./services/RootFolderService"
 import { SchedulerServiceLive } from "./services/SchedulerService"
 import { SeriesServiceLive } from "./services/SeriesService"
 import { SessionHistoryServiceLive } from "./services/SessionHistoryService"
+import { SettingsServiceLive } from "./services/SettingsService"
 import { StatsServiceLive } from "./services/StatsService"
 import { TitleParserServiceLive } from "./services/TitleParserService"
 import { TmdbClientLive } from "./services/TmdbClient"
 
 /** All application services, fully wired. Db + CryptoService also exposed for direct use. */
 export const AppLive = Layer.mergeAll(
-  SchedulerServiceLive,
+  DiagnosticsServiceLive,
+  QueueServiceLive,
   AcquisitionPipelineLive,
   DownloadMonitorLive,
   PlexSessionMonitorLive,
   ImportServiceLive,
 ).pipe(
+  Layer.provideMerge(SchedulerServiceLive),
   Layer.provideMerge(OnboardingServiceLive),
   Layer.provideMerge(AuthServiceLive),
   Layer.provideMerge(
@@ -52,6 +57,7 @@ export const AppLive = Layer.mergeAll(
   Layer.provideMerge(TitleParserServiceLive),
   Layer.provideMerge(ProfileDefaultsEngineLive),
   Layer.provideMerge(ConfigServiceLive),
+  Layer.provideMerge(SettingsServiceLive),
   Layer.provideMerge(RootFolderServiceLive),
   Layer.provideMerge(ProfileServiceLive),
   Layer.provideMerge(AdapterRegistryLive),

--- a/src/effect/services/DiagnosticsService.test.ts
+++ b/src/effect/services/DiagnosticsService.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "@effect/vitest"
+import { Effect, Layer } from "effect"
+
+import { TestDbLive } from "#/effect/test/TestDb"
+
+import { DiagnosticsService, DiagnosticsServiceLive } from "./DiagnosticsService"
+import { DownloadClientService } from "./DownloadClientService"
+import { IndexerService } from "./IndexerService"
+import { MediaServerService } from "./MediaServerService"
+import { SchedulerService, SchedulerServiceLive } from "./SchedulerService"
+
+const MockIndexerService = Layer.succeed(IndexerService, {
+  add: () => Effect.die("not implemented"),
+  list: () =>
+    Effect.succeed([
+      {
+        id: 1,
+        name: "Indexer",
+        type: "torznab",
+        baseUrl: "http://indexer",
+        enabled: true,
+        priority: 50,
+        categories: [],
+        capabilities: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        health: {
+          status: "healthy",
+          lastCheck: new Date(),
+          errorMessage: null,
+          responseTimeMs: 10,
+        },
+      },
+    ]),
+  getById: () => Effect.die("not implemented"),
+  update: () => Effect.die("not implemented"),
+  remove: () => Effect.die("not implemented"),
+  testConnection: () => Effect.die("not implemented"),
+  search: () => Effect.die("not implemented"),
+  listTypes: () => [],
+})
+
+const MockDownloadClientService = Layer.succeed(DownloadClientService, {
+  add: () => Effect.die("not implemented"),
+  list: () =>
+    Effect.succeed([
+      {
+        id: 1,
+        name: "qBit",
+        type: "qbittorrent",
+        host: "localhost",
+        port: 8080,
+        username: "admin",
+        useSsl: false,
+        category: null,
+        priority: 50,
+        enabled: true,
+        settings: { pollIntervalMs: 5000 },
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        health: {
+          status: "unhealthy",
+          lastCheck: new Date(),
+          errorMessage: "connection refused",
+          responseTimeMs: null,
+        },
+      },
+    ]),
+  getById: () => Effect.die("not implemented"),
+  update: () => Effect.die("not implemented"),
+  remove: () => Effect.die("not implemented"),
+  testConnection: () => Effect.die("not implemented"),
+  addDownload: () => Effect.die("not implemented"),
+  getQueue: () => Effect.die("not implemented"),
+  removeDownload: () => Effect.die("not implemented"),
+  listTypes: () => [],
+})
+
+const MockMediaServerService = Layer.succeed(MediaServerService, {
+  add: () => Effect.die("not implemented"),
+  list: () => Effect.succeed([]),
+  getById: () => Effect.die("not implemented"),
+  update: () => Effect.die("not implemented"),
+  remove: () => Effect.die("not implemented"),
+  testConnection: () => Effect.die("not implemented"),
+  getLibraries: () => Effect.die("not implemented"),
+  syncLibrary: () => Effect.die("not implemented"),
+  refreshLibrary: () => Effect.die("not implemented"),
+  listTypes: () => [],
+})
+
+const BaseLayer = Layer.mergeAll(
+  SchedulerServiceLive,
+  MockIndexerService,
+  MockDownloadClientService,
+  MockMediaServerService,
+).pipe(Layer.provideMerge(TestDbLive))
+
+const TestLayer = DiagnosticsServiceLive.pipe(Layer.provideMerge(BaseLayer))
+
+describe("DiagnosticsService", () => {
+  it.effect("returns system status with DB counts and resource usage", () =>
+    Effect.gen(function* () {
+      const diagnostics = yield* DiagnosticsService
+      const status = yield* diagnostics.status()
+
+      expect(status.version.length).toBeGreaterThan(0)
+      expect(status.uptimeSeconds).toBeGreaterThanOrEqual(0)
+      expect(status.database.tableCounts.movies).toBe(0)
+      expect(status.resources.heapTotalBytes).toBeGreaterThan(0)
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.effect("aggregates health without failing on unhealthy integrations", () =>
+    Effect.gen(function* () {
+      const diagnostics = yield* DiagnosticsService
+      const health = yield* diagnostics.health()
+
+      expect(health.status).toBe("unhealthy")
+      expect(health.integrations.some((item) => item.type === "download_client")).toBe(true)
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.effect("filters structured logs by level", () =>
+    Effect.gen(function* () {
+      const diagnostics = yield* DiagnosticsService
+      yield* diagnostics.log("info", "started")
+      yield* diagnostics.log("error", "failed")
+
+      const entries = yield* diagnostics.logs({ level: "error", count: 10 })
+
+      expect(entries).toHaveLength(1)
+      expect(entries[0]?.message).toBe("failed")
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.effect("summarizes scheduler task states", () =>
+    Effect.gen(function* () {
+      const scheduler = yield* SchedulerService
+      const diagnostics = yield* DiagnosticsService
+
+      yield* scheduler.seedConfig()
+      yield* scheduler.enqueue({ _tag: "rss_sync" })
+      const tasks = yield* diagnostics.tasks()
+
+      expect(tasks.pending).toBe(1)
+      expect(tasks.byType.some((item) => item.jobType === "rss_sync")).toBe(true)
+    }).pipe(Effect.provide(TestLayer)),
+  )
+})

--- a/src/effect/services/DiagnosticsService.ts
+++ b/src/effect/services/DiagnosticsService.ts
@@ -1,0 +1,326 @@
+import { existsSync, statSync } from "node:fs"
+
+import { SqlError } from "@effect/sql/SqlError"
+import { count, eq } from "drizzle-orm"
+import { Context, Effect, Layer, Ref } from "effect"
+
+import {
+  apiKeys,
+  downloadClients,
+  downloadQueue,
+  indexers,
+  mediaServers,
+  movies,
+  schedulerJobs,
+  series,
+  settings,
+} from "#/db/schema"
+
+import type { JobTypeSummary } from "../domain/scheduler"
+import { DiagnosticsError } from "../errors"
+import { Db } from "./Db"
+import { DownloadClientService } from "./DownloadClientService"
+import { IndexerService } from "./IndexerService"
+import { MediaServerService } from "./MediaServerService"
+import { SchedulerService } from "./SchedulerService"
+
+const DB_PATH = process.env.DATABASE_PATH ?? "data/arr-hub.db"
+const LOG_LIMIT = 500
+
+export type LogLevel = "debug" | "info" | "warn" | "error"
+export type HealthStatus = "healthy" | "degraded" | "unhealthy"
+
+export interface SystemStatus {
+  readonly version: string
+  readonly uptimeSeconds: number
+  readonly database: {
+    readonly path: string
+    readonly sizeBytes: number
+    readonly tableCounts: {
+      readonly movies: number
+      readonly series: number
+      readonly indexers: number
+      readonly downloadClients: number
+      readonly mediaServers: number
+      readonly queueItems: number
+      readonly settings: number
+      readonly apiKeys: number
+    }
+  }
+  readonly resources: {
+    readonly rssBytes: number
+    readonly heapUsedBytes: number
+    readonly heapTotalBytes: number
+    readonly externalBytes: number
+    readonly userCpuMicros: number
+    readonly systemCpuMicros: number
+  }
+}
+
+export interface IntegrationHealthItem {
+  readonly type: "indexer" | "download_client" | "media_server"
+  readonly id: number
+  readonly name: string
+  readonly enabled: boolean
+  readonly status: HealthStatus
+  readonly lastCheck: Date | null
+  readonly message: string | null
+}
+
+export interface AggregatedHealth {
+  readonly status: HealthStatus
+  readonly integrations: ReadonlyArray<IntegrationHealthItem>
+  readonly failures: ReadonlyArray<{ readonly type: string; readonly message: string }>
+}
+
+export interface LogEntry {
+  readonly id: number
+  readonly timestamp: Date
+  readonly level: LogLevel
+  readonly message: string
+  readonly context: Record<string, unknown> | null
+}
+
+export interface TaskSummary {
+  readonly running: number
+  readonly pending: number
+  readonly failed: number
+  readonly dead: number
+  readonly byType: ReadonlyArray<JobTypeSummary>
+}
+
+export class DiagnosticsService extends Context.Tag("@arr-hub/DiagnosticsService")<
+  DiagnosticsService,
+  {
+    readonly status: () => Effect.Effect<SystemStatus, SqlError>
+    readonly health: () => Effect.Effect<AggregatedHealth, SqlError>
+    readonly logs: (filters?: {
+      readonly level?: LogLevel
+      readonly count?: number
+    }) => Effect.Effect<ReadonlyArray<LogEntry>, DiagnosticsError>
+    readonly log: (
+      level: LogLevel,
+      message: string,
+      context?: Record<string, unknown>,
+    ) => Effect.Effect<void>
+    readonly tasks: () => Effect.Effect<TaskSummary, SqlError>
+  }
+>() {}
+
+function dbSizeBytes(): number {
+  return existsSync(DB_PATH) ? statSync(DB_PATH).size : 0
+}
+
+function normalizeHealth(status: string | null | undefined, enabled: boolean): HealthStatus {
+  if (!enabled) return "degraded"
+  if (status === "healthy") return "healthy"
+  if (status === "unhealthy") return "unhealthy"
+  return "degraded"
+}
+
+function worstStatus(
+  items: ReadonlyArray<IntegrationHealthItem>,
+  failures: ReadonlyArray<unknown>,
+) {
+  if (items.some((item) => item.status === "unhealthy")) return "unhealthy" as const
+  if (failures.length > 0 || items.some((item) => item.status === "degraded")) {
+    return "degraded" as const
+  }
+  return "healthy" as const
+}
+
+export const DiagnosticsServiceLive = Layer.effect(
+  DiagnosticsService,
+  Effect.gen(function* () {
+    const db = yield* Db
+    const indexerService = yield* IndexerService
+    const downloadClientService = yield* DownloadClientService
+    const mediaServerService = yield* MediaServerService
+    const schedulerService = yield* SchedulerService
+    const logsRef = yield* Ref.make<ReadonlyArray<LogEntry>>([])
+    const nextLogIdRef = yield* Ref.make(1)
+
+    const tableCount = <T>(table: T) =>
+      db
+        .select({ value: count() })
+        // @ts-expect-error drizzle table type is preserved at call sites; generic helper keeps repetition low.
+        .from(table)
+        .pipe(Effect.map((rows) => rows[0]?.value ?? 0))
+
+    return {
+      status: () =>
+        Effect.gen(function* () {
+          const [
+            movieCount,
+            seriesCount,
+            indexerCount,
+            clientCount,
+            serverCount,
+            queueCount,
+            settingCount,
+            keyCount,
+          ] = yield* Effect.all([
+            tableCount(movies),
+            tableCount(series),
+            tableCount(indexers),
+            tableCount(downloadClients),
+            tableCount(mediaServers),
+            tableCount(downloadQueue),
+            tableCount(settings),
+            tableCount(apiKeys),
+          ])
+          const memory = process.memoryUsage()
+          const cpu = process.cpuUsage()
+
+          return {
+            version: process.env.npm_package_version ?? "0.0.0-dev",
+            uptimeSeconds: Math.floor(process.uptime()),
+            database: {
+              path: DB_PATH,
+              sizeBytes: dbSizeBytes(),
+              tableCounts: {
+                movies: movieCount,
+                series: seriesCount,
+                indexers: indexerCount,
+                downloadClients: clientCount,
+                mediaServers: serverCount,
+                queueItems: queueCount,
+                settings: settingCount,
+                apiKeys: keyCount,
+              },
+            },
+            resources: {
+              rssBytes: memory.rss,
+              heapUsedBytes: memory.heapUsed,
+              heapTotalBytes: memory.heapTotal,
+              externalBytes: memory.external,
+              userCpuMicros: cpu.user,
+              systemCpuMicros: cpu.system,
+            },
+          }
+        }),
+
+      health: () =>
+        Effect.gen(function* () {
+          const [indexerResult, clientResult, serverResult] = yield* Effect.all([
+            Effect.either(indexerService.list()),
+            Effect.either(downloadClientService.list()),
+            Effect.either(mediaServerService.list()),
+          ])
+
+          const failures: Array<{ type: string; message: string }> = []
+          const integrations: Array<IntegrationHealthItem> = []
+
+          if (indexerResult._tag === "Left") {
+            failures.push({ type: "indexer", message: indexerResult.left.message })
+          } else {
+            for (const item of indexerResult.right) {
+              integrations.push({
+                type: "indexer",
+                id: item.id,
+                name: item.name,
+                enabled: item.enabled,
+                status: normalizeHealth(item.health?.status, item.enabled),
+                lastCheck: item.health?.lastCheck ?? null,
+                message: item.health?.errorMessage ?? null,
+              })
+            }
+          }
+
+          if (clientResult._tag === "Left") {
+            failures.push({ type: "download_client", message: clientResult.left.message })
+          } else {
+            for (const item of clientResult.right) {
+              integrations.push({
+                type: "download_client",
+                id: item.id,
+                name: item.name,
+                enabled: item.enabled,
+                status: normalizeHealth(item.health?.status, item.enabled),
+                lastCheck: item.health?.lastCheck ?? null,
+                message: item.health?.errorMessage ?? null,
+              })
+            }
+          }
+
+          if (serverResult._tag === "Left") {
+            failures.push({ type: "media_server", message: serverResult.left.message })
+          } else {
+            for (const item of serverResult.right) {
+              integrations.push({
+                type: "media_server",
+                id: item.id,
+                name: item.name,
+                enabled: item.enabled,
+                status: normalizeHealth(item.health?.status, item.enabled),
+                lastCheck: item.health?.lastCheck ?? null,
+                message: item.health?.errorMessage ?? null,
+              })
+            }
+          }
+
+          return {
+            status: worstStatus(integrations, failures),
+            integrations,
+            failures,
+          }
+        }),
+
+      logs: (filters): Effect.Effect<ReadonlyArray<LogEntry>, DiagnosticsError> =>
+        Effect.gen(function* () {
+          const requestedCount = Math.min(Math.max(filters?.count ?? 100, 1), LOG_LIMIT)
+          const rows = yield* Ref.get(logsRef).pipe(
+            Effect.map((entries) =>
+              entries
+                .filter((entry) => !filters?.level || entry.level === filters.level)
+                .slice(-requestedCount)
+                .reverse(),
+            ),
+          )
+          return rows
+        }),
+
+      log: (level, message, context) =>
+        Effect.gen(function* () {
+          const id = yield* Ref.getAndUpdate(nextLogIdRef, (current) => current + 1)
+          const entry: LogEntry = {
+            id,
+            timestamp: new Date(),
+            level,
+            message,
+            context: context ?? null,
+          }
+          yield* Ref.update(logsRef, (entries) => [...entries, entry].slice(-LOG_LIMIT))
+        }),
+
+      tasks: () =>
+        Effect.gen(function* () {
+          const [running, pending, failed, dead, byType] = yield* Effect.all([
+            db
+              .select({ value: count() })
+              .from(schedulerJobs)
+              .where(eq(schedulerJobs.status, "running"))
+              .pipe(Effect.map((rows) => rows[0]?.value ?? 0)),
+            db
+              .select({ value: count() })
+              .from(schedulerJobs)
+              .where(eq(schedulerJobs.status, "pending"))
+              .pipe(Effect.map((rows) => rows[0]?.value ?? 0)),
+            db
+              .select({ value: count() })
+              .from(schedulerJobs)
+              .where(eq(schedulerJobs.status, "failed"))
+              .pipe(Effect.map((rows) => rows[0]?.value ?? 0)),
+            db
+              .select({ value: count() })
+              .from(schedulerJobs)
+              .where(eq(schedulerJobs.status, "dead"))
+              .pipe(Effect.map((rows) => rows[0]?.value ?? 0)),
+            schedulerService.status(),
+          ])
+
+          return { running, pending, failed, dead, byType }
+        }),
+    }
+  }),
+)

--- a/src/effect/services/QueueService.test.ts
+++ b/src/effect/services/QueueService.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "@effect/vitest"
+import { eq } from "drizzle-orm"
+import { Effect, Layer } from "effect"
+
+import {
+  downloadClients,
+  downloadQueue,
+  movies,
+  qualityProfiles,
+  releaseDecisions,
+} from "#/db/schema"
+import { Db } from "#/effect/services/Db"
+import { TestDbLive } from "#/effect/test/TestDb"
+
+import { DownloadClientService } from "./DownloadClientService"
+import { QueueService, QueueServiceLive } from "./QueueService"
+import { SchedulerService, SchedulerServiceLive } from "./SchedulerService"
+
+const MockDownloadClientService = Layer.succeed(DownloadClientService, {
+  add: () => Effect.die("not implemented"),
+  list: () => Effect.succeed([]),
+  getById: () => Effect.die("not implemented"),
+  update: () => Effect.die("not implemented"),
+  remove: () => Effect.die("not implemented"),
+  testConnection: () => Effect.die("not implemented"),
+  addDownload: () => Effect.die("not implemented"),
+  getQueue: () => Effect.die("not implemented"),
+  removeDownload: () => Effect.void,
+  listTypes: () => [],
+})
+
+const BaseLayer = Layer.mergeAll(SchedulerServiceLive, MockDownloadClientService).pipe(
+  Layer.provideMerge(TestDbLive),
+)
+
+const TestLayer = QueueServiceLive.pipe(Layer.provideMerge(BaseLayer))
+
+function seedQueue(status: "queued" | "downloading" | "importing" | "completed" | "failed") {
+  return Effect.gen(function* () {
+    const db = yield* Db
+    const scheduler = yield* SchedulerService
+    yield* scheduler.seedConfig()
+    const profile = yield* db
+      .insert(qualityProfiles)
+      .values({ name: "Default" })
+      .returning({ id: qualityProfiles.id })
+    const movie = yield* db
+      .insert(movies)
+      .values({ tmdbId: 1, title: "Example Movie", qualityProfileId: profile[0].id })
+      .returning({ id: movies.id })
+    const client = yield* db
+      .insert(downloadClients)
+      .values({
+        name: "qBit",
+        type: "qbittorrent",
+        host: "localhost",
+        port: 8080,
+        username: "admin",
+        passwordEncrypted: "enc:pw",
+      })
+      .returning({ id: downloadClients.id })
+    const queue = yield* db
+      .insert(downloadQueue)
+      .values({
+        downloadClientId: client[0].id,
+        movieId: movie[0].id,
+        externalId: `hash-${status}`,
+        title: "Example.Movie.2024.1080p-GROUP",
+        status,
+        sizeBytes: 1000,
+        progress: status === "failed" ? 0.5 : 0.25,
+        errorMessage: status === "failed" ? "download failed" : null,
+      })
+      .returning({ id: downloadQueue.id })
+
+    return { queueId: queue[0].id, movieId: movie[0].id }
+  })
+}
+
+describe("QueueService", () => {
+  it.effect("lists queue rows grouped with media and client details", () =>
+    Effect.gen(function* () {
+      yield* seedQueue("downloading")
+      const service = yield* QueueService
+      const items = yield* service.list({ status: "downloading", mediaType: "movie" })
+
+      expect(items).toHaveLength(1)
+      expect(items[0]?.media.title).toBe("Example Movie")
+      expect(items[0]?.downloadClient.name).toBe("qBit")
+      expect(items[0]?.progress).toBe(0.25)
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.effect("retries a failed queue item and enqueues a movie search", () =>
+    Effect.gen(function* () {
+      const seeded = yield* seedQueue("failed")
+      const service = yield* QueueService
+      const retried = yield* service.retry(seeded.queueId)
+      const scheduler = yield* SchedulerService
+      const jobs = yield* scheduler.listJobs({ jobType: "search_missing" })
+
+      expect(retried.status).toBe("queued")
+      expect(retried.errorMessage).toBeNull()
+      expect(jobs).toHaveLength(1)
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.effect("blocklists a queue item and records decision rationale", () =>
+    Effect.gen(function* () {
+      const seeded = yield* seedQueue("failed")
+      const service = yield* QueueService
+      const blocked = yield* service.blocklist(seeded.queueId)
+      const db = yield* Db
+      const decisions = yield* db
+        .select()
+        .from(releaseDecisions)
+        .where(eq(releaseDecisions.mediaId, seeded.movieId))
+
+      expect(blocked.status).toBe("failed")
+      expect(decisions).toHaveLength(1)
+      expect(decisions[0]?.reasons[0]?.rule).toBe("queue_blocklist")
+    }).pipe(Effect.provide(TestLayer)),
+  )
+})

--- a/src/effect/services/QueueService.ts
+++ b/src/effect/services/QueueService.ts
@@ -1,0 +1,242 @@
+import { SqlError } from "@effect/sql/SqlError"
+import { desc, eq } from "drizzle-orm"
+import { Context, Effect, Layer } from "effect"
+
+import { downloadClients, downloadQueue, movies, releaseDecisions, series } from "#/db/schema"
+
+import { NotFoundError, SchedulerError } from "../errors"
+import { Db } from "./Db"
+import { DownloadClientService } from "./DownloadClientService"
+import { SchedulerService } from "./SchedulerService"
+
+export type QueueStatusFilter =
+  | "all"
+  | "queued"
+  | "downloading"
+  | "importing"
+  | "completed"
+  | "failed"
+export type QueueMediaTypeFilter = "all" | "movie" | "series" | "unlinked"
+
+export interface QueueItem {
+  readonly id: number
+  readonly externalId: string
+  readonly title: string
+  readonly status: string
+  readonly sizeBytes: number
+  readonly progress: number
+  readonly etaSeconds: number | null
+  readonly errorMessage: string | null
+  readonly addedAt: Date
+  readonly updatedAt: Date
+  readonly downloadClient: {
+    readonly id: number
+    readonly name: string
+    readonly type: string
+  }
+  readonly media: {
+    readonly type: "movie" | "series" | "unlinked"
+    readonly id: number | null
+    readonly title: string
+    readonly episodeIds: ReadonlyArray<number> | null
+  }
+}
+
+export class QueueService extends Context.Tag("@arr-hub/QueueService")<
+  QueueService,
+  {
+    readonly list: (filters?: {
+      readonly status?: QueueStatusFilter
+      readonly clientId?: number
+      readonly mediaType?: QueueMediaTypeFilter
+    }) => Effect.Effect<ReadonlyArray<QueueItem>, SqlError>
+    readonly retry: (
+      id: number,
+    ) => Effect.Effect<QueueItem, NotFoundError | SchedulerError | SqlError>
+    readonly remove: (
+      id: number,
+      options?: { readonly deleteFiles?: boolean },
+    ) => Effect.Effect<void, NotFoundError | SqlError>
+    readonly blocklist: (
+      id: number,
+    ) => Effect.Effect<QueueItem, NotFoundError | SchedulerError | SqlError>
+  }
+>() {}
+
+export const QueueServiceLive = Layer.effect(
+  QueueService,
+  Effect.gen(function* () {
+    const db = yield* Db
+    const downloads = yield* DownloadClientService
+    const scheduler = yield* SchedulerService
+
+    const fetchItem = (id: number) =>
+      Effect.gen(function* () {
+        const rows = yield* db
+          .select()
+          .from(downloadQueue)
+          .innerJoin(downloadClients, eq(downloadQueue.downloadClientId, downloadClients.id))
+          .leftJoin(movies, eq(downloadQueue.movieId, movies.id))
+          .leftJoin(series, eq(downloadQueue.seriesId, series.id))
+          .where(eq(downloadQueue.id, id))
+        const row = rows[0]
+        if (!row) return yield* new NotFoundError({ entity: "queue_item", id })
+        return toQueueItem(row)
+      })
+
+    const enqueueSearch = (item: QueueItem) =>
+      Effect.gen(function* () {
+        if (item.media.type === "movie" && item.media.id !== null) {
+          yield* scheduler
+            .enqueue({ _tag: "search_missing", movieId: item.media.id })
+            .pipe(
+              Effect.catchTag("SchedulerError", (error) =>
+                error.reason === "duplicate_job" ? Effect.succeed(null) : Effect.fail(error),
+              ),
+            )
+        }
+        if (item.media.type === "series" && item.media.id !== null) {
+          yield* scheduler
+            .enqueue({ _tag: "tv_search_series", seriesId: item.media.id })
+            .pipe(
+              Effect.catchTag("SchedulerError", (error) =>
+                error.reason === "duplicate_job" ? Effect.succeed(null) : Effect.fail(error),
+              ),
+            )
+        }
+      })
+
+    return {
+      list: (filters) =>
+        Effect.gen(function* () {
+          const rows = yield* db
+            .select()
+            .from(downloadQueue)
+            .innerJoin(downloadClients, eq(downloadQueue.downloadClientId, downloadClients.id))
+            .leftJoin(movies, eq(downloadQueue.movieId, movies.id))
+            .leftJoin(series, eq(downloadQueue.seriesId, series.id))
+            .orderBy(desc(downloadQueue.updatedAt))
+
+          return rows
+            .map(toQueueItem)
+            .filter((item) => !filters?.clientId || item.downloadClient.id === filters.clientId)
+            .filter(
+              (item) =>
+                !filters?.status || filters.status === "all" || item.status === filters.status,
+            )
+            .filter(
+              (item) =>
+                !filters?.mediaType ||
+                filters.mediaType === "all" ||
+                item.media.type === filters.mediaType,
+            )
+        }),
+
+      retry: (id) =>
+        Effect.gen(function* () {
+          const item = yield* fetchItem(id)
+          yield* db
+            .update(downloadQueue)
+            .set({
+              status: "queued",
+              progress: 0,
+              errorMessage: null,
+              updatedAt: new Date(),
+            })
+            .where(eq(downloadQueue.id, id))
+          yield* enqueueSearch(item)
+          return yield* fetchItem(id)
+        }),
+
+      remove: (id, options) =>
+        Effect.gen(function* () {
+          const item = yield* fetchItem(id)
+          yield* downloads
+            .removeDownload(item.downloadClient.id, item.externalId, options?.deleteFiles ?? false)
+            .pipe(
+              Effect.catchAll(() =>
+                db.delete(downloadQueue).where(eq(downloadQueue.id, id)).pipe(Effect.asVoid),
+              ),
+            )
+        }),
+
+      blocklist: (id) =>
+        Effect.gen(function* () {
+          const item = yield* fetchItem(id)
+          if (item.media.id !== null && item.media.type !== "unlinked") {
+            yield* db.insert(releaseDecisions).values({
+              mediaId: item.media.id,
+              mediaType: item.media.type === "movie" ? "movie" : "season",
+              candidateTitle: item.title,
+              decision: "rejected",
+              reasons: [
+                {
+                  stage: "filter",
+                  rule: "queue_blocklist",
+                  detail: `blocked failed queue item ${item.externalId}`,
+                },
+              ],
+            })
+            yield* enqueueSearch(item)
+          }
+          yield* db
+            .update(downloadQueue)
+            .set({
+              status: "failed",
+              errorMessage: "Blocklisted and queued for alternative search",
+              updatedAt: new Date(),
+            })
+            .where(eq(downloadQueue.id, id))
+          return yield* fetchItem(id)
+        }),
+    }
+  }),
+)
+
+function toQueueItem(row: {
+  readonly download_queue: typeof downloadQueue.$inferSelect
+  readonly download_clients: typeof downloadClients.$inferSelect
+  readonly movies: typeof movies.$inferSelect | null
+  readonly series: typeof series.$inferSelect | null
+}): QueueItem {
+  const media =
+    row.movies !== null
+      ? {
+          type: "movie" as const,
+          id: row.movies.id,
+          title: row.movies.title,
+          episodeIds: null,
+        }
+      : row.series !== null
+        ? {
+            type: "series" as const,
+            id: row.series.id,
+            title: row.series.title,
+            episodeIds: row.download_queue.episodeIds,
+          }
+        : {
+            type: "unlinked" as const,
+            id: null,
+            title: "Unlinked",
+            episodeIds: null,
+          }
+
+  return {
+    id: row.download_queue.id,
+    externalId: row.download_queue.externalId,
+    title: row.download_queue.title,
+    status: row.download_queue.status,
+    sizeBytes: row.download_queue.sizeBytes,
+    progress: row.download_queue.progress,
+    etaSeconds: row.download_queue.etaSeconds,
+    errorMessage: row.download_queue.errorMessage,
+    addedAt: row.download_queue.addedAt,
+    updatedAt: row.download_queue.updatedAt,
+    downloadClient: {
+      id: row.download_clients.id,
+      name: row.download_clients.name,
+      type: row.download_clients.type,
+    },
+    media,
+  }
+}

--- a/src/effect/services/SettingsService.test.ts
+++ b/src/effect/services/SettingsService.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "@effect/vitest"
+import { Effect, Layer } from "effect"
+
+import { TestDbLive } from "#/effect/test/TestDb"
+
+import { SettingsService, SettingsServiceLive } from "./SettingsService"
+
+const TestLayer = SettingsServiceLive.pipe(Layer.provideMerge(TestDbLive))
+
+describe("SettingsService", () => {
+  it.effect("lists default settings grouped by workflow domain", () =>
+    Effect.gen(function* () {
+      const service = yield* SettingsService
+      const entries = yield* service.list()
+
+      expect(entries.map((entry) => entry.group)).toContain("General")
+      expect(entries.map((entry) => entry.group)).toContain("Media Management")
+      expect(entries.map((entry) => entry.group)).toContain("Scheduler")
+      expect(entries.find((entry) => entry.key === "app.name")?.value).toBe("ARR Hub")
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.effect("sets and reads a validated setting", () =>
+    Effect.gen(function* () {
+      const service = yield* SettingsService
+      const updated = yield* service.set("app.name", "Media Ops")
+      const loaded = yield* service.get("app.name")
+
+      expect(updated.value).toBe("Media Ops")
+      expect(loaded.value).toBe("Media Ops")
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.effect("rejects unknown keys and invalid values", () =>
+    Effect.gen(function* () {
+      const service = yield* SettingsService
+      const unknown = yield* Effect.flip(service.get("unknown.key"))
+      const invalid = yield* Effect.flip(service.set("app.updateChannel", "nightly"))
+
+      expect(unknown._tag).toBe("SettingsError")
+      if (unknown._tag === "SettingsError") expect(unknown.reason).toBe("invalid_key")
+      expect(invalid._tag).toBe("SettingsError")
+      if (invalid._tag === "SettingsError") expect(invalid.reason).toBe("invalid_value")
+    }).pipe(Effect.provide(TestLayer)),
+  )
+})

--- a/src/effect/services/SettingsService.ts
+++ b/src/effect/services/SettingsService.ts
@@ -1,0 +1,144 @@
+import { SqlError } from "@effect/sql/SqlError"
+import { eq } from "drizzle-orm"
+import { Context, Effect, Layer } from "effect"
+
+import { settings } from "#/db/schema"
+
+import { SettingsError } from "../errors"
+import { Db } from "./Db"
+
+export type SettingKey =
+  | "app.name"
+  | "app.updateChannel"
+  | "media.namingConvention"
+  | "media.fileHandling"
+  | "scheduler.paused"
+
+const SETTING_DEFINITIONS: Record<SettingKey, { readonly label: string; readonly group: string }> =
+  {
+    "app.name": { label: "App name", group: "General" },
+    "app.updateChannel": { label: "Update channel", group: "General" },
+    "media.namingConvention": { label: "Naming convention", group: "Media Management" },
+    "media.fileHandling": { label: "File handling", group: "Media Management" },
+    "scheduler.paused": { label: "Scheduler paused", group: "Scheduler" },
+  }
+
+const DEFAULT_VALUES: Record<SettingKey, string> = {
+  "app.name": "ARR Hub",
+  "app.updateChannel": "stable",
+  "media.namingConvention": "{Title} ({Year})",
+  "media.fileHandling": "copy",
+  "scheduler.paused": "false",
+}
+
+export interface SettingEntry {
+  readonly key: SettingKey
+  readonly label: string
+  readonly group: string
+  readonly value: string
+  readonly updatedAt: Date | null
+}
+
+function parseKey(key: string): Effect.Effect<SettingKey, SettingsError> {
+  if (key in SETTING_DEFINITIONS) return Effect.succeed(key as SettingKey)
+  return Effect.fail(
+    new SettingsError({ reason: "invalid_key", message: `unknown setting key: ${key}` }),
+  )
+}
+
+function validateValue(key: SettingKey, value: string): Effect.Effect<string, SettingsError> {
+  const trimmed = value.trim()
+  if (key === "app.name" && trimmed.length === 0) {
+    return Effect.fail(
+      new SettingsError({ reason: "invalid_value", message: "app name cannot be empty" }),
+    )
+  }
+  if (key === "app.updateChannel" && !["stable", "beta"].includes(trimmed)) {
+    return Effect.fail(
+      new SettingsError({
+        reason: "invalid_value",
+        message: "update channel must be stable or beta",
+      }),
+    )
+  }
+  if (key === "media.fileHandling" && !["copy", "move", "hardlink"].includes(trimmed)) {
+    return Effect.fail(
+      new SettingsError({
+        reason: "invalid_value",
+        message: "file handling must be copy, move, or hardlink",
+      }),
+    )
+  }
+  if (key === "scheduler.paused" && !["true", "false"].includes(trimmed)) {
+    return Effect.fail(
+      new SettingsError({
+        reason: "invalid_value",
+        message: "scheduler.paused must be true or false",
+      }),
+    )
+  }
+  return Effect.succeed(trimmed)
+}
+
+export class SettingsService extends Context.Tag("@arr-hub/SettingsService")<
+  SettingsService,
+  {
+    readonly list: () => Effect.Effect<ReadonlyArray<SettingEntry>, SqlError>
+    readonly get: (key: string) => Effect.Effect<SettingEntry, SettingsError | SqlError>
+    readonly set: (
+      key: string,
+      value: string,
+    ) => Effect.Effect<SettingEntry, SettingsError | SqlError>
+  }
+>() {}
+
+export const SettingsServiceLive = Layer.effect(
+  SettingsService,
+  Effect.gen(function* () {
+    const db = yield* Db
+
+    const buildEntry = (key: SettingKey, value: string, updatedAt: Date | null): SettingEntry => ({
+      key,
+      label: SETTING_DEFINITIONS[key].label,
+      group: SETTING_DEFINITIONS[key].group,
+      value,
+      updatedAt,
+    })
+
+    return {
+      list: () =>
+        Effect.gen(function* () {
+          const rows = yield* db.select().from(settings)
+          const values = new Map(rows.map((row) => [row.key, row]))
+          return (Object.keys(SETTING_DEFINITIONS) as Array<SettingKey>).map((key) => {
+            const row = values.get(key)
+            return buildEntry(key, row?.value ?? DEFAULT_VALUES[key], row?.updatedAt ?? null)
+          })
+        }),
+
+      get: (rawKey) =>
+        Effect.gen(function* () {
+          const key = yield* parseKey(rawKey)
+          const rows = yield* db.select().from(settings).where(eq(settings.key, key))
+          const row = rows[0]
+          return buildEntry(key, row?.value ?? DEFAULT_VALUES[key], row?.updatedAt ?? null)
+        }),
+
+      set: (rawKey, rawValue) =>
+        Effect.gen(function* () {
+          const key = yield* parseKey(rawKey)
+          const value = yield* validateValue(key, rawValue)
+          yield* db
+            .insert(settings)
+            .values({ key, value })
+            .onConflictDoUpdate({
+              target: settings.key,
+              set: { value, updatedAt: new Date() },
+            })
+          const rows = yield* db.select().from(settings).where(eq(settings.key, key))
+          const row = rows[0]
+          return buildEntry(key, row?.value ?? value, row?.updatedAt ?? null)
+        }),
+    }
+  }),
+)

--- a/src/integrations/http/effect.ts
+++ b/src/integrations/http/effect.ts
@@ -1,0 +1,75 @@
+import { SqlError } from "@effect/sql/SqlError"
+import { TRPCError } from "@trpc/server"
+import { Effect } from "effect"
+
+import { AppRuntime } from "#/effect/runtime"
+import { AuthService } from "#/effect/services/AuthService"
+import type { DomainError } from "#/integrations/trpc/init"
+import { domainToTRPC } from "#/integrations/trpc/init"
+
+type AppContext =
+  Parameters<typeof AppRuntime.runPromise>[0] extends Effect.Effect<unknown, unknown, infer R>
+    ? R
+    : never
+
+function errorResponse(error: unknown): Response {
+  if (error instanceof TRPCError) {
+    return Response.json({ error: error.message }, { status: trpcStatus(error.code) })
+  }
+  return Response.json({ error: "unexpected error" }, { status: 500 })
+}
+
+export async function runAuthedJson<A>(
+  request: Request,
+  effect: Effect.Effect<A, DomainError | SqlError, AppContext>,
+): Promise<Response> {
+  const authHeader = request.headers.get("authorization")
+  if (!authHeader?.startsWith("Bearer ")) {
+    return Response.json({ error: "missing" }, { status: 401 })
+  }
+
+  const token = authHeader.slice(7)
+  try {
+    const data = await AppRuntime.runPromise(
+      Effect.gen(function* () {
+        const auth = yield* AuthService
+        yield* auth.validateToken(token)
+        return yield* effect
+      }),
+    )
+    return Response.json(data)
+  } catch (error) {
+    if (typeof error === "object" && error !== null && "_tag" in error) {
+      if (error._tag === "SqlError") {
+        return Response.json({ error: "database error" }, { status: 500 })
+      }
+      return errorResponse(domainToTRPC(error as DomainError))
+    }
+    return errorResponse(error)
+  }
+}
+
+function trpcStatus(code: TRPCError["code"]): number {
+  switch (code) {
+    case "BAD_REQUEST":
+      return 400
+    case "UNAUTHORIZED":
+      return 401
+    case "FORBIDDEN":
+      return 403
+    case "NOT_FOUND":
+      return 404
+    case "TIMEOUT":
+      return 408
+    case "CONFLICT":
+      return 409
+    case "PRECONDITION_FAILED":
+      return 412
+    case "TOO_MANY_REQUESTS":
+      return 429
+    case "BAD_GATEWAY":
+      return 502
+    default:
+      return 500
+  }
+}

--- a/src/integrations/trpc/init.ts
+++ b/src/integrations/trpc/init.ts
@@ -9,6 +9,7 @@ import type {
   BundleNotFoundError,
   BundleVersionConflictError,
   ConflictError,
+  DiagnosticsError,
   DownloadClientError,
   EncryptionError,
   ImportError,
@@ -20,6 +21,7 @@ import type {
   ParseFailed,
   ProfileInUseError,
   SchedulerError,
+  SettingsError,
   ValidationError,
 } from "#/effect/errors"
 import { AppRuntime } from "#/effect/runtime"
@@ -45,7 +47,7 @@ export const createTRPCRouter = t.router
 
 export const publicProcedure = t.procedure
 
-type DomainError =
+export type DomainError =
   | NotFoundError
   | ValidationError
   | ConflictError
@@ -59,6 +61,8 @@ type DomainError =
   | EncryptionError
   | ParseFailed
   | SchedulerError
+  | DiagnosticsError
+  | SettingsError
   | AcquisitionError
   | MetadataError
   | OnboardingError
@@ -145,6 +149,10 @@ export function domainToTRPC(error: DomainError): TRPCError {
         message: error.message,
       })
     }
+    case "DiagnosticsError":
+      return new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: error.message })
+    case "SettingsError":
+      return new TRPCError({ code: "BAD_REQUEST", message: error.message })
     case "AcquisitionError":
       return new TRPCError({
         code: "BAD_REQUEST",

--- a/src/integrations/trpc/router.ts
+++ b/src/integrations/trpc/router.ts
@@ -1,5 +1,6 @@
 import { createTRPCRouter } from "./init"
 import { authRouter } from "./routers/auth"
+import { diagnosticsRouter } from "./routers/diagnostics"
 import { downloadClientsRouter } from "./routers/downloadClients"
 import { formatsRouter } from "./routers/formats"
 import { historyRouter } from "./routers/history"
@@ -10,10 +11,12 @@ import { moviesRouter } from "./routers/movies"
 import { onboardingRouter } from "./routers/onboarding"
 import { plexUsersRouter } from "./routers/plexUsers"
 import { profilesRouter } from "./routers/profiles"
+import { queueRouter } from "./routers/queue"
 import { releasesRouter } from "./routers/releases"
 import { rootFoldersRouter } from "./routers/rootFolders"
 import { schedulerRouter } from "./routers/scheduler"
 import { seriesRouter } from "./routers/series"
+import { settingsRouter } from "./routers/settings"
 import { statsRouter } from "./routers/stats"
 import { tmdbRouter } from "./routers/tmdb"
 
@@ -23,6 +26,7 @@ export const trpcRouter = createTRPCRouter({
   movies: moviesRouter,
   series: seriesRouter,
   profiles: profilesRouter,
+  settings: settingsRouter,
   formats: formatsRouter,
   indexers: indexersRouter,
   downloadClients: downloadClientsRouter,
@@ -31,9 +35,11 @@ export const trpcRouter = createTRPCRouter({
   history: historyRouter,
   import: importRouter,
   releases: releasesRouter,
+  queue: queueRouter,
   rootFolders: rootFoldersRouter,
   scheduler: schedulerRouter,
   stats: statsRouter,
+  diagnostics: diagnosticsRouter,
   tmdb: tmdbRouter,
 })
 

--- a/src/integrations/trpc/routers/diagnostics.ts
+++ b/src/integrations/trpc/routers/diagnostics.ts
@@ -1,0 +1,56 @@
+import type { TRPCRouterRecord } from "@trpc/server"
+import { Effect } from "effect"
+import { z } from "zod"
+
+import { DiagnosticsService } from "#/effect/services/DiagnosticsService"
+
+import { authedProcedure, runEffect } from "../init"
+
+const logLevelSchema = z.enum(["debug", "info", "warn", "error"])
+
+export const diagnosticsRouter = {
+  status: authedProcedure.query(() =>
+    runEffect(
+      Effect.gen(function* () {
+        const diagnostics = yield* DiagnosticsService
+        return yield* diagnostics.status()
+      }),
+    ),
+  ),
+
+  health: authedProcedure.query(() =>
+    runEffect(
+      Effect.gen(function* () {
+        const diagnostics = yield* DiagnosticsService
+        return yield* diagnostics.health()
+      }),
+    ),
+  ),
+
+  logs: authedProcedure
+    .input(
+      z
+        .object({
+          level: logLevelSchema.optional(),
+          count: z.number().int().min(1).max(500).optional(),
+        })
+        .optional(),
+    )
+    .query(({ input }) =>
+      runEffect(
+        Effect.gen(function* () {
+          const diagnostics = yield* DiagnosticsService
+          return yield* diagnostics.logs(input)
+        }),
+      ),
+    ),
+
+  tasks: authedProcedure.query(() =>
+    runEffect(
+      Effect.gen(function* () {
+        const diagnostics = yield* DiagnosticsService
+        return yield* diagnostics.tasks()
+      }),
+    ),
+  ),
+} satisfies TRPCRouterRecord

--- a/src/integrations/trpc/routers/queue.ts
+++ b/src/integrations/trpc/routers/queue.ts
@@ -1,0 +1,67 @@
+import type { TRPCRouterRecord } from "@trpc/server"
+import { Effect } from "effect"
+import { z } from "zod"
+
+import { QueueService } from "#/effect/services/QueueService"
+
+import { authedProcedure, runEffect } from "../init"
+
+const queueStatusSchema = z.enum([
+  "all",
+  "queued",
+  "downloading",
+  "importing",
+  "completed",
+  "failed",
+])
+const queueMediaTypeSchema = z.enum(["all", "movie", "series", "unlinked"])
+
+export const queueRouter = {
+  list: authedProcedure
+    .input(
+      z
+        .object({
+          status: queueStatusSchema.optional(),
+          clientId: z.number().int().optional(),
+          mediaType: queueMediaTypeSchema.optional(),
+        })
+        .optional(),
+    )
+    .query(({ input }) =>
+      runEffect(
+        Effect.gen(function* () {
+          const queue = yield* QueueService
+          return yield* queue.list(input)
+        }),
+      ),
+    ),
+
+  retry: authedProcedure.input(z.object({ id: z.number().int() })).mutation(({ input }) =>
+    runEffect(
+      Effect.gen(function* () {
+        const queue = yield* QueueService
+        return yield* queue.retry(input.id)
+      }),
+    ),
+  ),
+
+  remove: authedProcedure
+    .input(z.object({ id: z.number().int(), deleteFiles: z.boolean().optional() }))
+    .mutation(({ input }) =>
+      runEffect(
+        Effect.gen(function* () {
+          const queue = yield* QueueService
+          yield* queue.remove(input.id, { deleteFiles: input.deleteFiles })
+        }),
+      ),
+    ),
+
+  blocklist: authedProcedure.input(z.object({ id: z.number().int() })).mutation(({ input }) =>
+    runEffect(
+      Effect.gen(function* () {
+        const queue = yield* QueueService
+        return yield* queue.blocklist(input.id)
+      }),
+    ),
+  ),
+} satisfies TRPCRouterRecord

--- a/src/integrations/trpc/routers/scheduler.ts
+++ b/src/integrations/trpc/routers/scheduler.ts
@@ -6,7 +6,17 @@ import { SchedulerService } from "#/effect/services/SchedulerService"
 
 import { authedProcedure, runEffect } from "../init"
 
-const jobTypeSchema = z.enum(["rss_sync", "search_missing", "search_cutoff", "download_monitor"])
+const jobTypeSchema = z.enum([
+  "rss_sync",
+  "search_missing",
+  "search_cutoff",
+  "download_monitor",
+  "tv_rss_sync",
+  "tv_search_cutoff",
+  "tv_search_series",
+  "tv_search_season",
+  "tv_search_episode",
+])
 
 export const schedulerRouter = {
   jobs: authedProcedure

--- a/src/integrations/trpc/routers/settings.ts
+++ b/src/integrations/trpc/routers/settings.ts
@@ -1,0 +1,38 @@
+import type { TRPCRouterRecord } from "@trpc/server"
+import { Effect } from "effect"
+import { z } from "zod"
+
+import { SettingsService } from "#/effect/services/SettingsService"
+
+import { authedProcedure, runEffect } from "../init"
+
+export const settingsRouter = {
+  list: authedProcedure.query(() =>
+    runEffect(
+      Effect.gen(function* () {
+        const settings = yield* SettingsService
+        return yield* settings.list()
+      }),
+    ),
+  ),
+
+  get: authedProcedure.input(z.object({ key: z.string() })).query(({ input }) =>
+    runEffect(
+      Effect.gen(function* () {
+        const settings = yield* SettingsService
+        return yield* settings.get(input.key)
+      }),
+    ),
+  ),
+
+  set: authedProcedure
+    .input(z.object({ key: z.string(), value: z.string() }))
+    .mutation(({ input }) =>
+      runEffect(
+        Effect.gen(function* () {
+          const settings = yield* SettingsService
+          return yield* settings.set(input.key, input.value)
+        }),
+      ),
+    ),
+} satisfies TRPCRouterRecord

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -29,11 +29,19 @@ import { Route as SettingsGeneralRouteImport } from './routes/settings/general'
 import { Route as SettingsDownloadClientsRouteImport } from './routes/settings/download-clients'
 import { Route as OnboardingWizardRouteImport } from './routes/onboarding/wizard'
 import { Route as OnboardingQuickstartRouteImport } from './routes/onboarding/quickstart'
+import { Route as ApiQueueRouteImport } from './routes/api.queue'
 import { Route as ActivityUsersRouteImport } from './routes/activity/users'
 import { Route as ActivityStatsRouteImport } from './routes/activity/stats'
 import { Route as ActivityQueueRouteImport } from './routes/activity/queue'
 import { Route as ActivityHistoryRouteImport } from './routes/activity/history'
 import { Route as ApiTrpcSplatRouteImport } from './routes/api.trpc.$'
+import { Route as ApiSystemTasksRouteImport } from './routes/api.system.tasks'
+import { Route as ApiSystemStatusRouteImport } from './routes/api.system.status'
+import { Route as ApiSystemLogsRouteImport } from './routes/api.system.logs'
+import { Route as ApiSystemHealthRouteImport } from './routes/api.system.health'
+import { Route as ApiQueueIdRetryRouteImport } from './routes/api.queue.$id.retry'
+import { Route as ApiQueueIdRemoveRouteImport } from './routes/api.queue.$id.remove'
+import { Route as ApiQueueIdBlocklistRouteImport } from './routes/api.queue.$id.blocklist'
 
 const SystemRoute = SystemRouteImport.update({
   id: '/system',
@@ -135,6 +143,11 @@ const OnboardingQuickstartRoute = OnboardingQuickstartRouteImport.update({
   path: '/onboarding/quickstart',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiQueueRoute = ApiQueueRouteImport.update({
+  id: '/api/queue',
+  path: '/api/queue',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ActivityUsersRoute = ActivityUsersRouteImport.update({
   id: '/activity/users',
   path: '/activity/users',
@@ -160,6 +173,41 @@ const ApiTrpcSplatRoute = ApiTrpcSplatRouteImport.update({
   path: '/api/trpc/$',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiSystemTasksRoute = ApiSystemTasksRouteImport.update({
+  id: '/api/system/tasks',
+  path: '/api/system/tasks',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiSystemStatusRoute = ApiSystemStatusRouteImport.update({
+  id: '/api/system/status',
+  path: '/api/system/status',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiSystemLogsRoute = ApiSystemLogsRouteImport.update({
+  id: '/api/system/logs',
+  path: '/api/system/logs',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiSystemHealthRoute = ApiSystemHealthRouteImport.update({
+  id: '/api/system/health',
+  path: '/api/system/health',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiQueueIdRetryRoute = ApiQueueIdRetryRouteImport.update({
+  id: '/$id/retry',
+  path: '/$id/retry',
+  getParentRoute: () => ApiQueueRoute,
+} as any)
+const ApiQueueIdRemoveRoute = ApiQueueIdRemoveRouteImport.update({
+  id: '/$id/remove',
+  path: '/$id/remove',
+  getParentRoute: () => ApiQueueRoute,
+} as any)
+const ApiQueueIdBlocklistRoute = ApiQueueIdBlocklistRouteImport.update({
+  id: '/$id/blocklist',
+  path: '/$id/blocklist',
+  getParentRoute: () => ApiQueueRoute,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -169,6 +217,7 @@ export interface FileRoutesByFullPath {
   '/activity/queue': typeof ActivityQueueRoute
   '/activity/stats': typeof ActivityStatsRoute
   '/activity/users': typeof ActivityUsersRoute
+  '/api/queue': typeof ApiQueueRouteWithChildren
   '/onboarding/quickstart': typeof OnboardingQuickstartRoute
   '/onboarding/wizard': typeof OnboardingWizardRoute
   '/settings/download-clients': typeof SettingsDownloadClientsRoute
@@ -186,7 +235,14 @@ export interface FileRoutesByFullPath {
   '/onboarding/': typeof OnboardingIndexRoute
   '/settings/': typeof SettingsIndexRoute
   '/tv/': typeof TvIndexRoute
+  '/api/system/health': typeof ApiSystemHealthRoute
+  '/api/system/logs': typeof ApiSystemLogsRoute
+  '/api/system/status': typeof ApiSystemStatusRoute
+  '/api/system/tasks': typeof ApiSystemTasksRoute
   '/api/trpc/$': typeof ApiTrpcSplatRoute
+  '/api/queue/$id/blocklist': typeof ApiQueueIdBlocklistRoute
+  '/api/queue/$id/remove': typeof ApiQueueIdRemoveRoute
+  '/api/queue/$id/retry': typeof ApiQueueIdRetryRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -196,6 +252,7 @@ export interface FileRoutesByTo {
   '/activity/queue': typeof ActivityQueueRoute
   '/activity/stats': typeof ActivityStatsRoute
   '/activity/users': typeof ActivityUsersRoute
+  '/api/queue': typeof ApiQueueRouteWithChildren
   '/onboarding/quickstart': typeof OnboardingQuickstartRoute
   '/onboarding/wizard': typeof OnboardingWizardRoute
   '/settings/download-clients': typeof SettingsDownloadClientsRoute
@@ -213,7 +270,14 @@ export interface FileRoutesByTo {
   '/onboarding': typeof OnboardingIndexRoute
   '/settings': typeof SettingsIndexRoute
   '/tv': typeof TvIndexRoute
+  '/api/system/health': typeof ApiSystemHealthRoute
+  '/api/system/logs': typeof ApiSystemLogsRoute
+  '/api/system/status': typeof ApiSystemStatusRoute
+  '/api/system/tasks': typeof ApiSystemTasksRoute
   '/api/trpc/$': typeof ApiTrpcSplatRoute
+  '/api/queue/$id/blocklist': typeof ApiQueueIdBlocklistRoute
+  '/api/queue/$id/remove': typeof ApiQueueIdRemoveRoute
+  '/api/queue/$id/retry': typeof ApiQueueIdRetryRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -224,6 +288,7 @@ export interface FileRoutesById {
   '/activity/queue': typeof ActivityQueueRoute
   '/activity/stats': typeof ActivityStatsRoute
   '/activity/users': typeof ActivityUsersRoute
+  '/api/queue': typeof ApiQueueRouteWithChildren
   '/onboarding/quickstart': typeof OnboardingQuickstartRoute
   '/onboarding/wizard': typeof OnboardingWizardRoute
   '/settings/download-clients': typeof SettingsDownloadClientsRoute
@@ -241,7 +306,14 @@ export interface FileRoutesById {
   '/onboarding/': typeof OnboardingIndexRoute
   '/settings/': typeof SettingsIndexRoute
   '/tv/': typeof TvIndexRoute
+  '/api/system/health': typeof ApiSystemHealthRoute
+  '/api/system/logs': typeof ApiSystemLogsRoute
+  '/api/system/status': typeof ApiSystemStatusRoute
+  '/api/system/tasks': typeof ApiSystemTasksRoute
   '/api/trpc/$': typeof ApiTrpcSplatRoute
+  '/api/queue/$id/blocklist': typeof ApiQueueIdBlocklistRoute
+  '/api/queue/$id/remove': typeof ApiQueueIdRemoveRoute
+  '/api/queue/$id/retry': typeof ApiQueueIdRetryRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -253,6 +325,7 @@ export interface FileRouteTypes {
     | '/activity/queue'
     | '/activity/stats'
     | '/activity/users'
+    | '/api/queue'
     | '/onboarding/quickstart'
     | '/onboarding/wizard'
     | '/settings/download-clients'
@@ -270,7 +343,14 @@ export interface FileRouteTypes {
     | '/onboarding/'
     | '/settings/'
     | '/tv/'
+    | '/api/system/health'
+    | '/api/system/logs'
+    | '/api/system/status'
+    | '/api/system/tasks'
     | '/api/trpc/$'
+    | '/api/queue/$id/blocklist'
+    | '/api/queue/$id/remove'
+    | '/api/queue/$id/retry'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -280,6 +360,7 @@ export interface FileRouteTypes {
     | '/activity/queue'
     | '/activity/stats'
     | '/activity/users'
+    | '/api/queue'
     | '/onboarding/quickstart'
     | '/onboarding/wizard'
     | '/settings/download-clients'
@@ -297,7 +378,14 @@ export interface FileRouteTypes {
     | '/onboarding'
     | '/settings'
     | '/tv'
+    | '/api/system/health'
+    | '/api/system/logs'
+    | '/api/system/status'
+    | '/api/system/tasks'
     | '/api/trpc/$'
+    | '/api/queue/$id/blocklist'
+    | '/api/queue/$id/remove'
+    | '/api/queue/$id/retry'
   id:
     | '__root__'
     | '/'
@@ -307,6 +395,7 @@ export interface FileRouteTypes {
     | '/activity/queue'
     | '/activity/stats'
     | '/activity/users'
+    | '/api/queue'
     | '/onboarding/quickstart'
     | '/onboarding/wizard'
     | '/settings/download-clients'
@@ -324,7 +413,14 @@ export interface FileRouteTypes {
     | '/onboarding/'
     | '/settings/'
     | '/tv/'
+    | '/api/system/health'
+    | '/api/system/logs'
+    | '/api/system/status'
+    | '/api/system/tasks'
     | '/api/trpc/$'
+    | '/api/queue/$id/blocklist'
+    | '/api/queue/$id/remove'
+    | '/api/queue/$id/retry'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -335,6 +431,7 @@ export interface RootRouteChildren {
   ActivityQueueRoute: typeof ActivityQueueRoute
   ActivityStatsRoute: typeof ActivityStatsRoute
   ActivityUsersRoute: typeof ActivityUsersRoute
+  ApiQueueRoute: typeof ApiQueueRouteWithChildren
   OnboardingQuickstartRoute: typeof OnboardingQuickstartRoute
   OnboardingWizardRoute: typeof OnboardingWizardRoute
   SettingsDownloadClientsRoute: typeof SettingsDownloadClientsRoute
@@ -352,6 +449,10 @@ export interface RootRouteChildren {
   OnboardingIndexRoute: typeof OnboardingIndexRoute
   SettingsIndexRoute: typeof SettingsIndexRoute
   TvIndexRoute: typeof TvIndexRoute
+  ApiSystemHealthRoute: typeof ApiSystemHealthRoute
+  ApiSystemLogsRoute: typeof ApiSystemLogsRoute
+  ApiSystemStatusRoute: typeof ApiSystemStatusRoute
+  ApiSystemTasksRoute: typeof ApiSystemTasksRoute
   ApiTrpcSplatRoute: typeof ApiTrpcSplatRoute
 }
 
@@ -497,6 +598,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof OnboardingQuickstartRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/queue': {
+      id: '/api/queue'
+      path: '/api/queue'
+      fullPath: '/api/queue'
+      preLoaderRoute: typeof ApiQueueRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/activity/users': {
       id: '/activity/users'
       path: '/activity/users'
@@ -532,8 +640,73 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiTrpcSplatRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/system/tasks': {
+      id: '/api/system/tasks'
+      path: '/api/system/tasks'
+      fullPath: '/api/system/tasks'
+      preLoaderRoute: typeof ApiSystemTasksRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/system/status': {
+      id: '/api/system/status'
+      path: '/api/system/status'
+      fullPath: '/api/system/status'
+      preLoaderRoute: typeof ApiSystemStatusRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/system/logs': {
+      id: '/api/system/logs'
+      path: '/api/system/logs'
+      fullPath: '/api/system/logs'
+      preLoaderRoute: typeof ApiSystemLogsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/system/health': {
+      id: '/api/system/health'
+      path: '/api/system/health'
+      fullPath: '/api/system/health'
+      preLoaderRoute: typeof ApiSystemHealthRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/queue/$id/retry': {
+      id: '/api/queue/$id/retry'
+      path: '/$id/retry'
+      fullPath: '/api/queue/$id/retry'
+      preLoaderRoute: typeof ApiQueueIdRetryRouteImport
+      parentRoute: typeof ApiQueueRoute
+    }
+    '/api/queue/$id/remove': {
+      id: '/api/queue/$id/remove'
+      path: '/$id/remove'
+      fullPath: '/api/queue/$id/remove'
+      preLoaderRoute: typeof ApiQueueIdRemoveRouteImport
+      parentRoute: typeof ApiQueueRoute
+    }
+    '/api/queue/$id/blocklist': {
+      id: '/api/queue/$id/blocklist'
+      path: '/$id/blocklist'
+      fullPath: '/api/queue/$id/blocklist'
+      preLoaderRoute: typeof ApiQueueIdBlocklistRouteImport
+      parentRoute: typeof ApiQueueRoute
+    }
   }
 }
+
+interface ApiQueueRouteChildren {
+  ApiQueueIdBlocklistRoute: typeof ApiQueueIdBlocklistRoute
+  ApiQueueIdRemoveRoute: typeof ApiQueueIdRemoveRoute
+  ApiQueueIdRetryRoute: typeof ApiQueueIdRetryRoute
+}
+
+const ApiQueueRouteChildren: ApiQueueRouteChildren = {
+  ApiQueueIdBlocklistRoute: ApiQueueIdBlocklistRoute,
+  ApiQueueIdRemoveRoute: ApiQueueIdRemoveRoute,
+  ApiQueueIdRetryRoute: ApiQueueIdRetryRoute,
+}
+
+const ApiQueueRouteWithChildren = ApiQueueRoute._addFileChildren(
+  ApiQueueRouteChildren,
+)
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
@@ -543,6 +716,7 @@ const rootRouteChildren: RootRouteChildren = {
   ActivityQueueRoute: ActivityQueueRoute,
   ActivityStatsRoute: ActivityStatsRoute,
   ActivityUsersRoute: ActivityUsersRoute,
+  ApiQueueRoute: ApiQueueRouteWithChildren,
   OnboardingQuickstartRoute: OnboardingQuickstartRoute,
   OnboardingWizardRoute: OnboardingWizardRoute,
   SettingsDownloadClientsRoute: SettingsDownloadClientsRoute,
@@ -560,6 +734,10 @@ const rootRouteChildren: RootRouteChildren = {
   OnboardingIndexRoute: OnboardingIndexRoute,
   SettingsIndexRoute: SettingsIndexRoute,
   TvIndexRoute: TvIndexRoute,
+  ApiSystemHealthRoute: ApiSystemHealthRoute,
+  ApiSystemLogsRoute: ApiSystemLogsRoute,
+  ApiSystemStatusRoute: ApiSystemStatusRoute,
+  ApiSystemTasksRoute: ApiSystemTasksRoute,
   ApiTrpcSplatRoute: ApiTrpcSplatRoute,
 }
 export const routeTree = rootRouteImport

--- a/src/routes/activity/queue.tsx
+++ b/src/routes/activity/queue.tsx
@@ -1,12 +1,165 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { createFileRoute } from "@tanstack/react-router"
+import { useState } from "react"
+
+import { useTRPC } from "#/integrations/trpc/react"
 
 export const Route = createFileRoute("/activity/queue")({ component: Queue })
 
+type StatusFilter = "all" | "queued" | "downloading" | "importing" | "completed" | "failed"
+type MediaTypeFilter = "all" | "movie" | "series" | "unlinked"
+
 function Queue() {
+  const trpc = useTRPC()
+  const queryClient = useQueryClient()
+  const [status, setStatus] = useState<StatusFilter>("all")
+  const [mediaType, setMediaType] = useState<MediaTypeFilter>("all")
+
+  const listKey = trpc.queue.list.queryKey({ status, mediaType })
+  const query = useQuery(trpc.queue.list.queryOptions({ status, mediaType }))
+  const retry = useMutation(
+    trpc.queue.retry.mutationOptions({
+      onSuccess: () => queryClient.invalidateQueries({ queryKey: listKey }),
+    }),
+  )
+  const remove = useMutation(
+    trpc.queue.remove.mutationOptions({
+      onSuccess: () => queryClient.invalidateQueries({ queryKey: listKey }),
+    }),
+  )
+  const blocklist = useMutation(
+    trpc.queue.blocklist.mutationOptions({
+      onSuccess: () => queryClient.invalidateQueries({ queryKey: listKey }),
+    }),
+  )
+  const pending = retry.isPending || remove.isPending || blocklist.isPending
+
   return (
-    <div className="p-6">
-      <h1 className="text-2xl font-bold">Queue</h1>
-      <p className="text-muted-foreground mt-1">Current download queue</p>
+    <div className="space-y-4 p-6">
+      <header className="flex flex-wrap items-end justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold">Queue</h1>
+          <p className="text-muted-foreground mt-1">Current download queue</p>
+        </div>
+        <div className="flex flex-wrap items-center gap-3 text-sm">
+          <label className="flex items-center gap-2">
+            <span className="text-muted-foreground">Status</span>
+            <select
+              className="bg-background rounded border px-2 py-1"
+              value={status}
+              onChange={(event) => setStatus(event.target.value as StatusFilter)}
+            >
+              <option value="all">All</option>
+              <option value="queued">Queued</option>
+              <option value="downloading">Downloading</option>
+              <option value="importing">Importing</option>
+              <option value="completed">Completed</option>
+              <option value="failed">Failed</option>
+            </select>
+          </label>
+          <label className="flex items-center gap-2">
+            <span className="text-muted-foreground">Media</span>
+            <select
+              className="bg-background rounded border px-2 py-1"
+              value={mediaType}
+              onChange={(event) => setMediaType(event.target.value as MediaTypeFilter)}
+            >
+              <option value="all">All</option>
+              <option value="movie">Movies</option>
+              <option value="series">Series</option>
+              <option value="unlinked">Unlinked</option>
+            </select>
+          </label>
+        </div>
+      </header>
+
+      {query.isLoading && <p className="text-muted-foreground">Loading queue...</p>}
+      {query.error && (
+        <p className="text-destructive">Failed to load queue: {query.error.message}</p>
+      )}
+      {query.data?.length === 0 && <p className="text-muted-foreground">No active downloads.</p>}
+
+      {query.data && query.data.length > 0 && (
+        <div className="overflow-hidden rounded-md border">
+          <table className="w-full text-sm">
+            <thead className="bg-muted/50 text-muted-foreground">
+              <tr>
+                <th className="px-3 py-2 text-left font-medium">Media</th>
+                <th className="px-3 py-2 text-left font-medium">Release</th>
+                <th className="px-3 py-2 text-left font-medium">Client</th>
+                <th className="px-3 py-2 text-right font-medium">Progress</th>
+                <th className="px-3 py-2 text-right font-medium">ETA</th>
+                <th className="px-3 py-2 text-right font-medium">Size</th>
+                <th className="px-3 py-2 text-left font-medium">Status</th>
+                <th className="px-3 py-2 text-right font-medium">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {query.data.map((item) => (
+                <tr key={item.id} className="border-t">
+                  <td className="px-3 py-2">
+                    <p>{item.media.title}</p>
+                    <p className="text-muted-foreground text-xs">{item.media.type}</p>
+                  </td>
+                  <td className="max-w-80 px-3 py-2">
+                    <p className="truncate">{item.title}</p>
+                    {item.errorMessage && (
+                      <p className="text-destructive truncate text-xs">{item.errorMessage}</p>
+                    )}
+                  </td>
+                  <td className="px-3 py-2">{item.downloadClient.name}</td>
+                  <td className="px-3 py-2 text-right">{Math.round(item.progress * 100)}%</td>
+                  <td className="px-3 py-2 text-right">{formatEta(item.etaSeconds)}</td>
+                  <td className="px-3 py-2 text-right">{formatBytes(item.sizeBytes)}</td>
+                  <td className="px-3 py-2">{item.status}</td>
+                  <td className="px-3 py-2">
+                    <div className="flex justify-end gap-2">
+                      <button
+                        type="button"
+                        className="rounded border px-2 py-1 text-xs disabled:opacity-50"
+                        disabled={pending || item.status !== "failed"}
+                        onClick={() => retry.mutate({ id: item.id })}
+                      >
+                        Retry
+                      </button>
+                      <button
+                        type="button"
+                        className="rounded border px-2 py-1 text-xs disabled:opacity-50"
+                        disabled={pending}
+                        onClick={() => remove.mutate({ id: item.id })}
+                      >
+                        Remove
+                      </button>
+                      <button
+                        type="button"
+                        className="rounded border px-2 py-1 text-xs disabled:opacity-50"
+                        disabled={pending}
+                        onClick={() => blocklist.mutate({ id: item.id })}
+                      >
+                        Blocklist
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
     </div>
   )
+}
+
+function formatEta(seconds: number | null) {
+  if (seconds === null) return "—"
+  if (seconds < 60) return `${seconds}s`
+  const minutes = Math.round(seconds / 60)
+  if (minutes < 60) return `${minutes}m`
+  return `${Math.round(minutes / 60)}h`
+}
+
+function formatBytes(bytes: number) {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`
+  return `${(bytes / 1024 / 1024).toFixed(1)} MB`
 }

--- a/src/routes/api.queue.$id.blocklist.tsx
+++ b/src/routes/api.queue.$id.blocklist.tsx
@@ -1,0 +1,20 @@
+import { createFileRoute } from "@tanstack/react-router"
+import { Effect } from "effect"
+
+import { QueueService } from "#/effect/services/QueueService"
+import { runAuthedJson } from "#/integrations/http/effect"
+
+function handler({ request }: { request: Request }) {
+  const id = Number(new URL(request.url).pathname.split("/").at(-2))
+  return runAuthedJson(
+    request,
+    Effect.gen(function* () {
+      const queue = yield* QueueService
+      return yield* queue.blocklist(id)
+    }),
+  )
+}
+
+export const Route = createFileRoute("/api/queue/$id/blocklist")({
+  server: { handlers: { POST: handler } },
+})

--- a/src/routes/api.queue.$id.remove.tsx
+++ b/src/routes/api.queue.$id.remove.tsx
@@ -1,0 +1,25 @@
+import { createFileRoute } from "@tanstack/react-router"
+import { Effect } from "effect"
+
+import { QueueService } from "#/effect/services/QueueService"
+import { runAuthedJson } from "#/integrations/http/effect"
+
+async function handler({ request }: { request: Request }) {
+  const id = Number(new URL(request.url).pathname.split("/").at(-2))
+  const body = request.headers.get("content-type")?.includes("application/json")
+    ? ((await request.json()) as { deleteFiles?: boolean })
+    : {}
+
+  return runAuthedJson(
+    request,
+    Effect.gen(function* () {
+      const queue = yield* QueueService
+      yield* queue.remove(id, { deleteFiles: body.deleteFiles })
+      return { ok: true }
+    }),
+  )
+}
+
+export const Route = createFileRoute("/api/queue/$id/remove")({
+  server: { handlers: { POST: handler } },
+})

--- a/src/routes/api.queue.$id.retry.tsx
+++ b/src/routes/api.queue.$id.retry.tsx
@@ -1,0 +1,20 @@
+import { createFileRoute } from "@tanstack/react-router"
+import { Effect } from "effect"
+
+import { QueueService } from "#/effect/services/QueueService"
+import { runAuthedJson } from "#/integrations/http/effect"
+
+function handler({ request }: { request: Request }) {
+  const id = Number(new URL(request.url).pathname.split("/").at(-2))
+  return runAuthedJson(
+    request,
+    Effect.gen(function* () {
+      const queue = yield* QueueService
+      return yield* queue.retry(id)
+    }),
+  )
+}
+
+export const Route = createFileRoute("/api/queue/$id/retry")({
+  server: { handlers: { POST: handler } },
+})

--- a/src/routes/api.queue.tsx
+++ b/src/routes/api.queue.tsx
@@ -1,0 +1,47 @@
+import { createFileRoute } from "@tanstack/react-router"
+import { Effect } from "effect"
+
+import {
+  QueueService,
+  type QueueMediaTypeFilter,
+  type QueueStatusFilter,
+} from "#/effect/services/QueueService"
+import { runAuthedJson } from "#/integrations/http/effect"
+
+function handler({ request }: { request: Request }) {
+  const url = new URL(request.url)
+  const status = url.searchParams.get("status")
+  const mediaType = url.searchParams.get("mediaType")
+  const clientId = Number(url.searchParams.get("clientId"))
+
+  return runAuthedJson(
+    request,
+    Effect.gen(function* () {
+      const queue = yield* QueueService
+      return yield* queue.list({
+        status: isStatus(status) ? status : undefined,
+        mediaType: isMediaType(mediaType) ? mediaType : undefined,
+        clientId: Number.isInteger(clientId) ? clientId : undefined,
+      })
+    }),
+  )
+}
+
+function isStatus(value: string | null): value is QueueStatusFilter {
+  return (
+    value === "all" ||
+    value === "queued" ||
+    value === "downloading" ||
+    value === "importing" ||
+    value === "completed" ||
+    value === "failed"
+  )
+}
+
+function isMediaType(value: string | null): value is QueueMediaTypeFilter {
+  return value === "all" || value === "movie" || value === "series" || value === "unlinked"
+}
+
+export const Route = createFileRoute("/api/queue")({
+  server: { handlers: { GET: handler } },
+})

--- a/src/routes/api.system.health.tsx
+++ b/src/routes/api.system.health.tsx
@@ -1,0 +1,19 @@
+import { createFileRoute } from "@tanstack/react-router"
+import { Effect } from "effect"
+
+import { DiagnosticsService } from "#/effect/services/DiagnosticsService"
+import { runAuthedJson } from "#/integrations/http/effect"
+
+function handler({ request }: { request: Request }) {
+  return runAuthedJson(
+    request,
+    Effect.gen(function* () {
+      const diagnostics = yield* DiagnosticsService
+      return yield* diagnostics.health()
+    }),
+  )
+}
+
+export const Route = createFileRoute("/api/system/health")({
+  server: { handlers: { GET: handler } },
+})

--- a/src/routes/api.system.logs.tsx
+++ b/src/routes/api.system.logs.tsx
@@ -1,0 +1,30 @@
+import { createFileRoute } from "@tanstack/react-router"
+import { Effect } from "effect"
+
+import { DiagnosticsService, type LogLevel } from "#/effect/services/DiagnosticsService"
+import { runAuthedJson } from "#/integrations/http/effect"
+
+function handler({ request }: { request: Request }) {
+  const url = new URL(request.url)
+  const level = url.searchParams.get("level")
+  const count = Number(url.searchParams.get("count") ?? "100")
+
+  return runAuthedJson(
+    request,
+    Effect.gen(function* () {
+      const diagnostics = yield* DiagnosticsService
+      return yield* diagnostics.logs({
+        level: isLogLevel(level) ? level : undefined,
+        count: Number.isFinite(count) ? count : 100,
+      })
+    }),
+  )
+}
+
+function isLogLevel(value: string | null): value is LogLevel {
+  return value === "debug" || value === "info" || value === "warn" || value === "error"
+}
+
+export const Route = createFileRoute("/api/system/logs")({
+  server: { handlers: { GET: handler } },
+})

--- a/src/routes/api.system.status.tsx
+++ b/src/routes/api.system.status.tsx
@@ -1,0 +1,19 @@
+import { createFileRoute } from "@tanstack/react-router"
+import { Effect } from "effect"
+
+import { DiagnosticsService } from "#/effect/services/DiagnosticsService"
+import { runAuthedJson } from "#/integrations/http/effect"
+
+function handler({ request }: { request: Request }) {
+  return runAuthedJson(
+    request,
+    Effect.gen(function* () {
+      const diagnostics = yield* DiagnosticsService
+      return yield* diagnostics.status()
+    }),
+  )
+}
+
+export const Route = createFileRoute("/api/system/status")({
+  server: { handlers: { GET: handler } },
+})

--- a/src/routes/api.system.tasks.tsx
+++ b/src/routes/api.system.tasks.tsx
@@ -1,0 +1,19 @@
+import { createFileRoute } from "@tanstack/react-router"
+import { Effect } from "effect"
+
+import { DiagnosticsService } from "#/effect/services/DiagnosticsService"
+import { runAuthedJson } from "#/integrations/http/effect"
+
+function handler({ request }: { request: Request }) {
+  return runAuthedJson(
+    request,
+    Effect.gen(function* () {
+      const diagnostics = yield* DiagnosticsService
+      return yield* diagnostics.tasks()
+    }),
+  )
+}
+
+export const Route = createFileRoute("/api/system/tasks")({
+  server: { handlers: { GET: handler } },
+})

--- a/src/routes/settings/index.tsx
+++ b/src/routes/settings/index.tsx
@@ -1,12 +1,93 @@
+import { useQuery } from "@tanstack/react-query"
 import { createFileRoute } from "@tanstack/react-router"
+import { Link } from "@tanstack/react-router"
+
+import { useTRPC } from "#/integrations/trpc/react"
 
 export const Route = createFileRoute("/settings/")({ component: Settings })
 
+const groups = [
+  {
+    title: "General",
+    href: "/settings/general",
+    description: "App identity, root folders, update channel",
+  },
+  {
+    title: "Media Management",
+    href: "/settings/media-management",
+    description: "Naming conventions and file handling",
+  },
+  {
+    title: "Profiles",
+    href: "/settings/profiles",
+    description: "Quality profiles and custom formats",
+  },
+  { title: "Indexers", href: "/settings/indexers", description: "Indexer connections and health" },
+  {
+    title: "Download Clients",
+    href: "/settings/download-clients",
+    description: "Download connections and health",
+  },
+  {
+    title: "Media Servers",
+    href: "/settings/media-servers",
+    description: "Plex/Jellyfin connections and health",
+  },
+  {
+    title: "Notifications",
+    href: "/settings/notifications",
+    description: "Notification placeholders",
+  },
+  {
+    title: "Scheduler",
+    href: "/settings/scheduler",
+    description: "Intervals, retries, pause and resume",
+  },
+  { title: "Security", href: "/settings/security", description: "Admin password and API keys" },
+  { title: "Plugins", href: "/settings/plugins", description: "Local plugin lifecycle and health" },
+]
+
 function Settings() {
+  const trpc = useTRPC()
+  const settings = useQuery(trpc.settings.list.queryOptions())
+
   return (
-    <div className="p-6">
-      <h1 className="text-2xl font-bold">Settings</h1>
-      <p className="text-muted-foreground mt-1">Application configuration overview</p>
+    <div className="space-y-6 p-6">
+      <header>
+        <h1 className="text-2xl font-bold">Settings</h1>
+        <p className="text-muted-foreground mt-1">Application configuration overview</p>
+      </header>
+
+      <section className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+        {groups.map((group) => (
+          <Link
+            key={group.title}
+            to={group.href}
+            className="hover:bg-muted/40 rounded-md border p-4 transition-colors"
+          >
+            <h2 className="font-semibold">{group.title}</h2>
+            <p className="text-muted-foreground mt-1 text-sm">{group.description}</p>
+          </Link>
+        ))}
+      </section>
+
+      <section className="rounded-md border">
+        <div className="border-b px-4 py-3">
+          <h2 className="font-semibold">Effective Settings</h2>
+        </div>
+        <div className="divide-y">
+          {settings.data?.map((item) => (
+            <div key={item.key} className="grid gap-2 p-3 text-sm md:grid-cols-[12rem_1fr_1fr]">
+              <span className="text-muted-foreground">{item.group}</span>
+              <span>{item.label}</span>
+              <span className="font-mono">{item.value}</span>
+            </div>
+          ))}
+          {settings.isLoading && (
+            <p className="text-muted-foreground p-4 text-sm">Loading settings...</p>
+          )}
+        </div>
+      </section>
     </div>
   )
 }

--- a/src/routes/settings/security.tsx
+++ b/src/routes/settings/security.tsx
@@ -1,12 +1,108 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { createFileRoute } from "@tanstack/react-router"
+import { useState } from "react"
+
+import { useTRPC } from "#/integrations/trpc/react"
 
 export const Route = createFileRoute("/settings/security")({ component: Security })
 
 function Security() {
+  const trpc = useTRPC()
+  const queryClient = useQueryClient()
+  const [name, setName] = useState("")
+  const [createdToken, setCreatedToken] = useState<string | null>(null)
+  const keysKey = trpc.auth.listApiKeys.queryKey()
+  const keys = useQuery(trpc.auth.listApiKeys.queryOptions())
+  const createKey = useMutation(
+    trpc.auth.createApiKey.mutationOptions({
+      onSuccess: (result) => {
+        setCreatedToken(result.token)
+        setName("")
+        queryClient.invalidateQueries({ queryKey: keysKey })
+      },
+    }),
+  )
+  const revokeKey = useMutation(
+    trpc.auth.revokeApiKey.mutationOptions({
+      onSuccess: () => queryClient.invalidateQueries({ queryKey: keysKey }),
+    }),
+  )
+
   return (
-    <div className="p-6">
-      <h1 className="text-2xl font-bold">Security</h1>
-      <p className="text-muted-foreground mt-1">Authentication and access control</p>
+    <div className="space-y-6 p-6">
+      <header>
+        <h1 className="text-2xl font-bold">Security</h1>
+        <p className="text-muted-foreground mt-1">Authentication and access control</p>
+      </header>
+
+      <section className="rounded-md border p-4">
+        <h2 className="font-semibold">API Keys</h2>
+        <form
+          className="mt-3 flex max-w-xl gap-2"
+          onSubmit={(event) => {
+            event.preventDefault()
+            if (name.trim()) createKey.mutate({ name: name.trim() })
+          }}
+        >
+          <input
+            className="bg-background flex-1 rounded border px-3 py-2 text-sm"
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            placeholder="Key name"
+          />
+          <button
+            type="submit"
+            className="rounded border px-3 py-2 text-sm disabled:opacity-50"
+            disabled={!name.trim() || createKey.isPending}
+          >
+            Create
+          </button>
+        </form>
+        {createdToken && (
+          <div className="bg-muted mt-3 rounded p-3 text-sm">
+            <p className="text-muted-foreground">New token</p>
+            <p className="mt-1 font-mono break-all">{createdToken}</p>
+          </div>
+        )}
+      </section>
+
+      <section className="overflow-hidden rounded-md border">
+        <table className="w-full text-sm">
+          <thead className="bg-muted/50 text-muted-foreground">
+            <tr>
+              <th className="px-3 py-2 text-left font-medium">Name</th>
+              <th className="px-3 py-2 text-left font-medium">Kind</th>
+              <th className="px-3 py-2 text-left font-medium">Last Used</th>
+              <th className="px-3 py-2 text-left font-medium">Created</th>
+              <th className="px-3 py-2 text-right font-medium">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {keys.data?.map((key) => (
+              <tr key={key.id} className="border-t">
+                <td className="px-3 py-2">{key.name}</td>
+                <td className="px-3 py-2">{key.kind}</td>
+                <td className="text-muted-foreground px-3 py-2">
+                  {key.lastUsedAt ? new Date(key.lastUsedAt).toLocaleString() : "Never"}
+                </td>
+                <td className="text-muted-foreground px-3 py-2">
+                  {new Date(key.createdAt).toLocaleString()}
+                </td>
+                <td className="px-3 py-2 text-right">
+                  <button
+                    type="button"
+                    className="rounded border px-2 py-1 text-xs disabled:opacity-50"
+                    disabled={key.revokedAt !== null || revokeKey.isPending}
+                    onClick={() => revokeKey.mutate({ id: key.id })}
+                  >
+                    {key.revokedAt ? "Revoked" : "Revoke"}
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </section>
     </div>
   )
 }

--- a/src/routes/system.tsx
+++ b/src/routes/system.tsx
@@ -1,12 +1,146 @@
+import { useQuery } from "@tanstack/react-query"
 import { createFileRoute } from "@tanstack/react-router"
+
+import { useTRPC } from "#/integrations/trpc/react"
 
 export const Route = createFileRoute("/system")({ component: System })
 
 function System() {
+  const trpc = useTRPC()
+  const status = useQuery(trpc.diagnostics.status.queryOptions())
+  const health = useQuery(trpc.diagnostics.health.queryOptions())
+  const tasks = useQuery(trpc.diagnostics.tasks.queryOptions())
+  const logs = useQuery(trpc.diagnostics.logs.queryOptions({ count: 50 }))
+
   return (
-    <div className="p-6">
-      <h1 className="text-2xl font-bold">System</h1>
-      <p className="text-muted-foreground mt-1">System status, logs, and diagnostics</p>
+    <div className="space-y-6 p-6">
+      <header>
+        <h1 className="text-2xl font-bold">System</h1>
+        <p className="text-muted-foreground mt-1">System status, logs, and diagnostics</p>
+      </header>
+
+      <section className="grid gap-4 md:grid-cols-4">
+        <Metric label="Version" value={status.data?.version ?? "unknown"} />
+        <Metric label="Uptime" value={formatDuration(status.data?.uptimeSeconds ?? 0)} />
+        <Metric label="DB size" value={formatBytes(status.data?.database.sizeBytes ?? 0)} />
+        <Metric label="Health" value={health.data?.status ?? "loading"} />
+      </section>
+
+      <section className="grid gap-4 lg:grid-cols-2">
+        <div className="rounded-md border">
+          <div className="border-b px-4 py-3">
+            <h2 className="font-semibold">Integration Health</h2>
+          </div>
+          <div className="divide-y">
+            {health.data?.integrations.length === 0 && (
+              <p className="text-muted-foreground p-4 text-sm">No integrations configured.</p>
+            )}
+            {health.data?.integrations.map((item) => (
+              <div
+                key={`${item.type}-${item.id}`}
+                className="flex items-center justify-between gap-3 p-4 text-sm"
+              >
+                <div>
+                  <p className="font-medium">{item.name}</p>
+                  <p className="text-muted-foreground">{item.type.replace("_", " ")}</p>
+                </div>
+                <div className="text-right">
+                  <p
+                    className={
+                      item.status === "unhealthy" ? "text-destructive" : "text-muted-foreground"
+                    }
+                  >
+                    {item.status}
+                  </p>
+                  {item.message && (
+                    <p className="text-muted-foreground max-w-64 truncate">{item.message}</p>
+                  )}
+                </div>
+              </div>
+            ))}
+            {health.error && <p className="text-destructive p-4 text-sm">{health.error.message}</p>}
+          </div>
+        </div>
+
+        <div className="rounded-md border">
+          <div className="border-b px-4 py-3">
+            <h2 className="font-semibold">Scheduler Tasks</h2>
+          </div>
+          <div className="grid grid-cols-4 border-b text-center text-sm">
+            <Metric label="Running" value={String(tasks.data?.running ?? 0)} compact />
+            <Metric label="Pending" value={String(tasks.data?.pending ?? 0)} compact />
+            <Metric label="Failed" value={String(tasks.data?.failed ?? 0)} compact />
+            <Metric label="Dead" value={String(tasks.data?.dead ?? 0)} compact />
+          </div>
+          <div className="divide-y">
+            {tasks.data?.byType.map((job) => (
+              <div key={job.jobType} className="grid grid-cols-[1fr_auto_auto] gap-3 p-3 text-sm">
+                <span className="font-medium">{job.jobType}</span>
+                <span className="text-muted-foreground">{job.activeCount} active</span>
+                <span className={job.enabled ? "text-green-500" : "text-muted-foreground"}>
+                  {job.enabled ? "enabled" : "paused"}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="rounded-md border">
+        <div className="border-b px-4 py-3">
+          <h2 className="font-semibold">Structured Logs</h2>
+        </div>
+        <div className="divide-y">
+          {logs.data?.length === 0 && (
+            <p className="text-muted-foreground p-4 text-sm">
+              No structured log entries captured yet.
+            </p>
+          )}
+          {logs.data?.map((entry) => (
+            <div key={entry.id} className="grid gap-2 p-3 text-sm md:grid-cols-[9rem_5rem_1fr]">
+              <span className="text-muted-foreground">
+                {new Date(entry.timestamp).toLocaleString()}
+              </span>
+              <span
+                className={entry.level === "error" ? "text-destructive" : "text-muted-foreground"}
+              >
+                {entry.level}
+              </span>
+              <span>{entry.message}</span>
+            </div>
+          ))}
+        </div>
+      </section>
     </div>
   )
+}
+
+function Metric({
+  label,
+  value,
+  compact = false,
+}: {
+  label: string
+  value: string
+  compact?: boolean
+}) {
+  return (
+    <div className={compact ? "p-3" : "rounded-md border p-4"}>
+      <p className="text-muted-foreground text-xs uppercase">{label}</p>
+      <p className={compact ? "mt-1 font-semibold" : "mt-1 text-xl font-semibold"}>{value}</p>
+    </div>
+  )
+}
+
+function formatBytes(bytes: number) {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`
+  return `${(bytes / 1024 / 1024).toFixed(1)} MB`
+}
+
+function formatDuration(seconds: number) {
+  const hours = Math.floor(seconds / 3600)
+  const minutes = Math.floor((seconds % 3600) / 60)
+  if (hours > 0) return `${hours}h ${minutes}m`
+  return `${minutes}m`
 }


### PR DESCRIPTION
## Summary
- add Effect DiagnosticsService, SettingsService, and QueueService with focused service tests
- add authenticated REST endpoints for /api/system/status, /api/system/health, /api/system/logs, /api/system/tasks, /api/queue, and queue retry/remove/blocklist actions
- add tRPC diagnostics/settings/queue routers and widen scheduler job type inputs for TV jobs
- expand System, Settings, Security, and Queue screens with status, health, task summaries, API key management, and queue actions

## Verification
- bun run fmt:check
- bun run lint (0 errors; existing warnings remain)
- bun run typecheck
- bun run test
- bun run build

Closes #14